### PR TITLE
feat(tui): remember last-opened project across sessions

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -147,9 +147,6 @@ to start without re-research.
 
 - **Single-project view filter.** Let user scope the TUI to one project
   at a time instead of a flat list of all services.
-- **Remember last-opened project.** On TUI launch, reopen whichever
-  project was active last session. If none (first run or project
-  deleted), start with no project selected.
 - **Backups per node.** Show backup status grouped by node — last run
   time, volume count, total size, any failures. Needs
   `GET /api/v1/cluster/backups` aggregating results from all nodes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **TUI remembers the last-opened project filter.** Selecting a project with `p` or `:project <name>` persists `last_project` to `~/.orca/tui-state.json`. On next launch the filter is reapplied optimistically; if the project no longer exists in the cluster the filter is dropped silently with a status-bar notice. Clearing the filter (Esc / `:project` with no args) is also persisted. (#34)
+
 ## [0.2.5-rc.6] - 2026-05-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,11 +2602,13 @@ version = "0.2.6-rc.7"
 dependencies = [
  "anyhow",
  "crossterm",
+ "dirs-next",
  "orca-core",
  "ratatui",
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/crates/orca-tui/Cargo.toml
+++ b/crates/orca-tui/Cargo.toml
@@ -20,3 +20,7 @@ crossterm = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+dirs-next = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/orca-tui/src/lib.rs
+++ b/crates/orca-tui/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 mod commands;
 mod keys;
+mod persist;
 pub mod state;
 pub mod ui;
 
@@ -27,6 +28,15 @@ pub async fn run_tui(api_url: &str) -> anyhow::Result<()> {
     let client = ApiClient::new(api_url);
     let mut state = AppState::new();
     state.api_url = client.url().to_string();
+
+    // Optimistically apply the last project filter so the user sees their
+    // saved view immediately. The first successful refresh validates that the
+    // project still exists; if not, refresh() clears it.
+    let persisted = persist::load();
+    if let Some(p) = persisted.last_project {
+        state.project_filter = Some(p.clone());
+        state.pending_restore_project = Some(p);
+    }
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -82,12 +92,20 @@ async fn event_loop(
             continue;
         }
 
+        // Snapshot the project filter so we can detect changes and persist
+        // them exactly once below, regardless of which handler mutated it.
+        let prev_project_filter = state.project_filter.clone();
+
         match state.input_mode {
             InputMode::Filter => keys::handle_filter_key(state, key.code),
             InputMode::Command => keys::handle_command_key(state, client, key.code).await,
             InputMode::Normal => {
                 keys::handle_normal_key(state, client, key.code, &mut last_refresh).await;
             }
+        }
+
+        if state.project_filter != prev_project_filter {
+            persist::save(state);
         }
 
         // If a :sh / :exec command left a pending shell request on the
@@ -161,7 +179,10 @@ fn current_service_name(state: &AppState) -> Option<String> {
 async fn refresh(client: &ApiClient, state: &mut AppState) {
     state.error = None;
     match client.status().await {
-        Ok(resp) => state.update_status(resp),
+        Ok(resp) => {
+            state.update_status(resp);
+            try_restore_project_filter(state);
+        }
         Err(e) => {
             state.mark_disconnected();
             state.error = Some(format!("API error: {e}"));
@@ -169,6 +190,29 @@ async fn refresh(client: &ApiClient, state: &mut AppState) {
     }
     if let Ok(info) = client.cluster_info().await {
         state.update_cluster(info);
+    }
+}
+
+/// Validate the project loaded from disk against the freshly-fetched service
+/// list. Runs at most once per session (the pending value is consumed). If the
+/// project still exists, flash a confirmation. If it does not, drop the filter
+/// and persist the cleared state so the next launch starts clean.
+pub(crate) fn try_restore_project_filter(state: &mut AppState) {
+    let Some(target) = state.pending_restore_project.take() else {
+        return;
+    };
+    let exists = state
+        .services
+        .iter()
+        .any(|s| s.project.as_deref() == Some(target.as_str()));
+    if exists {
+        state.flash(format!("Restored filter: {target}"));
+    } else {
+        state.project_filter = None;
+        persist::save(state);
+        state.flash(format!(
+            "Last project '{target}' no longer exists — filter cleared"
+        ));
     }
 }
 
@@ -192,5 +236,104 @@ async fn handle_stop(client: &ApiClient, state: &mut AppState) {
             Ok(()) => state.flash(format!("Stopped {name}")),
             Err(e) => state.error = Some(format!("Stop failed: {e}")),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::ServiceStatus;
+
+    fn svc_with_project(name: &str, project: Option<&str>) -> ServiceStatus {
+        ServiceStatus {
+            name: name.into(),
+            image: String::new(),
+            runtime: "container".into(),
+            desired_replicas: 1,
+            running_replicas: 1,
+            status: "running".into(),
+            domain: None,
+            project: project.map(String::from),
+            memory_usage: None,
+            cpu_percent: None,
+            node: None,
+            memory_limit_bytes: None,
+        }
+    }
+
+    /// With nothing pending, the function must be a no-op: the user is just
+    /// navigating, not relaunching, so we don't want to clobber state or fire
+    /// a stale flash.
+    #[test]
+    fn no_pending_restore_is_noop() {
+        let mut state = AppState::new();
+        state.project_filter = Some("compliance".into());
+        state.services = vec![svc_with_project("api", Some("compliance"))];
+
+        try_restore_project_filter(&mut state);
+
+        assert_eq!(state.project_filter.as_deref(), Some("compliance"));
+        assert!(state.pending_restore_project.is_none());
+        assert!(state.status_msg.is_none());
+    }
+
+    /// When the persisted project still has at least one service, the filter
+    /// stays active and the user gets a confirmation flash. The pending slot
+    /// is consumed so the next refresh doesn't re-trigger.
+    #[test]
+    fn pending_with_matching_project_flashes_restored() {
+        let mut state = AppState::new();
+        state.project_filter = Some("compliance".into());
+        state.pending_restore_project = Some("compliance".into());
+        state.services = vec![
+            svc_with_project("api", Some("compliance")),
+            svc_with_project("web", Some("frontend")),
+        ];
+
+        try_restore_project_filter(&mut state);
+
+        assert_eq!(state.project_filter.as_deref(), Some("compliance"));
+        assert!(state.pending_restore_project.is_none());
+        assert_eq!(
+            state.status_msg.as_deref(),
+            Some("Restored filter: compliance"),
+        );
+    }
+
+    /// If the persisted project has been deleted between sessions, drop the
+    /// filter and tell the user. Without this, the TUI would show an empty
+    /// list with no explanation and the stale value would survive the next
+    /// launch too.
+    #[test]
+    fn pending_with_missing_project_clears_filter() {
+        let mut state = AppState::new();
+        state.project_filter = Some("compliance".into());
+        state.pending_restore_project = Some("compliance".into());
+        state.services = vec![svc_with_project("web", Some("frontend"))];
+
+        try_restore_project_filter(&mut state);
+
+        assert!(state.project_filter.is_none());
+        assert!(state.pending_restore_project.is_none());
+        let msg = state.status_msg.as_deref().unwrap_or("");
+        assert!(
+            msg.contains("compliance") && msg.contains("no longer exists"),
+            "expected explanatory flash, got: {msg:?}"
+        );
+    }
+
+    /// An empty service list (cluster just booted, nothing deployed) counts as
+    /// "project missing" — we don't have any way to know it'll come back, so
+    /// clear cleanly rather than holding the user in a stuck filtered view.
+    #[test]
+    fn pending_with_empty_service_list_clears_filter() {
+        let mut state = AppState::new();
+        state.project_filter = Some("compliance".into());
+        state.pending_restore_project = Some("compliance".into());
+
+        try_restore_project_filter(&mut state);
+
+        assert!(state.project_filter.is_none());
+        assert!(state.pending_restore_project.is_none());
     }
 }

--- a/crates/orca-tui/src/persist.rs
+++ b/crates/orca-tui/src/persist.rs
@@ -1,0 +1,181 @@
+//! Persisted TUI state at `~/.orca/tui-state.json`.
+//!
+//! Forward-compatible JSON: unknown fields are ignored, missing fields use
+//! `Default`. All I/O is best-effort — a missing or unwritable home directory
+//! must not break the TUI.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::state::AppState;
+
+const ORCA_DIR: &str = ".orca";
+const STATE_FILE: &str = "tui-state.json";
+
+/// Snapshot of TUI state that survives across sessions.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PersistedState {
+    /// Project filter that was active when the TUI last exited. `None` means
+    /// the user was viewing all services.
+    #[serde(default)]
+    pub last_project: Option<String>,
+}
+
+/// Load persisted state from the default path. Returns `Default::default()`
+/// on any failure (no home, missing file, parse error).
+pub fn load() -> PersistedState {
+    state_path().as_deref().map(load_from).unwrap_or_default()
+}
+
+/// Persist the relevant slice of `AppState` to the default path. Errors are
+/// swallowed — TUI behavior must not depend on the state file being writable.
+pub fn save(state: &AppState) {
+    let Some(path) = state_path() else {
+        return;
+    };
+    let _ = save_state_to(&path, state);
+}
+
+/// Project the live `AppState` onto the persisted-state schema and write it.
+/// Split from `save()` so tests can target the AppState → JSON mapping without
+/// having to mock `dirs_next::home_dir`.
+fn save_state_to(path: &Path, state: &AppState) -> std::io::Result<()> {
+    save_to(
+        path,
+        &PersistedState {
+            last_project: state.project_filter.clone(),
+        },
+    )
+}
+
+fn state_path() -> Option<PathBuf> {
+    Some(dirs_next::home_dir()?.join(ORCA_DIR).join(STATE_FILE))
+}
+
+fn load_from(path: &Path) -> PersistedState {
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return PersistedState::default();
+    };
+    serde_json::from_str(&raw).unwrap_or_default()
+}
+
+fn save_to(path: &Path, state: &PersistedState) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(state).unwrap_or_else(|_| "{}".to_string());
+    std::fs::write(path, json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// A saved `last_project` survives a round trip through the JSON file.
+    #[test]
+    fn round_trips_last_project() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("tui-state.json");
+        let state = PersistedState {
+            last_project: Some("compliance".into()),
+        };
+        save_to(&path, &state).unwrap();
+        assert_eq!(load_from(&path), state);
+    }
+
+    /// A missing file is normal on first launch — `load_from` must return the
+    /// default and never error.
+    #[test]
+    fn load_missing_file_returns_default() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("does-not-exist.json");
+        assert_eq!(load_from(&path), PersistedState::default());
+    }
+
+    /// Corrupt JSON on disk (truncated write, manual edit) must be tolerated:
+    /// the TUI silently falls back to the default rather than refusing to launch.
+    #[test]
+    fn load_corrupt_file_returns_default() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("tui-state.json");
+        std::fs::write(&path, "{ not valid json").unwrap();
+        assert_eq!(load_from(&path), PersistedState::default());
+    }
+
+    /// A future binary writes a field this version doesn't know about; we must
+    /// still decode the known fields rather than fail closed.
+    #[test]
+    fn load_with_extra_fields_decodes_known() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("tui-state.json");
+        std::fs::write(&path, r#"{"last_project":"frontend","future_field":42}"#).unwrap();
+        assert_eq!(
+            load_from(&path),
+            PersistedState {
+                last_project: Some("frontend".into()),
+            },
+        );
+    }
+
+    /// `save_to` creates `~/.orca/` (or any other missing parent) on demand
+    /// so a fresh install doesn't need to mkdir manually.
+    #[test]
+    fn save_creates_parent_dir() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nested/sub/tui-state.json");
+        save_to(
+            &path,
+            &PersistedState {
+                last_project: Some("x".into()),
+            },
+        )
+        .unwrap();
+        assert!(path.exists());
+    }
+
+    /// `save_state_to` must map `AppState::project_filter` onto
+    /// `PersistedState::last_project`. This is the only place that mapping
+    /// exists, so the test guards against silent renames on either side.
+    #[test]
+    fn save_state_to_round_trips_project_filter() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("tui-state.json");
+        let mut state = AppState::new();
+        state.project_filter = Some("compliance".into());
+
+        save_state_to(&path, &state).unwrap();
+        assert_eq!(
+            load_from(&path),
+            PersistedState {
+                last_project: Some("compliance".into()),
+            },
+        );
+    }
+
+    /// Clearing the filter (Esc / `:project` with no args) must persist as
+    /// `last_project: null` so the next launch starts unfiltered. If we wrote
+    /// nothing or skipped the call, the stale value from a prior session
+    /// would silently come back.
+    #[test]
+    fn save_state_to_persists_none_to_clear_stale_value() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("tui-state.json");
+
+        // Seed the file with a stale value.
+        save_to(
+            &path,
+            &PersistedState {
+                last_project: Some("old".into()),
+            },
+        )
+        .unwrap();
+
+        // User has now cleared the filter — save must overwrite, not append.
+        let state = AppState::new();
+        save_state_to(&path, &state).unwrap();
+
+        assert_eq!(load_from(&path), PersistedState::default());
+    }
+}

