### PR TITLE
fix: remote placeholder instances survive watchdog + DeployResult sets Running

### DIFF
--- a/crates/orca-control/src/watchdog.rs
+++ b/crates/orca-control/src/watchdog.rs
@@ -117,8 +117,13 @@ async fn check_and_prune(state: &AppState, service_name: &str, runtime_kind: Run
     // Refresh live status from the runtime for every instance. This catches
     // containers that are stuck in a restart-loop but still report "Running"
     // in the cached status (e.g. after a disk-full recovery).
+    // Remote placeholders are owned by the heartbeat handler — querying them
+    // via the local Docker runtime always returns Failed and would prune them.
     let mut live: Vec<(usize, WorkloadStatus)> = Vec::with_capacity(handles.len());
     for (idx, handle) in &handles {
+        if handle.runtime_id.starts_with("remote-") {
+            continue;
+        }
         let status = runtime
             .status(handle)
             .await
@@ -139,12 +144,17 @@ async fn check_and_prune(state: &AppState, service_name: &str, runtime_kind: Run
     }
 
     let mut removed = 0u32;
-    svc.instances.retain(|inst| match inst.status {
-        WorkloadStatus::Stopped | WorkloadStatus::Failed => {
-            removed += 1;
-            false
+    svc.instances.retain(|inst| {
+        if inst.handle.runtime_id.starts_with("remote-") {
+            return true;
         }
-        _ => true,
+        match inst.status {
+            WorkloadStatus::Stopped | WorkloadStatus::Failed => {
+                removed += 1;
+                false
+            }
+            _ => true,
+        }
     });
 
     if removed > 0 {

--- a/crates/orca-control/src/ws_handler.rs
+++ b/crates/orca-control/src/ws_handler.rs
@@ -210,6 +210,17 @@ async fn handle_agent_message(
         } => {
             if success {
                 info!("Node {node_id}: deploy of {service_name} succeeded");
+                let mut services = state.services.write().await;
+                if let Some(svc) = services.get_mut(&service_name) {
+                    let placeholder_id = format!("remote-{node_id}");
+                    if let Some(inst) = svc
+                        .instances
+                        .iter_mut()
+                        .find(|i| i.handle.runtime_id == placeholder_id)
+                    {
+                        inst.status = orca_core::types::WorkloadStatus::Running;
+                    }
+                }
             } else {
                 error!(
                     "Node {node_id}: deploy of {service_name} failed: {}",

--- a/crates/orca-control/tests/remote_state_test.rs
+++ b/crates/orca-control/tests/remote_state_test.rs
@@ -1,0 +1,215 @@
+//! Regression tests for remote placeholder instance state management.
+//!
+//! Verifies that watchdog, health checker, and WS DeployResult handler
+//! all correctly handle remote-{node_id} placeholder instances.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::RwLock;
+use tokio_tungstenite::tungstenite;
+
+use orca_control::health::HealthChecker;
+use orca_control::state::{AppState, InstanceState, ServiceState};
+use orca_control::watchdog::run_watchdog_cycle;
+use orca_core::config::{ClusterConfig, ServiceConfig};
+use orca_core::runtime::WorkloadHandle;
+use orca_core::testing::MockRuntime;
+use orca_core::types::{HealthState, Replicas, RuntimeKind, WorkloadStatus};
+use orca_core::ws_types::AgentMessage;
+
+fn make_state(token: &str) -> Arc<AppState> {
+    let runtime = Arc::new(MockRuntime::new());
+    let mut cfg = ClusterConfig::default();
+    cfg.api_tokens = vec![token.into()];
+    Arc::new(AppState::new(
+        cfg,
+        runtime,
+        None,
+        Arc::new(RwLock::new(HashMap::new())),
+        Arc::new(RwLock::new(Vec::new())),
+    ))
+}
+
+fn make_config(name: &str) -> ServiceConfig {
+    ServiceConfig {
+        name: name.into(),
+        project: None,
+        runtime: RuntimeKind::Container,
+        image: Some("nginx:latest".into()),
+        module: None,
+        replicas: Replicas::Fixed(1),
+        port: Some(8080),
+        host_port: None,
+        domain: None,
+        routes: vec![],
+        health: None,
+        readiness: None,
+        liveness: None,
+        env: HashMap::new(),
+        resources: None,
+        volume: None,
+        deploy: None,
+        placement: None,
+        network: None,
+        aliases: vec![],
+        mounts: vec![],
+        triggers: vec![],
+        assets: None,
+        build: None,
+        tls_cert: None,
+        tls_key: None,
+        internal: false,
+        depends_on: vec![],
+        cmd: vec![],
+        extra_ports: vec![],
+        strip_prefix: None,
+        pull_policy: Default::default(),
+        backup: None,
+    }
+}
+
+fn remote_instance(node_id: u64, status: WorkloadStatus) -> InstanceState {
+    InstanceState {
+        handle: WorkloadHandle {
+            runtime_id: format!("remote-{node_id}"),
+            name: format!("remote-{node_id}"),
+            metadata: HashMap::new(),
+        },
+        status,
+        host_port: None,
+        container_address: None,
+        health: HealthState::Healthy,
+        is_canary: false,
+        started_at: std::time::Instant::now() - Duration::from_secs(10),
+    }
+}
+
+/// Watchdog must not prune remote placeholder instances even when their
+/// cached status is Stopped. The heartbeat handler owns their lifecycle.
+#[tokio::test]
+async fn watchdog_does_not_prune_remote_placeholder() {
+    let state = make_state("tok");
+    {
+        let mut services = state.services.write().await;
+        let mut svc = ServiceState::from_config(make_config("rem-svc"));
+        svc.instances
+            .push(remote_instance(42, WorkloadStatus::Stopped));
+        services.insert("rem-svc".into(), svc);
+    }
+
+    run_watchdog_cycle(&state).await;
+
+    let services = state.services.read().await;
+    let svc = services.get("rem-svc").expect("service must still exist");
+    assert_eq!(
+        svc.instances.len(),
+        1,
+        "remote placeholder must not be pruned"
+    );
+    assert_eq!(svc.instances[0].handle.runtime_id, "remote-42");
+}
+
+/// When a service has only a remote placeholder (even with status Stopped),
+/// the watchdog must not trigger local reconciliation and create new instances.
+#[tokio::test]
+async fn watchdog_no_spurious_reconcile_for_remote_service() {
+    let state = make_state("tok");
+    {
+        let mut services = state.services.write().await;
+        let mut svc = ServiceState::from_config(make_config("rem-svc2"));
+        svc.instances
+            .push(remote_instance(99, WorkloadStatus::Stopped));
+        services.insert("rem-svc2".into(), svc);
+    }
+
+    run_watchdog_cycle(&state).await;
+
+    let services = state.services.read().await;
+    let svc = services.get("rem-svc2").unwrap();
+    assert_eq!(
+        svc.instances.len(),
+        1,
+        "reconcile must not create additional local instances"
+    );
+    assert!(
+        svc.instances[0].handle.runtime_id.starts_with("remote-"),
+        "only the original remote placeholder should remain"
+    );
+}
+
+/// DeployResult success from an agent must flip the remote placeholder's
+/// status from Stopped to Running.
+#[tokio::test]
+async fn deploy_result_updates_remote_instance_to_running() {
+    let state = make_state("test-tok");
+    {
+        let mut services = state.services.write().await;
+        let mut svc = ServiceState::from_config(make_config("my-svc"));
+        svc.instances
+            .push(remote_instance(7, WorkloadStatus::Stopped));
+        services.insert("my-svc".into(), svc);
+    }
+
+    let app = axum::Router::new()
+        .route(
+            "/api/v1/ws/agent",
+            axum::routing::get(orca_control::ws_handler::ws_agent_handler),
+        )
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let url = format!("ws://{addr}/api/v1/ws/agent?token=test-tok&node_id=7");
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    let _ = ws.next().await; // consume Ack
+
+    let msg = AgentMessage::DeployResult {
+        service_name: "my-svc".into(),
+        success: true,
+        error: None,
+    };
+    ws.send(tungstenite::Message::Text(
+        serde_json::to_string(&msg).unwrap().into(),
+    ))
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let services = state.services.read().await;
+    assert_eq!(
+        services["my-svc"].instances[0].status,
+        WorkloadStatus::Running,
+        "DeployResult success must set remote placeholder to Running"
+    );
+    ws.close(None).await.ok();
+}
+
+/// Health checker must not record failures for remote placeholder instances.
+/// Without the guard, it calls runtime.status on a remote handle (which the
+/// local Docker daemon doesn't know about) → returns Failed → increments
+/// failure_counts → eventually triggers a spurious restart.
+#[tokio::test]
+async fn health_checker_skips_remote_instance() {
+    let state = make_state("tok");
+    {
+        let mut services = state.services.write().await;
+        let mut svc = ServiceState::from_config(make_config("hc-svc"));
+        svc.instances
+            .push(remote_instance(55, WorkloadStatus::Running));
+        services.insert("hc-svc".into(), svc);
+    }
+
+    let checker = HealthChecker::new(state);
+    let mut failure_counts = HashMap::new();
+    checker.check_all(&mut failure_counts).await;
+
+    assert!(
+        !failure_counts.contains_key("remote-55"),
+        "health checker must not record failures for remote instances"
+    );
+}


### PR DESCRIPTION
## Summary

- **watchdog.rs**: Skip `remote-{node_id}` handles in the live-status refresh loop (no `runtime.status()` call on the master's Docker daemon, which has never seen these containers). Also guard the `retain` filter to never prune remote placeholders regardless of their cached status.
- **ws_handler.rs**: `DeployResult` success now updates the placeholder instance's status from `Stopped` → `Running`, so service status polling reflects deployed state immediately without waiting for the next heartbeat.

## Root cause

PR #30 (`lib.rs`) registered remote service placeholder instances at master startup. This exposed two pre-existing gaps:

1. **Watchdog** called `runtime.status(remote-N-handle)` → Docker on master returns `Err(WorkloadNotFound)` → mapped to `Failed` → `retain` pruned the placeholder → service went from 1 → 0 instances → watchdog triggered reconcile → sent another `Deploy` to the agent every 30s (infinite loop).

2. **DeployResult handler** resolved the `pending_deploys` waiter but never updated the placeholder's status, leaving it as `Stopped` forever (until the next heartbeat).

## Regression tests

New file `tests/remote_state_test.rs` with 4 tests:
- `watchdog_does_not_prune_remote_placeholder`
- `watchdog_no_spurious_reconcile_for_remote_service`
- `deploy_result_updates_remote_instance_to_running`
- `health_checker_skips_remote_instance`

## Test plan
- [x] `cargo clippy -p orca-control -- -D warnings` clean
- [x] All 4 regression tests pass
- [x] Full `cargo test -p orca-control` clean (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)