### PR TITLE
hotfix: health checker must skip remote instances

### DIFF
--- a/crates/orca-control/src/health.rs
+++ b/crates/orca-control/src/health.rs
@@ -122,6 +122,9 @@ impl HealthChecker {
             };
 
             for inst in &target.targets {
+                if inst.runtime_id.starts_with("remote-") {
+                    continue;
+                }
                 let healthy = if let Some(path) = &target.health_path {
                     if let Some(port) = inst.host_port {
                         self.probe_with_timeout(port, path, timeout).await


### PR DESCRIPTION
## Summary

**Critical hotfix** for an infinite deploy loop on agent nodes.

The health checker was iterating over all instances including remote placeholders (`runtime_id = "remote-{node_id}"`). It cannot health-check or restart these via local Docker — they're running on agent nodes. The failure sequence every ~8 minutes:

1. Health check fails on `remote-1775653757946` (not a Docker container on master)
2. After 3 failures → tries to stop/remove → 404
3. Falls through to `create_and_start_instance` with the agent's image → fails (image not on master)
4. Sends a fresh `Deploy` to the agent anyway → duplicate container created
5. Old container still running → master state drifts → services show as stopped while actually reachable
6. Repeat forever

**Fix:** One guard at the top of the per-instance health check loop — skip any instance whose `runtime_id` starts with `"remote-"`. Agent nodes self-manage their container health independently.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test -j4 --workspace` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)