--- a/crates/orca-tui/src/state.rs
+++ b/crates/orca-tui/src/state.rs
@@ -95,6 +95,10 @@ pub struct AppState {
     pub auto_refresh_logs: bool,
     /// Project filter (separate from text filter).
     pub project_filter: Option<String>,
+    /// Project loaded from `~/.orca/tui-state.json` on launch, kept here until
+    /// the first successful status refresh confirms (or denies) that the
+    /// project still exists in the cluster.
+    pub pending_restore_project: Option<String>,
     /// Set by `:sh` / `:exec` to signal the event loop to suspend the TUI
     /// and run an interactive command inside a container. Contents:
     /// (service name, optional node hostname, command argv).
@@ -146,6 +150,7 @@ impl AppState {
             tick: 0,
             auto_refresh_logs: true,
             project_filter: None,
+            pending_restore_project: None,
             pending_shell: None,
             history: HashMap::new(),
             node_history: HashMap::new(),


### PR DESCRIPTION
Closes #34.

## Summary

- Persist the active project filter (`p` / `:project <name>`) to `~/.orca/tui-state.json`.
- On the next launch, optimistically reapply the filter so the user sees their saved view immediately. The first successful status refresh validates that the project still exists; if it does not, drop the filter silently and overwrite the persisted value so the stale name does not survive another launch.
- Forward-compatible JSON schema (`#[serde(default)]` on every field, unknown fields ignored).
- All I/O is best-effort — a missing or unwritable home directory must not break the TUI.

## Design

- New module `crates/orca-tui/src/persist.rs` owns the schema and load/save. The path-resolving \`load\`/\`save\` wrap testable \`load_from(path)\` / \`save_to(path, ...)\` / \`save_state_to(path, &AppState)\` helpers so tests do not have to mock \`dirs_next::home_dir\`.
- New \`pending_restore_project: Option<String>\` field on \`AppState\` carries the value loaded at startup until the first refresh consumes it.
- Single persist trigger in the event loop: snapshot \`project_filter\` before the key handler, compare after, call \`persist::save\` on diff. Any future code that mutates the filter is automatically covered without needing to remember to persist.
- The "missing project" branch persists the cleared state itself, since the event-loop diff trigger only fires on key events.

## Test plan

- [x] 11 unit tests pass (\`cargo test -p orca-tui\`):
  - persist I/O: round-trip, missing file, corrupt JSON, forward-compat extra fields, parent-dir creation
  - AppState ↔ JSON mapping: round-trip + clearing overwrites a stale value
  - restore decision logic: no-op when nothing pending, restored when project exists, cleared+flashed when project missing, cleared on empty service list
- [x] \`cargo clippy -p orca-tui --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Manually tested against a live cluster: \`p\` writes the file, relaunch restores the filter and flashes \`Restored filter: <project>\`, editing the file to a missing project triggers the silent-clear branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)