### PR TITLE
Add impressum and privacy policy to docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -69,7 +69,7 @@ export default defineConfig({
     },
 
     footer: {
-      message: 'Released under the AGPL-3.0 License.',
+      message: 'Released under the AGPL-3.0 License. <a href="/orca/legal/privacy-policy">Privacy Policy</a> · <a href="/orca/legal/impressum">Impressum</a>',
       copyright: 'Copyright 2025-present Orca Contributors',
     },
   },

--- a/docs/legal/impressum.md
+++ b/docs/legal/impressum.md
@@ -1,0 +1,30 @@
+# Impressum
+
+Information according to § 5 TMG (German Telemedia Act)
+
+## Responsible Person
+
+Sharang Parnerkar  
+Matthias-Claudius-Strasse 24  
+78234 Engen  
+Deutschland
+
+**Phone:** +49 176 64296347  
+**Email:** parnerkarsharang@gmail.com
+
+## Responsible for Content
+
+Responsible for content pursuant to § 55 Abs. 2 RStV:  
+Sharang Parnerkar (address as above)
+
+## Liability for Content
+
+As a service provider, we are responsible for our own content on this site pursuant to § 7 Abs. 1 TMG. Under §§ 8–10 TMG, however, we are not obligated to monitor transmitted or stored third-party information. Obligations to remove or block content under general law remain unaffected.
+
+## Liability for Links
+
+This documentation contains links to external websites. We have no influence over the content of those sites and accept no liability for them. The respective operator is responsible for linked content.
+
+## Copyright
+
+All original content on this site is subject to German copyright law. Reproduction or distribution beyond personal use requires written permission from the author.

--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -1,0 +1,34 @@
+# Privacy Policy
+
+**Last updated:** April 2026
+
+## Controller
+
+Sharang Parnerkar  
+Matthias-Claudius-Strasse 24  
+78234 Engen, Deutschland  
+Email: parnerkarsharang@gmail.com
+
+## Data Collection
+
+This documentation site collects no active personal data. Standard HTTP server logs may record browser transmissions including anonymised IP address, browser details, operating system, referrer URL, and request timestamps. This information supports technical site operation only and is processed by GitHub Pages.
+
+## Hosting
+
+This site is hosted on [GitHub Pages](https://pages.github.com/) operated by GitHub, Inc., 88 Colin P Kelly Jr St, San Francisco, CA 94107, USA. GitHub may log standard request metadata as described in their [Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement). We have no access to this data.
+
+## Cookies
+
+This site creates no first-party cookies. The documentation search runs entirely in your browser and sends no queries to any server.
+
+## External Links
+
+This documentation links to GitHub and other third-party services. Those platforms' independent privacy policies govern data collection on their sites.
+
+## GDPR Rights
+
+Under Articles 15–17 and 21 GDPR, you may request information about, correction of, deletion of, or restriction of processing of personal data, as well as data portability and the right to object. Contact the controller via email to exercise these rights. For data collected by GitHub Pages, contact GitHub directly.
+
+## Policy Updates
+
+This policy may be updated periodically. The current version is always available at `/legal/privacy-policy`.


### PR DESCRIPTION
## Summary

- Adds `docs/legal/impressum.md` — German legal notice (§ 5 TMG) with maintainer contact details
- Adds `docs/legal/privacy-policy.md` — GDPR-compliant policy covering GitHub Pages hosting and no first-party data collection
- Updates VitePress footer in `docs/.vitepress/config.mts` with links to both pages

## Test plan

- [ ] Build docs locally: `npm run docs:build` — verify no broken links
- [ ] Confirm `/orca/legal/impressum` and `/orca/legal/privacy-policy` render after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)