### PR TITLE
fix: real host stats on StatusPing + reconcile correctness

### DIFF
--- a/crates/orca-agent/src/ws_client.rs
+++ b/crates/orca-agent/src/ws_client.rs
@@ -132,6 +132,7 @@ async fn handle_ws_session(
                     domain_tx,
                     &out_tx,
                     &exec_sessions,
+                    &stats_collector,
                 )
                 .await
                 {
@@ -148,7 +149,7 @@ async fn handle_ws_session(
     Ok(())
 }
 
-/// Process a single message from the master.
+#[allow(clippy::too_many_arguments)]
 async fn handle_master_message(
     text: &str,
     node_id: u64,
@@ -157,6 +158,7 @@ async fn handle_master_message(
     domain_tx: &mpsc::Sender<(String, String, u16)>,
     out_tx: &mpsc::Sender<AgentMessage>,
     exec_sessions: &ExecSessions,
+    stats_collector: &crate::host_stats::HostStatsCollector,
 ) -> anyhow::Result<()> {
     let msg: MasterMessage = serde_json::from_str(text)?;
 
@@ -267,11 +269,21 @@ async fn handle_master_message(
         }
         MasterMessage::StatusPing => {
             let workloads = agent.collect_workload_reports(runtime.as_ref()).await;
+            let sample = stats_collector.sample();
             let _ = out_tx
                 .send(AgentMessage::Heartbeat {
                     node_id,
                     workloads,
-                    stats: HostStats::default(),
+                    stats: HostStats {
+                        cpu_percent: sample.cpu_percent,
+                        memory_bytes: sample.memory_bytes,
+                        memory_total: sample.memory_total,
+                        disk_used: sample.disk_used,
+                        disk_total: sample.disk_total,
+                        net_rx: sample.net_rx,
+                        net_tx: sample.net_tx,
+                        domains: vec![],
+                    },
                 })
                 .await;
         }
@@ -469,6 +481,31 @@ async fn reconcile_services(
     for spec in &expected {
         if running_names.contains(&spec.name) {
             skipped += 1;
+            continue;
+        }
+
+        // In-memory state is empty after an agent restart. Check Docker
+        // directly so we don't force-remove a running container.
+        let probe_handle = orca_core::runtime::WorkloadHandle {
+            runtime_id: format!("orca-{}", spec.name),
+            name: format!("orca-{}", spec.name),
+            metadata: Default::default(),
+        };
+        if runtime
+            .status(&probe_handle)
+            .await
+            .unwrap_or(orca_core::types::WorkloadStatus::Stopped)
+            == orca_core::types::WorkloadStatus::Running
+        {
+            agent
+                .update_workload_status(
+                    &probe_handle.runtime_id,
+                    &spec.name,
+                    orca_core::types::WorkloadStatus::Running,
+                )
+                .await;
+            skipped += 1;
+            info!("Reconcile: {} already running, adopted", spec.name);
             continue;
         }
 

--- a/crates/orca-agent/src/ws_client.rs
+++ b/crates/orca-agent/src/ws_client.rs
@@ -456,8 +456,12 @@ async fn reconcile_services(
     domain_tx: &mpsc::Sender<(String, String, u16)>,
 ) {
     let running = agent.collect_workload_reports(runtime.as_ref()).await;
-    let running_names: std::collections::HashSet<String> =
-        running.iter().map(|r| r.service_name.clone()).collect();
+    // Only containers in "running" state count — exited/dead containers must be redeployed.
+    let running_names: std::collections::HashSet<String> = running
+        .iter()
+        .filter(|r| r.status == "running")
+        .map(|r| r.service_name.clone())
+        .collect();
 
     let mut deployed = 0u32;
     let mut skipped = 0u32;

--- a/crates/orca-control/src/health.rs
+++ b/crates/orca-control/src/health.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use tracing::{error, info, warn};
 
 use orca_core::config::ProbeConfig;
-use orca_core::runtime::Runtime;
+use orca_core::runtime::{Runtime, WorkloadHandle};
 use orca_core::types::{HealthState, RuntimeKind, WorkloadStatus};
 
 use crate::routes::{service_config_to_spec, update_container_routes};
@@ -66,14 +66,14 @@ impl HealthChecker {
                 .values()
                 .filter_map(|svc| {
                     // Use liveness probe path, fall back to health path.
+                    // Services with neither get runtime-only checks (no HTTP probe).
                     let (health_path, probe) = if let Some(lp) = &svc.config.liveness {
-                        (lp.path.clone(), Some(lp.clone()))
+                        (Some(lp.path.clone()), Some(lp.clone()))
+                    } else if let Some(path) = svc.config.health.as_deref() {
+                        (Some(path.to_string()), None)
                     } else {
-                        let path = svc.config.health.as_deref()?;
-                        (path.to_string(), None)
+                        (None, None)
                     };
-                    // Respect initial_delay_secs — skip checks until the
-                    // container has been running long enough to become ready.
                     let initial_delay = probe
                         .as_ref()
                         .map(|p| Duration::from_secs(p.initial_delay_secs))
@@ -84,13 +84,11 @@ impl HealthChecker {
                         .enumerate()
                         .filter(|(_, inst)| inst.status == WorkloadStatus::Running)
                         .filter(|(_, inst)| inst.started_at.elapsed() >= initial_delay)
-                        .filter_map(|(idx, inst)| {
-                            let port = inst.host_port?;
-                            Some(InstanceTarget {
-                                index: idx,
-                                runtime_id: inst.handle.runtime_id.clone(),
-                                host_port: port,
-                            })
+                        .map(|(idx, inst)| InstanceTarget {
+                            index: idx,
+                            runtime_id: inst.handle.runtime_id.clone(),
+                            handle: inst.handle.clone(),
+                            host_port: inst.host_port,
                         })
                         .collect();
                     if targets.is_empty() {
@@ -117,10 +115,34 @@ impl HealthChecker {
                 .as_ref()
                 .map_or(DEFAULT_TIMEOUT, |p| Duration::from_secs(p.timeout_secs));
 
+            let runtime: &dyn Runtime = match target.runtime_kind {
+                RuntimeKind::Container => self.state.container_runtime.as_ref(),
+                RuntimeKind::Wasm => match &self.state.wasm_runtime {
+                    Some(r) => r.as_ref(),
+                    None => continue,
+                },
+            };
+
             for inst in &target.targets {
-                let healthy = self
-                    .probe_with_timeout(inst.host_port, &target.health_path, timeout)
-                    .await;
+                let healthy = if let Some(path) = &target.health_path {
+                    if let Some(port) = inst.host_port {
+                        self.probe_with_timeout(port, path, timeout).await
+                    } else {
+                        runtime
+                            .status(&inst.handle)
+                            .await
+                            .unwrap_or(WorkloadStatus::Failed)
+                            == WorkloadStatus::Running
+                    }
+                } else {
+                    // No HTTP endpoint — runtime status is the health signal.
+                    // Catches databases stuck after events like disk-full.
+                    runtime
+                        .status(&inst.handle)
+                        .await
+                        .unwrap_or(WorkloadStatus::Failed)
+                        == WorkloadStatus::Running
+                };
                 let count = failure_counts.entry(inst.runtime_id.clone()).or_insert(0);
 
                 if healthy {
@@ -291,7 +313,7 @@ impl HealthChecker {
 /// Internal struct for collecting check targets without holding locks.
 struct CheckTarget {
     service_name: String,
-    health_path: String,
+    health_path: Option<String>,
     probe_config: Option<ProbeConfig>,
     runtime_kind: RuntimeKind,
     targets: Vec<InstanceTarget>,
@@ -301,5 +323,6 @@ struct CheckTarget {
 struct InstanceTarget {
     index: usize,
     runtime_id: String,
-    host_port: u16,
+    handle: WorkloadHandle,
+    host_port: Option<u16>,
 }

--- a/crates/orca-control/src/health.rs
+++ b/crates/orca-control/src/health.rs
@@ -81,11 +81,9 @@ impl HealthChecker {
                     let targets: Vec<InstanceTarget> = svc
                         .instances
                         .iter()
-                        .enumerate()
-                        .filter(|(_, inst)| inst.status == WorkloadStatus::Running)
-                        .filter(|(_, inst)| inst.started_at.elapsed() >= initial_delay)
-                        .map(|(idx, inst)| InstanceTarget {
-                            index: idx,
+                        .filter(|inst| inst.status == WorkloadStatus::Running)
+                        .filter(|inst| inst.started_at.elapsed() >= initial_delay)
+                        .map(|inst| InstanceTarget {
                             runtime_id: inst.handle.runtime_id.clone(),
                             handle: inst.handle.clone(),
                             host_port: inst.host_port,
@@ -155,7 +153,7 @@ impl HealthChecker {
                         );
                     }
                     *count = 0;
-                    self.set_health(&target.service_name, inst.index, HealthState::Healthy)
+                    self.set_health(&target.service_name, &inst.runtime_id, HealthState::Healthy)
                         .await;
                     // Refresh routes when an instance becomes healthy.
                     self.refresh_routes(&target.service_name).await;
@@ -167,8 +165,12 @@ impl HealthChecker {
                         consecutive_failures = *count,
                         "Health check failed"
                     );
-                    self.set_health(&target.service_name, inst.index, HealthState::Unhealthy)
-                        .await;
+                    self.set_health(
+                        &target.service_name,
+                        &inst.runtime_id,
+                        HealthState::Unhealthy,
+                    )
+                    .await;
                     // Refresh routes so unhealthy backend is removed from rotation.
                     self.refresh_routes(&target.service_name).await;
 
@@ -181,7 +183,7 @@ impl HealthChecker {
                         );
                         self.restart_instance(
                             &target.service_name,
-                            inst.index,
+                            &inst.runtime_id,
                             target.runtime_kind,
                         )
                         .await;
@@ -206,18 +208,26 @@ impl HealthChecker {
         }
     }
 
-    /// Update the health state of a specific instance.
-    async fn set_health(&self, service_name: &str, index: usize, health: HealthState) {
+    /// Update the health state of a specific instance, looked up by runtime_id.
+    async fn set_health(&self, service_name: &str, runtime_id: &str, health: HealthState) {
         let mut services = self.state.services.write().await;
         if let Some(svc) = services.get_mut(service_name)
-            && let Some(inst) = svc.instances.get_mut(index)
+            && let Some(inst) = svc
+                .instances
+                .iter_mut()
+                .find(|i| i.handle.runtime_id == runtime_id)
         {
             inst.health = health;
         }
     }
 
     /// Restart a failed instance by stopping/removing the old one and creating a new one.
-    async fn restart_instance(&self, service_name: &str, index: usize, runtime_kind: RuntimeKind) {
+    async fn restart_instance(
+        &self,
+        service_name: &str,
+        runtime_id: &str,
+        runtime_kind: RuntimeKind,
+    ) {
         let runtime: &dyn Runtime = match runtime_kind {
             RuntimeKind::Container => self.state.container_runtime.as_ref(),
             RuntimeKind::Wasm => match &self.state.wasm_runtime {
@@ -229,13 +239,17 @@ impl HealthChecker {
             },
         };
 
-        // Extract the old handle and config under a write lock, then drop it.
+        // Extract the old handle and config under a read lock, then drop it.
         let (old_handle, spec, port) = {
             let services = self.state.services.read().await;
             let Some(svc) = services.get(service_name) else {
                 return;
             };
-            let Some(inst) = svc.instances.get(index) else {
+            let Some(inst) = svc
+                .instances
+                .iter()
+                .find(|i| i.handle.runtime_id == runtime_id)
+            else {
                 return;
             };
             let spec = match service_config_to_spec(&svc.config) {
@@ -275,15 +289,19 @@ impl HealthChecker {
 
                 {
                     let mut services = self.state.services.write().await;
-                    if let Some(svc) = services.get_mut(service_name)
-                        && let Some(inst) = svc.instances.get_mut(index)
-                    {
-                        inst.handle = new_handle;
-                        inst.status = WorkloadStatus::Running;
-                        inst.host_port = host_port;
-                        inst.started_at = std::time::Instant::now();
-                        // Mark Healthy optimistically — next probe will correct.
-                        inst.health = HealthState::Healthy;
+                    if let Some(svc) = services.get_mut(service_name) {
+                        // Look up by old runtime_id — index is unreliable after watchdog pruning.
+                        if let Some(inst) = svc
+                            .instances
+                            .iter_mut()
+                            .find(|i| i.handle.runtime_id == old_handle.runtime_id)
+                        {
+                            inst.handle = new_handle;
+                            inst.status = WorkloadStatus::Running;
+                            inst.host_port = host_port;
+                            inst.started_at = std::time::Instant::now();
+                            inst.health = HealthState::Healthy;
+                        }
                     }
                 }
                 // Refresh routes with the new host_port.
@@ -321,7 +339,6 @@ struct CheckTarget {
 
 /// Internal struct for a single instance to probe.
 struct InstanceTarget {
-    index: usize,
     runtime_id: String,
     handle: WorkloadHandle,
     host_port: Option<u16>,

--- a/crates/orca-control/src/lib.rs
+++ b/crates/orca-control/src/lib.rs
@@ -153,7 +153,31 @@ async fn restore_or_reconcile(
     state: &AppState,
     config: &orca_core::config::ServiceConfig,
 ) -> anyhow::Result<()> {
-    // Try to downcast to ContainerRuntime for find_existing
+    // Remote services run on an agent node whose WS connection isn't open yet
+    // at startup. Register a placeholder so send_reconcile includes this service
+    // when the agent connects — the agent will skip deployment if the container
+    // is already running.
+    if config
+        .placement
+        .as_ref()
+        .and_then(|p| p.node.as_ref())
+        .is_some()
+    {
+        let desired = match &config.replicas {
+            orca_core::types::Replicas::Fixed(n) => *n,
+            orca_core::types::Replicas::Auto => 1,
+        };
+        let mut services = state.services.write().await;
+        let svc_state = services
+            .entry(config.name.clone())
+            .or_insert_with(|| state::ServiceState::from_config(config.clone()));
+        svc_state.config = config.clone();
+        svc_state.desired_replicas = desired;
+        info!(service = %config.name, "Registered remote service placeholder");
+        return Ok(());
+    }
+
+    // Local service: try to re-attach existing containers first.
     let cr = state
         .container_runtime
         .as_any()

--- a/crates/orca-control/src/reconciler.rs
+++ b/crates/orca-control/src/reconciler.rs
@@ -224,20 +224,29 @@ pub(crate) async fn reconcile_service(
             "Scaling up {} ({:?}): {} -> {} (+{})",
             config.name, config.runtime, current, desired, to_create
         );
-
-        let mut failures = 0u32;
-        for i in current..desired {
-            let mut replica_spec = spec.clone();
-            if desired > 1 {
-                replica_spec.name = format!("{}-{i}", spec.name);
-            }
-
-            match create_and_start_instance(runtime, &replica_spec).await {
-                Ok(instance) => {
-                    svc_state.instances.push(instance);
+        let specs: Vec<_> = (current..desired)
+            .map(|i| {
+                let mut r = spec.clone();
+                if desired > 1 {
+                    r.name = format!("{}-{i}", spec.name);
                 }
+                r
+            })
+            .collect();
+        // Drop the write lock before async I/O so heartbeat processing is not blocked.
+        drop(services);
+
+        let mut new_instances = Vec::new();
+        let mut failures = 0u32;
+        for (idx, replica_spec) in specs.into_iter().enumerate() {
+            match create_and_start_instance(runtime, &replica_spec).await {
+                Ok(inst) => new_instances.push(inst),
                 Err(e) => {
-                    error!("Failed to create instance {}-{i}: {e}", config.name);
+                    error!(
+                        "Failed to create instance {}-{}: {e}",
+                        config.name,
+                        current + idx as u32
+                    );
                     failures += 1;
                 }
             }
@@ -245,31 +254,32 @@ pub(crate) async fn reconcile_service(
         if failures > 0 {
             tracing::warn!("{failures}/{to_create} replicas failed for {}", config.name);
         }
+        let mut services = state.services.write().await;
+        if let Some(svc_state) = services.get_mut(&config.name) {
+            svc_state.instances.extend(new_instances);
+        }
+        drop(services);
     } else if current > desired {
         let to_remove = current - desired;
         info!(
             "Scaling down {} ({:?}): {} -> {} (-{})",
             config.name, config.runtime, current, desired, to_remove
         );
-
+        let mut handles = Vec::new();
         for _ in 0..to_remove {
-            if let Some(instance) = svc_state.instances.pop() {
-                let _ = runtime
-                    .stop(&instance.handle, Duration::from_secs(10))
-                    .await;
-                let _ = runtime.remove(&instance.handle).await;
+            if let Some(inst) = svc_state.instances.pop() {
+                handles.push(inst.handle);
             }
         }
-    }
-
-    // Refresh status of all instances
-    for instance in &mut svc_state.instances {
-        if let Ok(status) = runtime.status(&instance.handle).await {
-            instance.status = status;
+        // Drop the write lock before async I/O.
+        drop(services);
+        for handle in handles {
+            let _ = runtime.stop(&handle, Duration::from_secs(10)).await;
+            let _ = runtime.remove(&handle).await;
         }
+    } else {
+        drop(services);
     }
-
-    drop(services);
 
     // Update routing based on runtime type
     match config.runtime {

--- a/crates/orca-control/src/reconciler.rs
+++ b/crates/orca-control/src/reconciler.rs
@@ -265,6 +265,14 @@ pub(crate) async fn reconcile_service(
             "Scaling down {} ({:?}): {} -> {} (-{})",
             config.name, config.runtime, current, desired, to_remove
         );
+        // Sort so failed/stopped instances are removed first, canary last.
+        svc_state
+            .instances
+            .sort_unstable_by_key(|i| match i.status {
+                WorkloadStatus::Failed | WorkloadStatus::Stopped => 2u8,
+                _ if !i.is_canary => 1,
+                _ => 0,
+            });
         let mut handles = Vec::new();
         for _ in 0..to_remove {
             if let Some(inst) = svc_state.instances.pop() {

--- a/crates/orca-control/src/reconciler.rs
+++ b/crates/orca-control/src/reconciler.rs
@@ -254,11 +254,34 @@ pub(crate) async fn reconcile_service(
         if failures > 0 {
             tracing::warn!("{failures}/{to_create} replicas failed for {}", config.name);
         }
-        let mut services = state.services.write().await;
-        if let Some(svc_state) = services.get_mut(&config.name) {
-            svc_state.instances.extend(new_instances);
+        // Re-acquire write lock and guard against concurrent deploy overshoot:
+        // another reconcile may have created instances while the lock was dropped.
+        let excess_handles = {
+            let mut services = state.services.write().await;
+            let mut excess = Vec::new();
+            if let Some(svc_state) = services.get_mut(&config.name) {
+                let already = svc_state
+                    .instances
+                    .iter()
+                    .filter(|i| i.status == WorkloadStatus::Running)
+                    .count() as u32;
+                let cap = svc_state.desired_replicas.saturating_sub(already) as usize;
+                let mut to_add = new_instances;
+                if to_add.len() > cap {
+                    excess = to_add
+                        .split_off(cap)
+                        .into_iter()
+                        .map(|i| i.handle)
+                        .collect();
+                }
+                svc_state.instances.extend(to_add);
+            }
+            excess
+        };
+        for handle in excess_handles {
+            let _ = runtime.stop(&handle, Duration::from_secs(10)).await;
+            let _ = runtime.remove(&handle).await;
         }
-        drop(services);
     } else if current > desired {
         let to_remove = current - desired;
         info!(

--- a/crates/orca-control/src/watchdog.rs
+++ b/crates/orca-control/src/watchdog.rs
@@ -101,23 +101,50 @@ async fn check_and_prune(state: &AppState, service_name: &str, runtime_kind: Run
         Err(_) => return false,
     };
 
+    // Collect handles under a read lock before any async calls.
+    let handles: Vec<(usize, orca_core::runtime::WorkloadHandle)> = {
+        let services = state.services.read().await;
+        let Some(svc) = services.get(service_name) else {
+            return false;
+        };
+        svc.instances
+            .iter()
+            .enumerate()
+            .map(|(i, inst)| (i, inst.handle.clone()))
+            .collect()
+    };
+
+    // Refresh live status from the runtime for every instance. This catches
+    // containers that are stuck in a restart-loop but still report "Running"
+    // in the cached status (e.g. after a disk-full recovery).
+    let mut live: Vec<(usize, WorkloadStatus)> = Vec::with_capacity(handles.len());
+    for (idx, handle) in &handles {
+        let status = runtime
+            .status(handle)
+            .await
+            .unwrap_or(WorkloadStatus::Failed);
+        live.push((*idx, status));
+    }
+
+    // Write back live statuses and prune dead instances.
     let mut services = state.services.write().await;
     let Some(svc) = services.get_mut(service_name) else {
         return false;
     };
 
-    let mut removed = 0u32;
-    svc.instances.retain_mut(|inst| {
-        // We cannot await inside retain, so check status synchronously
-        // by looking at the cached status. The health checker and
-        // reconciler keep this updated.
-        match inst.status {
-            WorkloadStatus::Stopped | WorkloadStatus::Failed => {
-                removed += 1;
-                false
-            }
-            _ => true,
+    for (idx, status) in &live {
+        if let Some(inst) = svc.instances.get_mut(*idx) {
+            inst.status = *status;
         }
+    }
+
+    let mut removed = 0u32;
+    svc.instances.retain(|inst| match inst.status {
+        WorkloadStatus::Stopped | WorkloadStatus::Failed => {
+            removed += 1;
+            false
+        }
+        _ => true,
     });
 
     if removed > 0 {
@@ -139,13 +166,6 @@ async fn check_and_prune(state: &AppState, service_name: &str, runtime_kind: Run
             desired,
             "Service degraded, needs reconciliation"
         );
-        // Also check live status from runtime for remaining instances
-        // (update cached status so next prune catches them).
-        for inst in &mut svc.instances {
-            if let Ok(status) = runtime.status(&inst.handle).await {
-                inst.status = status;
-            }
-        }
         true
     } else {
         false

--- a/crates/orca-control/src/ws_handler.rs
+++ b/crates/orca-control/src/ws_handler.rs
@@ -307,8 +307,18 @@ async fn handle_ws_heartbeat(
                     "failed" => orca_core::types::WorkloadStatus::Failed,
                     _ => orca_core::types::WorkloadStatus::Stopped,
                 };
-                for instance in &mut svc.instances {
-                    instance.status = status;
+                // Update only the placeholder instance for this node, or the single
+                // instance if there is only one. Blanket-overwriting all instances
+                // masks individual replica failures on multi-replica services.
+                let placeholder_id = format!("remote-{node_id}");
+                if let Some(inst) = svc
+                    .instances
+                    .iter_mut()
+                    .find(|i| i.handle.runtime_id == placeholder_id)
+                {
+                    inst.status = status;
+                } else if svc.instances.len() == 1 {
+                    svc.instances[0].status = status;
                 }
             }
 


### PR DESCRIPTION
## Summary

- **StatusPing zeroed stats** (`ws_client.rs`): The `MasterMessage::StatusPing` handler was sending `HostStats::default()` every 30 s, wiping out real metrics. The `stats_collector` is now threaded into `handle_master_message` so the pong uses a live sample — fixing the ubuntu node showing 0% CPU / 0 RAM / 0 disk.

- **Remote service placeholder at startup** (`orca-control/lib.rs`): Services with `placement.node` were not registered in the master's services map on startup, so the first `send_reconcile` to a fresh agent didn't include them. Master now inserts a placeholder immediately, causing the reconcile to flow correctly (agent skips deploy if container is already running).

- **Concurrent reconcile overshoot guard** (`reconciler.rs`): Re-acquires write lock after each deploy to count already-running instances and stop excess containers spawned by concurrent reconcile calls.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test -j4 --workspace` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)