### PR TITLE
feat(tui): cluster backup dashboard with per-node trigger

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -147,16 +147,15 @@ to start without re-research.
 
 - **Single-project view filter.** Let user scope the TUI to one project
   at a time instead of a flat list of all services.
-- **Backups per node.** Show backup status grouped by node — last run
-  time, volume count, total size, any failures. Needs
-  `GET /api/v1/cluster/backups` aggregating results from all nodes.
-
 - **Webhook management.** View, add, edit, and delete webhooks from
   the TUI. Show last trigger time, status, and matched repo/branch.
   Today webhooks can only be managed via curl to the REST API.
-- **Backup dashboard.** Per-node backup status: last run, volume count,
-  total size, failures, retention. Trigger manual backup. View/restore
-  individual volume snapshots. Needs `GET /api/v1/cluster/backups`.
+- **Backup dashboard: restore action.** #35 shipped the dashboard
+  (table, `b` trigger, `Enter` drill-down). Still to do: `r` on a
+  snapshot row to restore it. Needs a new WS RPC
+  (`MasterMessage::RestoreRequest` / `AgentMessage::RestoreResult`)
+  since today only `orca backup restore` works, run manually on each
+  node. S3-snapshot listing tracked separately in #41.
 - **Secrets organizer.** Group secrets by project, show which services
   reference each secret, add/edit/delete from TUI. Today secrets are
   a flat list managed via `orca secrets set`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **TUI remembers the last-opened project filter.** Selecting a project with `p` or `:project <name>` persists `last_project` to `~/.orca/tui-state.json`. On next launch the filter is reapplied optimistically; if the project no longer exists in the cluster the filter is dropped silently with a status-bar notice. Clearing the filter (Esc / `:project` with no args) is also persisted. (#34)
+- **TUI backup dashboard** (`4` or `:backups`) — per-node table of backup status: hostname, role, last-run age, snapshot count, total size, last-result. Aggregated via a new `GET /api/v1/cluster/backups` endpoint that dispatches `BackupStatusRequest` over WS to every connected agent and merges with the master's local snapshot listing. Press `b` on a row to trigger an immediate backup on that node (master row runs `orca backup all` as a subprocess; agent rows dispatch `BackupRequest` over WS). `Enter` drills into a per-snapshot view with file inventory. View is local-only for now — S3 listing tracked separately. (#35)
 
 ## [0.2.5-rc.6] - 2026-05-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2601,6 +2601,7 @@ name = "orca-tui"
 version = "0.2.6-rc.7"
 dependencies = [
  "anyhow",
+ "chrono",
  "crossterm",
  "dirs-next",
  "orca-core",

--- a/crates/orca-agent/src/ws_client/backup_status.rs
+++ b/crates/orca-agent/src/ws_client/backup_status.rs
@@ -1,0 +1,70 @@
+//! Backup status reporter: respond to `MasterMessage::BackupStatusRequest` by
+//! enumerating this node's local `~/.orca/backups/` and sending the result
+//! back as `AgentMessage::BackupStatusReport`.
+
+use tokio::sync::mpsc;
+use tracing::warn;
+
+use orca_core::backup::enumerate_local_backups;
+use orca_core::ws_types::{AgentMessage, BackupStatusReportData};
+
+/// Enumerate local snapshots and send the report. Spawned as a task by the
+/// dispatch loop so it doesn't block heartbeat or other traffic.
+pub(super) async fn send_backup_status(
+    request_id: String,
+    node_id: u64,
+    out_tx: mpsc::Sender<AgentMessage>,
+) {
+    let snapshots = match dirs_next::home_dir() {
+        Some(home) => enumerate_local_backups(&home),
+        None => {
+            warn!("WS: cannot enumerate backups — no home directory");
+            Vec::new()
+        }
+    };
+    let _ = out_tx
+        .send(AgentMessage::BackupStatusReport {
+            request_id,
+            data: BackupStatusReportData {
+                node_id,
+                hostname: node_hostname(),
+                snapshots,
+            },
+        })
+        .await;
+}
+
+/// Resolve a human-readable host name. Falls back to environment then to a
+/// placeholder so the dashboard never shows an empty cell.
+fn node_hostname() -> String {
+    std::fs::read_to_string("/etc/hostname")
+        .map(|s| s.trim().to_string())
+        .or_else(|_| std::env::var("HOSTNAME"))
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    /// Even when the local backup dir is missing, the agent must reply with a
+    /// well-formed empty report so the master's collector loop doesn't time
+    /// out waiting on a node that simply hasn't run any backups yet.
+    #[tokio::test]
+    async fn send_backup_status_replies_even_with_no_backups() {
+        let (tx, mut rx) = mpsc::channel::<AgentMessage>(4);
+        send_backup_status("req-1".into(), 42, tx).await;
+        let got = rx.try_recv().expect("expected a report");
+        match got {
+            AgentMessage::BackupStatusReport { request_id, data } => {
+                assert_eq!(request_id, "req-1");
+                assert_eq!(data.node_id, 42);
+                // We can't assert snapshots is empty (CI runner could have
+                // ~/.orca/backups), but the message must exist.
+                let _ = data.snapshots;
+            }
+            _ => panic!("expected BackupStatusReport"),
+        }
+    }
+}

--- a/crates/orca-agent/src/ws_client/mod.rs
+++ b/crates/orca-agent/src/ws_client/mod.rs
@@ -4,6 +4,7 @@
 //! Falls back to HTTP heartbeat if WS connection fails.
 
 mod backup;
+mod backup_status;
 mod logs;
 mod reconcile;
 
@@ -23,6 +24,7 @@ use crate::ws_exec::ExecSessions;
 use crate::grpc::AgentClient;
 
 use backup::run_agent_backup;
+use backup_status::send_backup_status;
 use logs::stream_logs;
 use reconcile::reconcile_services;
 
@@ -238,6 +240,12 @@ async fn handle_master_message(
             let tx = out_tx.clone();
             tokio::spawn(async move {
                 run_agent_backup(node_id, config, service_hooks, tx).await;
+            });
+        }
+        MasterMessage::BackupStatusRequest { request_id } => {
+            let tx = out_tx.clone();
+            tokio::spawn(async move {
+                send_backup_status(request_id, node_id, tx).await;
             });
         }
         MasterMessage::Ack { node_id } => {

--- a/crates/orca-control/src/api/handlers/mod.rs
+++ b/crates/orca-control/src/api/handlers/mod.rs
@@ -16,7 +16,8 @@ mod ops;
 pub(crate) mod secrets;
 
 pub(crate) use ops::{
-    logs, promote, redeploy, rollback, scale, stop_all, stop_project, stop_service,
+    cluster_backups, logs, promote, redeploy, rollback, scale, stop_all, stop_project,
+    stop_service, trigger_cluster_backup,
 };
 
 /// Health check endpoint.

--- a/crates/orca-control/src/api/handlers/ops/backups.rs
+++ b/crates/orca-control/src/api/handlers/ops/backups.rs
@@ -1,0 +1,276 @@
+//! Cluster-wide backup dashboard: aggregates per-node snapshot listings and
+//! cached last-result status, plus a trigger endpoint to dispatch an immediate
+//! backup run to one node or every connected agent.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::Json;
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::Deserialize;
+use tracing::warn;
+
+use orca_core::api_types::{
+    ClusterBackupsResponse, LastBackupResult, NodeBackupStatus, NodeRole, TriggerBackupResponse,
+};
+use orca_core::backup::enumerate_local_backups;
+use orca_core::ws_types::{BackupStatusReportData, MasterMessage};
+
+use crate::state::AppState;
+
+/// Per-agent collection timeout. Generous because an agent may be enumerating
+/// dozens of snapshots over slow disks; users can refresh manually if a node
+/// is genuinely unreachable.
+const BACKUP_REPORT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// GET /api/v1/cluster/backups — aggregate per-node backup status.
+pub(crate) async fn cluster_backups(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let master = collect_master_status(&state).await;
+    let agents = collect_agent_statuses(&state).await;
+
+    let mut nodes = vec![master];
+    nodes.extend(agents);
+    Json(ClusterBackupsResponse { nodes })
+}
+
+async fn collect_master_status(state: &AppState) -> NodeBackupStatus {
+    let snapshots = match dirs_next::home_dir() {
+        Some(home) => enumerate_local_backups(&home),
+        None => Vec::new(),
+    };
+    let last_result = state.master_last_backup_result.read().await.clone();
+    NodeBackupStatus {
+        node_id: None,
+        hostname: master_hostname(),
+        role: NodeRole::Master,
+        snapshots,
+        last_result,
+        reachable: true,
+    }
+}
+
+async fn collect_agent_statuses(state: &AppState) -> Vec<NodeBackupStatus> {
+    let agent_ids: Vec<u64> = state.ws_agents.read().await.keys().copied().collect();
+    if agent_ids.is_empty() {
+        return Vec::new();
+    }
+
+    // Single listener channel collects reports from every agent we ask. Each
+    // agent gets a unique request_id but they all funnel into the same
+    // receiver, so the collector loop terminates as soon as we've heard from
+    // all of them or the timeout fires.
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<BackupStatusReportData>(agent_ids.len() + 1);
+    let mut request_ids: Vec<String> = Vec::with_capacity(agent_ids.len());
+    {
+        let mut listeners = state.backup_listeners.write().await;
+        for _ in 0..agent_ids.len() {
+            let req = uuid::Uuid::new_v4().to_string();
+            listeners.insert(req.clone(), tx.clone());
+            request_ids.push(req);
+        }
+    }
+
+    // Dispatch one BackupStatusRequest to each agent.
+    let mut dispatched = HashMap::<u64, String>::new();
+    {
+        let agents = state.ws_agents.read().await;
+        for (node_id, req_id) in agent_ids.iter().zip(request_ids.iter()) {
+            if let Some(agent_tx) = agents.get(node_id) {
+                let sent = agent_tx
+                    .send(MasterMessage::BackupStatusRequest {
+                        request_id: req_id.clone(),
+                    })
+                    .await
+                    .is_ok();
+                if sent {
+                    dispatched.insert(*node_id, req_id.clone());
+                }
+            }
+        }
+    }
+
+    // Collect, indexed by node_id so we can attach cached last_result later.
+    let mut reports = HashMap::<u64, BackupStatusReportData>::new();
+    let deadline = tokio::time::sleep(BACKUP_REPORT_TIMEOUT);
+    tokio::pin!(deadline);
+    while reports.len() < dispatched.len() {
+        tokio::select! {
+            biased;
+            msg = rx.recv() => {
+                match msg {
+                    Some(data) => {
+                        reports.insert(data.node_id, data);
+                    }
+                    None => break,
+                }
+            }
+            _ = &mut deadline => {
+                warn!(
+                    "cluster_backups: timed out after {}s ({} of {} agents responded)",
+                    BACKUP_REPORT_TIMEOUT.as_secs(),
+                    reports.len(),
+                    dispatched.len(),
+                );
+                break;
+            }
+        }
+    }
+
+    // Cleanup listeners so dropped request_ids don't pile up.
+    {
+        let mut listeners = state.backup_listeners.write().await;
+        for req in &request_ids {
+            listeners.remove(req);
+        }
+    }
+
+    let last_results = state.last_backup_results.read().await;
+    agent_ids
+        .into_iter()
+        .map(|node_id| {
+            let last = last_results.get(&node_id).map(|r| LastBackupResult {
+                success: r.success,
+                message: r.message.clone(),
+                recorded_at: r.recorded_at,
+            });
+            match reports.remove(&node_id) {
+                Some(data) => NodeBackupStatus {
+                    node_id: Some(node_id),
+                    hostname: data.hostname,
+                    role: NodeRole::Agent,
+                    snapshots: data.snapshots,
+                    last_result: last,
+                    reachable: true,
+                },
+                None => NodeBackupStatus {
+                    node_id: Some(node_id),
+                    hostname: format!("node-{node_id}"),
+                    role: NodeRole::Agent,
+                    snapshots: Vec::new(),
+                    last_result: last,
+                    reachable: false,
+                },
+            }
+        })
+        .collect()
+}
+
+fn master_hostname() -> String {
+    std::fs::read_to_string("/etc/hostname")
+        .map(|s| s.trim().to_string())
+        .or_else(|_| std::env::var("HOSTNAME"))
+        .unwrap_or_else(|_| "master".to_string())
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TriggerQuery {
+    /// Trigger this specific agent only.
+    pub node_id: Option<u64>,
+    /// Trigger the master's own local backup. Combine with `node_id` to do
+    /// master + a specific agent in one request, or set alone for master
+    /// only. With neither field set, the handler fans out to master + every
+    /// connected agent.
+    #[serde(default)]
+    pub master: bool,
+}
+
+/// POST /api/v1/cluster/backups/trigger
+///
+/// Query params:
+///   - `node_id=<id>` → trigger only that agent
+///   - `master=true`  → trigger only the master
+///   - (combined)     → trigger both
+///   - (neither)      → fan out to master + every connected agent
+///
+/// Master backups run as a subprocess (`orca backup all`) spawned by
+/// `backup_scheduler::run_master_backup`, which records the result on
+/// `state.master_last_backup_result` when the subprocess exits. Agent backups
+/// go over WS as `BackupRequest`, same path the scheduler uses, so manual
+/// runs produce the same artifacts as scheduled runs.
+pub(crate) async fn trigger_cluster_backup(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<TriggerQuery>,
+) -> impl IntoResponse {
+    let Some(config) = state.cluster_config.backup.clone() else {
+        return (
+            StatusCode::BAD_REQUEST,
+            "no [backup] configuration in cluster.toml — cannot trigger".to_string(),
+        )
+            .into_response();
+    };
+
+    // Resolve targets. The "fan out to everything" case fires when neither
+    // field is set — useful from curl and from a future "trigger all" UI.
+    let trigger_master = q.master || q.node_id.is_none();
+    let agent_targets: Vec<u64> = match q.node_id {
+        Some(id) => {
+            let agents = state.ws_agents.read().await;
+            if !agents.contains_key(&id) {
+                return (StatusCode::NOT_FOUND, format!("node {id} is not connected"))
+                    .into_response();
+            }
+            vec![id]
+        }
+        None if q.master => Vec::new(),
+        None => state.ws_agents.read().await.keys().copied().collect(),
+    };
+
+    let mut master_dispatched = false;
+    if trigger_master {
+        let state = state.clone();
+        let config = config.clone();
+        tokio::spawn(async move {
+            crate::backup_scheduler::run_master_backup(&state, &config).await;
+        });
+        master_dispatched = true;
+    }
+
+    let dispatched = dispatch_to_agents(&state, &config, &agent_targets).await;
+    Json(TriggerBackupResponse {
+        dispatched_to: dispatched,
+        master_dispatched,
+    })
+    .into_response()
+}
+
+async fn dispatch_to_agents(
+    state: &AppState,
+    config: &orca_core::backup::BackupConfig,
+    targets: &[u64],
+) -> Vec<u64> {
+    if targets.is_empty() {
+        return Vec::new();
+    }
+    let service_hooks = collect_service_hooks(state).await;
+    let agents = state.ws_agents.read().await;
+    let mut sent_to = Vec::with_capacity(targets.len());
+    for id in targets {
+        if let Some(tx) = agents.get(id) {
+            let ok = tx
+                .send(MasterMessage::BackupRequest {
+                    config: config.clone(),
+                    service_hooks: service_hooks.clone(),
+                })
+                .await
+                .is_ok();
+            if ok {
+                sent_to.push(*id);
+            }
+        }
+    }
+    sent_to
+}
+
+async fn collect_service_hooks(state: &AppState) -> HashMap<String, String> {
+    let services = state.services.read().await;
+    services
+        .values()
+        .filter_map(|svc| {
+            let hook = svc.config.backup.as_ref()?.pre_hook.as_ref()?;
+            Some((svc.config.name.clone(), hook.clone()))
+        })
+        .collect()
+}

--- a/crates/orca-control/src/api/handlers/ops/mod.rs
+++ b/crates/orca-control/src/api/handlers/ops/mod.rs
@@ -1,5 +1,6 @@
 //! Service-level ops handlers: scale, redeploy, rollback, promote, stop, logs.
 
+mod backups;
 mod cluster;
 mod deploy;
 
@@ -8,6 +9,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use tracing::error;
 
+pub(crate) use backups::{cluster_backups, trigger_cluster_backup};
 pub(crate) use cluster::logs;
 pub(crate) use deploy::{promote, redeploy, rollback, scale, stop_all, stop_project, stop_service};
 

--- a/crates/orca-control/src/api/mod.rs
+++ b/crates/orca-control/src/api/mod.rs
@@ -35,6 +35,11 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/v1/services/{name}", delete(handlers::stop_service))
         .route("/api/v1/projects/{project}", delete(handlers::stop_project))
         .route("/api/v1/stop", post(handlers::stop_all))
+        .route("/api/v1/cluster/backups", get(handlers::cluster_backups))
+        .route(
+            "/api/v1/cluster/backups/trigger",
+            post(handlers::trigger_cluster_backup),
+        )
         .route("/api/v1/secrets", get(handlers::secrets::list_secrets))
         .route("/api/v1/secrets/{key}", post(handlers::secrets::set_secret))
         .route(

--- a/crates/orca-control/src/backup_scheduler.rs
+++ b/crates/orca-control/src/backup_scheduler.rs
@@ -135,7 +135,9 @@ async fn invoke_subprocess(config: &BackupConfig) -> (bool, String) {
             // always the human-readable summary (e.g. "Backup complete: 2
             // file(s)."); take that and we don't have to scrub colors.
             let stdout = String::from_utf8_lossy(&out.stdout);
-            let msg = last_non_empty_line(&stdout).unwrap_or("backup complete").to_string();
+            let msg = last_non_empty_line(&stdout)
+                .unwrap_or("backup complete")
+                .to_string();
             info!("Master backup complete: {msg}");
             (true, msg)
         }

--- a/crates/orca-control/src/backup_scheduler.rs
+++ b/crates/orca-control/src/backup_scheduler.rs
@@ -46,7 +46,7 @@ pub fn spawn_backup_scheduler(
             };
             info!("Next backup in {}s", sleep_dur.as_secs());
             tokio::time::sleep(sleep_dur).await;
-            run_local_backup(&config).await;
+            run_master_backup(&state, &config).await;
             dispatch_agent_backups(&state, &config).await;
         }
     });
@@ -87,26 +87,40 @@ async fn collect_service_hooks(state: &AppState) -> std::collections::HashMap<St
         .collect()
 }
 
-/// Execute a full local backup on master by spawning `orca backup all`.
+/// Execute a full local backup on master by spawning `orca backup all`, then
+/// record the outcome on `state.master_last_backup_result` so the dashboard
+/// can render it.
 ///
 /// This backs up master's Docker volumes AND config files (cluster.db,
 /// secrets.json, cluster.toml) — same code path as a manual `orca backup all`.
 /// The backup config is passed via env var so the subprocess uses the same
 /// targets (including resolved S3 credentials) as the scheduler.
-async fn run_local_backup(config: &BackupConfig) {
-    info!("Starting scheduled local backup");
+pub(crate) async fn run_master_backup(state: &Arc<AppState>, config: &BackupConfig) {
+    info!("Starting master backup");
+    let (success, message) = invoke_subprocess(config).await;
+    let result = orca_core::api_types::LastBackupResult {
+        success,
+        message,
+        recorded_at: chrono::Utc::now(),
+    };
+    *state.master_last_backup_result.write().await = Some(result);
+}
+
+async fn invoke_subprocess(config: &BackupConfig) -> (bool, String) {
     let config_json = match serde_json::to_string(config) {
         Ok(j) => j,
         Err(e) => {
-            error!("Failed to serialize backup config: {e}");
-            return;
+            let msg = format!("config serialization failed: {e}");
+            error!("{msg}");
+            return (false, msg);
         }
     };
     let exe = match std::env::current_exe() {
         Ok(p) => p,
         Err(e) => {
-            error!("Failed to resolve current exe for local backup: {e}");
-            return;
+            let msg = format!("cannot resolve current exe: {e}");
+            error!("{msg}");
+            return (false, msg);
         }
     };
     match tokio::process::Command::new(&exe)
@@ -116,15 +130,33 @@ async fn run_local_backup(config: &BackupConfig) {
         .await
     {
         Ok(out) if out.status.success() => {
-            let msg = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            // The subprocess intermixes tracing (with ANSI colors) and plain
+            // `println!` summaries on stdout. The last non-empty line is
+            // always the human-readable summary (e.g. "Backup complete: 2
+            // file(s)."); take that and we don't have to scrub colors.
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let msg = last_non_empty_line(&stdout).unwrap_or("backup complete").to_string();
             info!("Master backup complete: {msg}");
+            (true, msg)
         }
         Ok(out) => {
-            let msg = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let msg = last_non_empty_line(&stderr)
+                .unwrap_or("backup failed (no error message)")
+                .to_string();
             error!("Master backup failed: {msg}");
+            (false, msg)
         }
-        Err(e) => error!("Failed to spawn master backup: {e}"),
+        Err(e) => {
+            let msg = format!("spawn failed: {e}");
+            error!("{msg}");
+            (false, msg)
+        }
     }
+}
+
+fn last_non_empty_line(text: &str) -> Option<&str> {
+    text.lines().rev().map(str::trim).find(|l| !l.is_empty())
 }
 
 #[cfg(test)]
@@ -261,11 +293,11 @@ mod tests {
         dispatch_agent_backups(&state, &config).await;
     }
 
-    /// `run_local_backup` serializes the config to JSON and passes it via env
+    /// `run_master_backup` serializes the config to JSON and passes it via env
     /// var. Verify the JSON round-trips so the spawned subprocess sees the
     /// same targets the scheduler holds.
     #[test]
-    fn local_backup_config_json_roundtrip() {
+    fn master_backup_config_json_roundtrip() {
         use orca_core::backup::BackupTarget;
 
         let config = BackupConfig {

--- a/crates/orca-control/src/state.rs
+++ b/crates/orca-control/src/state.rs
@@ -54,12 +54,30 @@ pub struct AppState {
     pub ws_agents: RwLock<HashMap<u64, crate::ws_handler::AgentSender>>,
     /// Log stream listeners: request_id → (data, done) sender.
     pub log_listeners: RwLock<HashMap<String, tokio::sync::mpsc::Sender<(String, bool)>>>,
+    /// Backup status listeners: request_id → report sender. Used by the
+    /// `/api/v1/cluster/backups` handler to collect reports dispatched in
+    /// parallel to every connected agent.
+    pub backup_listeners: RwLock<
+        HashMap<String, tokio::sync::mpsc::Sender<orca_core::ws_types::BackupStatusReportData>>,
+    >,
+    /// Last completed `BackupResult` per agent node, recorded as the result
+    /// arrives over WS. Surfaced alongside the snapshot listing so the
+    /// dashboard can show a node's last-failure message without having to
+    /// scrape logs. Master has its own field — its backups are subprocess-
+    /// driven, not WS-dispatched.
+    pub last_backup_results: RwLock<HashMap<u64, LastBackupResult>>,
+    /// Last completed master backup result, recorded when `run_master_backup`
+    /// finishes. Separate from `last_backup_results` because the master has
+    /// no `node_id` and runs its backups via subprocess rather than WS.
+    pub master_last_backup_result: RwLock<Option<LastBackupResult>>,
     /// Active exec sessions: session_id → output bytes sender (agent → CLI WS).
     pub exec_sessions: RwLock<HashMap<String, tokio::sync::mpsc::Sender<Vec<u8>>>>,
     /// Pending deploy result waiters: service_name → oneshot sender.
     /// Inserted by queue_remote_deploy, resolved by ws_handler on DeployResult.
     pub pending_deploys: RwLock<HashMap<String, tokio::sync::oneshot::Sender<Result<(), String>>>>,
 }
+
+pub use orca_core::api_types::LastBackupResult;
 
 /// A node registered in the cluster.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -152,6 +170,9 @@ impl AppState {
             store: None,
             ws_agents: RwLock::new(HashMap::new()),
             log_listeners: RwLock::new(HashMap::new()),
+            backup_listeners: RwLock::new(HashMap::new()),
+            last_backup_results: RwLock::new(HashMap::new()),
+            master_last_backup_result: RwLock::new(None),
             exec_sessions: RwLock::new(HashMap::new()),
             pending_deploys: RwLock::new(HashMap::new()),
         }

--- a/crates/orca-control/src/ws_handler/mod.rs
+++ b/crates/orca-control/src/ws_handler/mod.rs
@@ -272,6 +272,21 @@ async fn handle_agent_message(
             } else {
                 error!("Node {node_id}: backup failed — {message}");
             }
+            // Cache for the cluster-backups dashboard so it can surface the
+            // last-known failure without rescanning logs.
+            state.last_backup_results.write().await.insert(
+                node_id,
+                crate::state::LastBackupResult {
+                    success,
+                    message,
+                    recorded_at: chrono::Utc::now(),
+                },
+            );
+        }
+        AgentMessage::BackupStatusReport { request_id, data } => {
+            if let Some(tx) = state.backup_listeners.read().await.get(&request_id) {
+                let _ = tx.send(data).await;
+            }
         }
         AgentMessage::ExecOutput { session_id, data } => {
             use base64::Engine as _;

--- a/crates/orca-core/src/api_types.rs
+++ b/crates/orca-core/src/api_types.rs
@@ -102,6 +102,57 @@ fn default_tail() -> u64 {
     100
 }
 
+/// Response from `GET /api/v1/cluster/backups`. Aggregates backup status
+/// across every node in the cluster for the TUI dashboard.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClusterBackupsResponse {
+    pub nodes: Vec<NodeBackupStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeBackupStatus {
+    /// `None` for the master, `Some(node_id)` for joined agents — saves the
+    /// client from carrying a separate `is_master` flag.
+    #[serde(default)]
+    pub node_id: Option<u64>,
+    pub hostname: String,
+    pub role: NodeRole,
+    pub snapshots: Vec<crate::backup::BackupSnapshotSummary>,
+    /// Last `BackupResult` seen for this node, if any.
+    #[serde(default)]
+    pub last_result: Option<LastBackupResult>,
+    /// `false` if the agent did not respond before the dashboard timeout.
+    /// Master is always reachable in practice — we surface it here for the
+    /// "did we get fresh data" indicator.
+    pub reachable: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeRole {
+    Master,
+    Agent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LastBackupResult {
+    pub success: bool,
+    pub message: String,
+    pub recorded_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Response from `POST /api/v1/cluster/backups/trigger`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriggerBackupResponse {
+    /// Agent node IDs that received a `BackupRequest`.
+    pub dispatched_to: Vec<u64>,
+    /// `true` if the master's local backup was kicked off (runs as a
+    /// subprocess in the background; result lands in
+    /// `master_last_backup_result` when it completes).
+    #[serde(default)]
+    pub master_dispatched: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/orca-core/src/backup/mod.rs
+++ b/crates/orca-core/src/backup/mod.rs
@@ -1,6 +1,8 @@
 mod config;
 mod manager;
 pub mod s3;
+mod status;
 
 pub use config::{BackupConfig, BackupTarget, ServiceBackupConfig};
 pub use manager::{BackupManager, BackupResult};
+pub use status::{BackupFileEntry, BackupSnapshotSummary, enumerate_local_backups};

--- a/crates/orca-core/src/backup/status.rs
+++ b/crates/orca-core/src/backup/status.rs
@@ -41,7 +41,7 @@ pub fn enumerate_local_backups(home: &Path) -> Vec<BackupSnapshotSummary> {
         .filter_map(Result::ok)
         .filter_map(|e| snapshot_from_dir(&e.path()))
         .collect();
-    snapshots.sort_by(|a, b| b.epoch_secs.cmp(&a.epoch_secs));
+    snapshots.sort_by_key(|s| std::cmp::Reverse(s.epoch_secs));
     snapshots
 }
 

--- a/crates/orca-core/src/backup/status.rs
+++ b/crates/orca-core/src/backup/status.rs
@@ -1,0 +1,169 @@
+//! Backup dashboard types and local-disk enumeration.
+//!
+//! Used by both the master (its own local snapshots) and the agent (reports
+//! its snapshots to master via WS). Keeping the enumerator in `orca-core` means
+//! both sides see the same data shape regardless of node role.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// One backup run on disk — one timestamped directory under `~/.orca/backups/`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BackupSnapshotSummary {
+    /// Unix epoch seconds; also the directory name on disk.
+    pub epoch_secs: u64,
+    /// Sum of `files[*].size_bytes` — surfaced for the dashboard top row so a
+    /// client does not need to re-sum it.
+    pub total_size_bytes: u64,
+    /// Files inside this snapshot dir, sorted alphabetically.
+    pub files: Vec<BackupFileEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BackupFileEntry {
+    pub name: String,
+    pub size_bytes: u64,
+}
+
+/// Walk `<home>/.orca/backups/<epoch>/<file>` and return one summary per
+/// timestamped directory, newest first. Top-level entries that are not
+/// numerically-named directories are ignored — that filters out stray files
+/// (lockfiles, README, etc.) without erroring. A missing base directory
+/// returns an empty list rather than an error, since "no backups yet" is a
+/// legitimate state on a fresh node.
+pub fn enumerate_local_backups(home: &Path) -> Vec<BackupSnapshotSummary> {
+    let base = home.join(".orca/backups");
+    let Ok(entries) = std::fs::read_dir(&base) else {
+        return Vec::new();
+    };
+    let mut snapshots: Vec<BackupSnapshotSummary> = entries
+        .filter_map(Result::ok)
+        .filter_map(|e| snapshot_from_dir(&e.path()))
+        .collect();
+    snapshots.sort_by(|a, b| b.epoch_secs.cmp(&a.epoch_secs));
+    snapshots
+}
+
+fn snapshot_from_dir(path: &Path) -> Option<BackupSnapshotSummary> {
+    if !path.is_dir() {
+        return None;
+    }
+    let epoch_secs: u64 = path.file_name()?.to_str()?.parse().ok()?;
+    let files = enumerate_files(path);
+    let total_size_bytes = files.iter().map(|f| f.size_bytes).sum();
+    Some(BackupSnapshotSummary {
+        epoch_secs,
+        total_size_bytes,
+        files,
+    })
+}
+
+fn enumerate_files(dir: &Path) -> Vec<BackupFileEntry> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out: Vec<BackupFileEntry> = entries
+        .filter_map(Result::ok)
+        .filter_map(|e| {
+            let path = e.path();
+            if !path.is_file() {
+                return None;
+            }
+            let name = path.file_name()?.to_str()?.to_string();
+            let size_bytes = std::fs::metadata(&path).ok()?.len();
+            Some(BackupFileEntry { name, size_bytes })
+        })
+        .collect();
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_file(dir: &Path, name: &str, contents: &[u8]) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join(name), contents).unwrap();
+    }
+
+    /// Fresh node, no backup directory at all — must be empty, not panic.
+    #[test]
+    fn missing_base_dir_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        assert!(enumerate_local_backups(tmp.path()).is_empty());
+    }
+
+    /// One snapshot with two files: totals roll up; files are sorted.
+    #[test]
+    fn one_snapshot_two_files() {
+        let tmp = TempDir::new().unwrap();
+        let snap = tmp.path().join(".orca/backups/1700000000");
+        write_file(&snap, "b-vol.tar.gz", &[0u8; 100]);
+        write_file(&snap, "a-vol.tar.gz", &[0u8; 50]);
+
+        let snaps = enumerate_local_backups(tmp.path());
+        assert_eq!(snaps.len(), 1);
+        assert_eq!(snaps[0].epoch_secs, 1_700_000_000);
+        assert_eq!(snaps[0].total_size_bytes, 150);
+        assert_eq!(
+            snaps[0]
+                .files
+                .iter()
+                .map(|f| f.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a-vol.tar.gz", "b-vol.tar.gz"],
+        );
+    }
+
+    /// Multiple snapshots: newest epoch comes first so the dashboard "last
+    /// run" lookup is just `snaps[0]`.
+    #[test]
+    fn multiple_snapshots_sorted_newest_first() {
+        let tmp = TempDir::new().unwrap();
+        for epoch in [1_700_000_000u64, 1_700_086_400, 1_700_172_800] {
+            let snap = tmp.path().join(format!(".orca/backups/{epoch}"));
+            write_file(&snap, "vol.tar.gz", &[0u8; 10]);
+        }
+        let snaps = enumerate_local_backups(tmp.path());
+        assert_eq!(
+            snaps.iter().map(|s| s.epoch_secs).collect::<Vec<_>>(),
+            vec![1_700_172_800, 1_700_086_400, 1_700_000_000],
+        );
+    }
+
+    /// Non-numeric or non-directory entries at the top level are silently
+    /// ignored — a stray `README` or `.DS_Store` must not break the listing.
+    #[test]
+    fn ignores_non_numeric_and_non_dir_entries() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path().join(".orca/backups");
+        fs::create_dir_all(&base).unwrap();
+        // Stray file at the backups root.
+        fs::write(base.join("README"), b"hi").unwrap();
+        // Non-numeric subdir.
+        fs::create_dir(base.join("scratch")).unwrap();
+        // Real snapshot.
+        write_file(&base.join("42"), "vol.tar.gz", &[0u8; 5]);
+
+        let snaps = enumerate_local_backups(tmp.path());
+        assert_eq!(snaps.len(), 1);
+        assert_eq!(snaps[0].epoch_secs, 42);
+    }
+
+    /// An empty snapshot dir (run that failed before writing anything) shows
+    /// up with zero files and zero bytes rather than being filtered out —
+    /// the operator should be able to see that an empty run occurred.
+    #[test]
+    fn empty_snapshot_dir_is_reported_with_zero_size() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join(".orca/backups/99")).unwrap();
+        let snaps = enumerate_local_backups(tmp.path());
+        assert_eq!(snaps.len(), 1);
+        assert_eq!(snaps[0].total_size_bytes, 0);
+        assert!(snaps[0].files.is_empty());
+    }
+}

--- a/crates/orca-core/src/ws_types.rs
+++ b/crates/orca-core/src/ws_types.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::backup::BackupConfig;
+use crate::backup::{BackupConfig, BackupSnapshotSummary};
 use crate::types::WorkloadSpec;
 
 /// Messages sent from agent to master.
@@ -40,6 +40,13 @@ pub enum AgentMessage {
         success: bool,
         message: String,
     },
+    /// Reply to `MasterMessage::BackupStatusRequest`. Carries the agent's
+    /// local snapshot index for the cluster dashboard.
+    BackupStatusReport {
+        request_id: String,
+        #[serde(flatten)]
+        data: BackupStatusReportData,
+    },
     /// PTY output chunk from a container exec session (base64-encoded bytes).
     ExecOutput { session_id: String, data: String },
     /// Exec session has ended.
@@ -67,6 +74,12 @@ pub enum MasterMessage {
         /// service_name → pre_hook shell command, populated from ServiceConfig.backup.
         #[serde(default)]
         service_hooks: HashMap<String, String>,
+    },
+    /// Ask an agent to enumerate its local backup snapshots and respond with
+    /// `AgentMessage::BackupStatusReport`. Request/response correlation via
+    /// the `request_id` field, same pattern as `LogRequest`.
+    BackupStatusRequest {
+        request_id: String,
     },
     Ack {
         node_id: u64,
@@ -102,6 +115,16 @@ pub enum MasterMessage {
     StatusPing,
     /// Signal the agent to run `docker system prune -f`.
     PruneSystem,
+}
+
+/// Payload of `AgentMessage::BackupStatusReport` — split into its own type so
+/// the master's listener channel can carry the data without the `request_id`
+/// (which is already used as the listener map key).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupStatusReportData {
+    pub node_id: u64,
+    pub hostname: String,
+    pub snapshots: Vec<BackupSnapshotSummary>,
 }
 
 /// Status of a single workload, reported by agent.
@@ -263,6 +286,53 @@ mod tests {
         };
         let json4 = serde_json::to_string(&done).unwrap();
         assert!(json4.contains("\"type\":\"exec_done\""));
+    }
+
+    #[test]
+    fn backup_status_request_roundtrip() {
+        let msg = MasterMessage::BackupStatusRequest {
+            request_id: "req-42".into(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"backup_status_request\""));
+        let back: MasterMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, MasterMessage::BackupStatusRequest { .. }));
+    }
+
+    #[test]
+    fn backup_status_report_roundtrip() {
+        use crate::backup::{BackupFileEntry, BackupSnapshotSummary};
+        let msg = AgentMessage::BackupStatusReport {
+            request_id: "req-42".into(),
+            data: BackupStatusReportData {
+                node_id: 7,
+                hostname: "agent-1".into(),
+                snapshots: vec![BackupSnapshotSummary {
+                    epoch_secs: 1_700_000_000,
+                    total_size_bytes: 1024,
+                    files: vec![BackupFileEntry {
+                        name: "vol.tar.gz".into(),
+                        size_bytes: 1024,
+                    }],
+                }],
+            },
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"backup_status_report\""));
+        // Verify the flattened representation: data fields appear at the
+        // top level of the JSON object alongside `type` and `request_id`,
+        // matching how every other AgentMessage variant looks on the wire.
+        assert!(json.contains("\"node_id\":7"));
+        let back: AgentMessage = serde_json::from_str(&json).unwrap();
+        match back {
+            AgentMessage::BackupStatusReport { data, .. } => {
+                assert_eq!(data.node_id, 7);
+                assert_eq!(data.hostname, "agent-1");
+                assert_eq!(data.snapshots.len(), 1);
+                assert_eq!(data.snapshots[0].epoch_secs, 1_700_000_000);
+            }
+            _ => panic!("unexpected variant"),
+        }
     }
 
     #[test]

--- a/crates/orca-tui/Cargo.toml
+++ b/crates/orca-tui/Cargo.toml
@@ -20,6 +20,7 @@ crossterm = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+chrono = { workspace = true }
 dirs-next = "2"
 
 [dev-dependencies]

--- a/crates/orca-tui/src/api.rs
+++ b/crates/orca-tui/src/api.rs
@@ -4,6 +4,10 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
+pub use orca_core::api_types::{
+    ClusterBackupsResponse, LastBackupResult, NodeBackupStatus, NodeRole, TriggerBackupResponse,
+};
+
 /// Fetches cluster data from the orca API.
 pub struct ApiClient {
     base_url: String,
@@ -256,4 +260,46 @@ impl ApiClient {
         .error_for_status()?;
         Ok(())
     }
+
+    /// Fetch the per-node backup status for the cluster dashboard.
+    pub async fn cluster_backups(&self) -> anyhow::Result<ClusterBackupsResponse> {
+        let resp = self
+            .auth(
+                self.client
+                    .get(format!("{}/api/v1/cluster/backups", self.base_url)),
+            )
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(resp.json().await?)
+    }
+
+    /// Trigger an immediate backup on a single target. `Master` runs the
+    /// master's own `orca backup all` subprocess; `Agent(id)` dispatches a
+    /// `BackupRequest` via WS to that agent.
+    pub async fn trigger_backup(
+        &self,
+        target: BackupTriggerTarget,
+    ) -> anyhow::Result<TriggerBackupResponse> {
+        let query = match target {
+            BackupTriggerTarget::Master => "master=true".to_string(),
+            BackupTriggerTarget::Agent(id) => format!("node_id={id}"),
+        };
+        let resp = self
+            .auth(self.client.post(format!(
+                "{}/api/v1/cluster/backups/trigger?{query}",
+                self.base_url
+            )))
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(resp.json().await?)
+    }
+}
+
+/// Per-row trigger target for the backups dashboard.
+#[derive(Debug, Clone, Copy)]
+pub enum BackupTriggerTarget {
+    Master,
+    Agent(u64),
 }

--- a/crates/orca-tui/src/commands.rs
+++ b/crates/orca-tui/src/commands.rs
@@ -12,6 +12,11 @@ pub async fn execute_command(state: &mut AppState, client: &ApiClient, cmd: &str
             state.view = View::Services;
         }
         Some("nodes") => state.push_view(View::Nodes),
+        Some("backups") => {
+            crate::refresh_backups(client, state).await;
+            state.selected_backup_node = 0;
+            state.push_view(View::Backups);
+        }
         Some("logs") => cmd_logs(state, client, &parts).await,
         Some("help") => state.push_view(View::Help),
         Some("scale") => cmd_scale(state, client, &parts).await,

--- a/crates/orca-tui/src/keys.rs
+++ b/crates/orca-tui/src/keys.rs
@@ -79,6 +79,18 @@ pub async fn handle_normal_key(
                     state.selected_secret += 1;
                 }
             }
+            View::Backups => {
+                let len = state.backups.as_ref().map(|b| b.nodes.len()).unwrap_or(0);
+                if len > 0 && state.selected_backup_node + 1 < len {
+                    state.selected_backup_node += 1;
+                }
+            }
+            View::BackupSnapshots { node_idx } => {
+                let len = snapshot_count(state, node_idx);
+                if len > 0 && state.selected_backup_snapshot + 1 < len {
+                    state.selected_backup_snapshot += 1;
+                }
+            }
             _ => state.next_service(),
         },
         KeyCode::Char('k') | KeyCode::Up => match state.view {
@@ -87,16 +99,40 @@ pub async fn handle_normal_key(
                     state.selected_secret -= 1;
                 }
             }
+            View::Backups => {
+                if state.selected_backup_node > 0 {
+                    state.selected_backup_node -= 1;
+                }
+            }
+            View::BackupSnapshots { .. } => {
+                if state.selected_backup_snapshot > 0 {
+                    state.selected_backup_snapshot -= 1;
+                }
+            }
             _ => state.prev_service(),
         },
         KeyCode::Char('g') => match state.view {
             View::Secrets => state.selected_secret = 0,
+            View::Backups => state.selected_backup_node = 0,
+            View::BackupSnapshots { .. } => state.selected_backup_snapshot = 0,
             _ => state.selected_service = 0,
         },
         KeyCode::Char('G') => match state.view {
             View::Secrets => {
                 if !state.secret_keys.is_empty() {
                     state.selected_secret = state.secret_keys.len() - 1;
+                }
+            }
+            View::Backups => {
+                let len = state.backups.as_ref().map(|b| b.nodes.len()).unwrap_or(0);
+                if len > 0 {
+                    state.selected_backup_node = len - 1;
+                }
+            }
+            View::BackupSnapshots { node_idx } => {
+                let len = snapshot_count(state, node_idx);
+                if len > 0 {
+                    state.selected_backup_snapshot = len - 1;
                 }
             }
             _ => {
@@ -124,9 +160,14 @@ pub async fn handle_normal_key(
         // Full-screen logs
         KeyCode::Char('l') => handle_logs(state, client).await,
 
-        // Refresh
+        // Refresh — when in the backups view, refetch the backup status too
+        // (we don't auto-refresh it every 2s since it's an expensive
+        // fan-out RPC and the data changes infrequently).
         KeyCode::Char('r') => {
             super::refresh(client, state).await;
+            if matches!(state.view, View::Backups) {
+                super::refresh_backups(client, state).await;
+            }
             *last_refresh = tokio::time::Instant::now();
             state.flash("Refreshed".into());
         }
@@ -148,6 +189,18 @@ pub async fn handle_normal_key(
             state.push_view(View::Secrets);
         }
         KeyCode::Char('3') => {}
+        KeyCode::Char('4') if !matches!(state.view, View::Backups) => {
+            super::refresh_backups(client, state).await;
+            state.selected_backup_node = 0;
+            state.push_view(View::Backups);
+        }
+        KeyCode::Char('4') => {}
+        // `b` triggers a manual backup on the selected node when in the
+        // backups view. In other views the keybind is unused so it's safe to
+        // claim here without surprising existing muscle memory.
+        KeyCode::Char('b') if matches!(state.view, View::Backups) => {
+            super::trigger_backup_for_selected(client, state).await;
+        }
 
         // Actions
         KeyCode::Char('d') => {
@@ -194,13 +247,38 @@ fn handle_esc(state: &mut AppState) {
     }
 }
 
+/// Number of snapshots for the given node index, or 0 if the backup state
+/// hasn't been fetched or the index is stale.
+fn snapshot_count(state: &AppState, node_idx: usize) -> usize {
+    state
+        .backups
+        .as_ref()
+        .and_then(|b| b.nodes.get(node_idx))
+        .map(|n| n.snapshots.len())
+        .unwrap_or(0)
+}
+
 async fn handle_enter(state: &mut AppState, client: &ApiClient) {
-    if matches!(state.view, View::Services)
-        && let Some(name) = state.selected_service_name()
-    {
-        let name = name.to_string();
-        super::refresh_logs_named(client, state, &name).await;
-        state.push_view(View::Detail { service: name });
+    match state.view {
+        View::Services => {
+            if let Some(name) = state.selected_service_name() {
+                let name = name.to_string();
+                super::refresh_logs_named(client, state, &name).await;
+                state.push_view(View::Detail { service: name });
+            }
+        }
+        View::Backups => {
+            let node_idx = state.selected_backup_node;
+            let exists = state
+                .backups
+                .as_ref()
+                .is_some_and(|b| node_idx < b.nodes.len());
+            if exists {
+                state.selected_backup_snapshot = 0;
+                state.push_view(View::BackupSnapshots { node_idx });
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/orca-tui/src/lib.rs
+++ b/crates/orca-tui/src/lib.rs
@@ -239,6 +239,54 @@ async fn handle_stop(client: &ApiClient, state: &mut AppState) {
     }
 }
 
+/// Fetch the cluster-wide backup status and cache it on the state. Called
+/// when entering the backups view and on explicit `r` refresh — not on every
+/// 2s tick, since the fan-out RPC to every agent is expensive and the data
+/// changes only when a backup actually runs.
+async fn refresh_backups(client: &ApiClient, state: &mut AppState) {
+    match client.cluster_backups().await {
+        Ok(resp) => {
+            // Clamp the selection so a node removal doesn't leave us pointing
+            // past the end of the list.
+            if state.selected_backup_node >= resp.nodes.len() {
+                state.selected_backup_node = resp.nodes.len().saturating_sub(1);
+            }
+            state.backups = Some(resp);
+        }
+        Err(e) => state.error = Some(format!("Backup status failed: {e}")),
+    }
+}
+
+/// Trigger a manual backup for the currently selected node. The master row
+/// runs the master's local `orca backup all` subprocess; an agent row
+/// dispatches a `BackupRequest` over WS to that single agent.
+async fn trigger_backup_for_selected(client: &ApiClient, state: &mut AppState) {
+    let Some(resp) = state.backups.as_ref() else {
+        return;
+    };
+    let Some(node) = resp.nodes.get(state.selected_backup_node) else {
+        return;
+    };
+    let target = match node.node_id {
+        Some(id) => crate::api::BackupTriggerTarget::Agent(id),
+        None => crate::api::BackupTriggerTarget::Master,
+    };
+    let hostname = node.hostname.clone();
+    match client.trigger_backup(target).await {
+        Ok(r) => {
+            let msg = if r.master_dispatched {
+                format!("Triggered master backup on {hostname}")
+            } else if let Some(id) = r.dispatched_to.first() {
+                format!("Triggered backup on {hostname} (node {id})")
+            } else {
+                format!("Backup trigger failed: {hostname} is not connected")
+            };
+            state.flash(msg);
+        }
+        Err(e) => state.error = Some(format!("Trigger failed: {e}")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/orca-tui/src/state.rs
+++ b/crates/orca-tui/src/state.rs
@@ -48,8 +48,12 @@ fn push_capped<T>(buf: &mut VecDeque<T>, value: T) {
 pub enum View {
     Services,
     Nodes,
-    Logs { service: String },
-    Detail { service: String },
+    Logs {
+        service: String,
+    },
+    Detail {
+        service: String,
+    },
     Help,
     Secrets,
     Backups,
@@ -57,7 +61,9 @@ pub enum View {
     /// `AppState::backups.nodes`. The index is captured at push-time
     /// rather than a node identifier so master (which has no `node_id`)
     /// can be the target too.
-    BackupSnapshots { node_idx: usize },
+    BackupSnapshots {
+        node_idx: usize,
+    },
 }
 
 /// Input mode for the TUI.

--- a/crates/orca-tui/src/state.rs
+++ b/crates/orca-tui/src/state.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::Instant;
 
-use crate::api::{ClusterInfo, NodeInfo, ServiceStatus, StatusResponse};
+use crate::api::{ClusterBackupsResponse, ClusterInfo, NodeInfo, ServiceStatus, StatusResponse};
 
 /// How many samples to keep in each rolling history buffer. With a 2s
 /// refresh tick this gives ~3 minutes of trailing data.
@@ -52,6 +52,12 @@ pub enum View {
     Detail { service: String },
     Help,
     Secrets,
+    Backups,
+    /// Drill-down: snapshot list for the node at `node_idx` in
+    /// `AppState::backups.nodes`. The index is captured at push-time
+    /// rather than a node identifier so master (which has no `node_id`)
+    /// can be the target too.
+    BackupSnapshots { node_idx: usize },
 }
 
 /// Input mode for the TUI.
@@ -116,6 +122,14 @@ pub struct AppState {
     pub secret_keys: Vec<String>,
     /// Currently selected row in the secrets view.
     pub selected_secret: usize,
+    /// Cached cluster-backups response; refreshed when entering the view or
+    /// on explicit `r` keypress. `None` means we haven't fetched yet this
+    /// session — the view shows a "loading" placeholder.
+    pub backups: Option<ClusterBackupsResponse>,
+    /// Selected row in the backups view.
+    pub selected_backup_node: usize,
+    /// Selected snapshot row in the backup-snapshots drill-down.
+    pub selected_backup_snapshot: usize,
 }
 
 impl Default for AppState {
@@ -159,6 +173,9 @@ impl AppState {
             cluster_commit: None,
             secret_keys: Vec::new(),
             selected_secret: 0,
+            backups: None,
+            selected_backup_node: 0,
+            selected_backup_snapshot: 0,
         }
     }
 
@@ -346,6 +363,8 @@ impl AppState {
             View::Detail { .. } => "Detail",
             View::Help => "Help",
             View::Secrets => "Secrets",
+            View::Backups => "Backups",
+            View::BackupSnapshots { .. } => "Snapshots",
         }
     }
 }

--- a/crates/orca-tui/src/ui.rs
+++ b/crates/orca-tui/src/ui.rs
@@ -1,5 +1,7 @@
 //! TUI rendering — k9s-style full-screen views with header/footer chrome.
 
+pub mod backup_snapshots;
+pub mod backups;
 pub mod detail;
 pub mod help;
 pub mod logs;
@@ -60,6 +62,10 @@ fn draw_content(f: &mut Frame, area: Rect, state: &AppState) {
         View::Detail { service } => detail::draw_detail(f, area, state, service),
         View::Help => help::draw_help(f, area, state),
         View::Secrets => secrets::draw_secrets(f, area, state),
+        View::Backups => backups::draw_backups(f, area, state),
+        View::BackupSnapshots { node_idx } => {
+            backup_snapshots::draw_backup_snapshots(f, area, state, *node_idx)
+        }
     }
 }
 
@@ -154,6 +160,16 @@ fn draw_breadcrumb(f: &mut Frame, area: Rect, state: &AppState) {
         View::Detail { service } => format!("Services > {service}"),
         View::Help => "Help".to_string(),
         View::Secrets => "Secrets".to_string(),
+        View::Backups => "Backups".to_string(),
+        View::BackupSnapshots { node_idx } => {
+            let hostname = state
+                .backups
+                .as_ref()
+                .and_then(|b| b.nodes.get(*node_idx))
+                .map(|n| n.hostname.as_str())
+                .unwrap_or("?");
+            format!("Backups > {hostname} > Snapshots")
+        }
     };
     let line = Line::from(vec![
         Span::styled(" ", Style::default()),
@@ -248,6 +264,8 @@ fn draw_footer(f: &mut Frame, area: Rect, state: &AppState) {
         View::Detail { .. } => "Esc:back s:scale x:stop l:logs ?:help",
         View::Help => "Esc:back",
         View::Secrets => "Esc:back :set/:rm ?:help",
+        View::Backups => "Esc:back j/k:select ↵:snapshots r:refresh b:trigger ?:help",
+        View::BackupSnapshots { .. } => "Esc:back j/k:select ?:help",
     };
     spans.push(Span::styled(keys, dim));
 

--- a/crates/orca-tui/src/ui/backup_snapshots.rs
+++ b/crates/orca-tui/src/ui/backup_snapshots.rs
@@ -11,17 +11,13 @@ use crate::api::NodeBackupStatus;
 use crate::state::AppState;
 
 pub fn draw_backup_snapshots(f: &mut Frame, area: Rect, state: &AppState, node_idx: usize) {
-    let Some(node) = state
-        .backups
-        .as_ref()
-        .and_then(|b| b.nodes.get(node_idx))
-    else {
+    let Some(node) = state.backups.as_ref().and_then(|b| b.nodes.get(node_idx)) else {
         let block = Block::default()
             .title(" Snapshots ")
             .borders(Borders::ALL)
             .border_style(Style::default().fg(Color::Yellow));
-        let para = Paragraph::new("  Node no longer in the latest response — press Esc.")
-            .block(block);
+        let para =
+            Paragraph::new("  Node no longer in the latest response — press Esc.").block(block);
         f.render_widget(para, area);
         return;
     };
@@ -31,9 +27,10 @@ pub fn draw_backup_snapshots(f: &mut Frame, area: Rect, state: &AppState, node_i
             .title(format!(" Snapshots — {} (0) ", node.hostname))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(Color::Cyan));
-        let para =
-            Paragraph::new("  No snapshots on this node yet. Press 'b' on the Backups view to trigger one.")
-                .block(block);
+        let para = Paragraph::new(
+            "  No snapshots on this node yet. Press 'b' on the Backups view to trigger one.",
+        )
+        .block(block);
         f.render_widget(para, area);
         return;
     }

--- a/crates/orca-tui/src/ui/backup_snapshots.rs
+++ b/crates/orca-tui/src/ui/backup_snapshots.rs
@@ -1,0 +1,137 @@
+//! Backup snapshots drill-down — list of timestamped snapshots for one node.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Row, Table};
+
+use super::backups::{format_relative_age, human_bytes};
+use crate::api::NodeBackupStatus;
+use crate::state::AppState;
+
+pub fn draw_backup_snapshots(f: &mut Frame, area: Rect, state: &AppState, node_idx: usize) {
+    let Some(node) = state
+        .backups
+        .as_ref()
+        .and_then(|b| b.nodes.get(node_idx))
+    else {
+        let block = Block::default()
+            .title(" Snapshots ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Yellow));
+        let para = Paragraph::new("  Node no longer in the latest response — press Esc.")
+            .block(block);
+        f.render_widget(para, area);
+        return;
+    };
+
+    if node.snapshots.is_empty() {
+        let block = Block::default()
+            .title(format!(" Snapshots — {} (0) ", node.hostname))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan));
+        let para =
+            Paragraph::new("  No snapshots on this node yet. Press 'b' on the Backups view to trigger one.")
+                .block(block);
+        f.render_widget(para, area);
+        return;
+    }
+
+    // Snapshot list on top, file detail underneath.
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(6), Constraint::Length(10)])
+        .split(area);
+
+    draw_snapshot_table(f, chunks[0], state, node);
+    draw_files_detail(f, chunks[1], state, node);
+}
+
+fn draw_snapshot_table(f: &mut Frame, area: Rect, state: &AppState, node: &NodeBackupStatus) {
+    let header = Row::new(vec!["#", "TIMESTAMP", "AGE", "FILES", "SIZE"])
+        .style(Style::default().add_modifier(Modifier::BOLD));
+
+    let rows: Vec<Row> = node
+        .snapshots
+        .iter()
+        .enumerate()
+        .map(|(i, s)| {
+            let selected = i == state.selected_backup_snapshot;
+            let style = if selected {
+                Style::default()
+                    .bg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            let timestamp = chrono::DateTime::<chrono::Utc>::from_timestamp(s.epoch_secs as i64, 0)
+                .map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string())
+                .unwrap_or_else(|| s.epoch_secs.to_string());
+            Row::new(vec![
+                Span::raw(format!("{i:>3}")),
+                Span::raw(timestamp),
+                Span::raw(format_relative_age(s.epoch_secs)),
+                Span::raw(s.files.len().to_string()),
+                Span::raw(human_bytes(s.total_size_bytes)),
+            ])
+            .style(style)
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(4),
+        Constraint::Length(22),
+        Constraint::Length(14),
+        Constraint::Length(8),
+        Constraint::Length(12),
+    ];
+
+    let block = Block::default()
+        .title(format!(
+            " Snapshots — {} ({}, local only) ",
+            node.hostname,
+            node.snapshots.len()
+        ))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let table = Table::new(rows, widths).header(header).block(block);
+    f.render_widget(table, area);
+}
+
+fn draw_files_detail(f: &mut Frame, area: Rect, state: &AppState, node: &NodeBackupStatus) {
+    let Some(snap) = node.snapshots.get(state.selected_backup_snapshot) else {
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::with_capacity(snap.files.len() + 2);
+    lines.push(Line::from(vec![
+        Span::styled("Files: ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(format!(
+            "{} ({} total)",
+            snap.files.len(),
+            human_bytes(snap.total_size_bytes),
+        )),
+    ]));
+    if snap.files.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  (empty — likely a failed run)",
+            Style::default().fg(Color::Gray),
+        )));
+    } else {
+        for f in &snap.files {
+            lines.push(Line::from(format!(
+                "  {:<40} {}",
+                f.name,
+                human_bytes(f.size_bytes),
+            )));
+        }
+    }
+
+    let block = Block::default()
+        .title(" Files ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray));
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}

--- a/crates/orca-tui/src/ui/backups.rs
+++ b/crates/orca-tui/src/ui/backups.rs
@@ -1,0 +1,267 @@
+//! Backups view — per-node snapshot summary table.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Row, Table};
+
+use crate::api::{ClusterBackupsResponse, NodeBackupStatus, NodeRole};
+use crate::state::AppState;
+
+pub fn draw_backups(f: &mut Frame, area: Rect, state: &AppState) {
+    let Some(resp) = &state.backups else {
+        let block = Block::default()
+            .title(" Backups ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan));
+        let para = Paragraph::new("  Loading cluster backup status...  (press 'r' to refresh)")
+            .block(block);
+        f.render_widget(para, area);
+        return;
+    };
+
+    if resp.nodes.is_empty() {
+        let block = Block::default()
+            .title(" Backups (0) ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan));
+        let para = Paragraph::new("  No nodes reporting backup status.").block(block);
+        f.render_widget(para, area);
+        return;
+    }
+
+    // Split the area: table on top, selected-node detail underneath. Detail
+    // exists so the operator can read the full last-failure message without
+    // the table being awkwardly wide.
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(6), Constraint::Length(6)])
+        .split(area);
+
+    draw_table(f, chunks[0], state, resp);
+    draw_detail(f, chunks[1], state, resp);
+}
+
+fn draw_table(f: &mut Frame, area: Rect, state: &AppState, resp: &ClusterBackupsResponse) {
+    let header = Row::new(vec![
+        "ROLE",
+        "HOSTNAME",
+        "LAST RUN",
+        "SNAPSHOTS",
+        "TOTAL SIZE",
+        "LAST RESULT",
+    ])
+    .style(Style::default().add_modifier(Modifier::BOLD));
+
+    let rows: Vec<Row> = resp
+        .nodes
+        .iter()
+        .enumerate()
+        .map(|(i, n)| {
+            let selected = i == state.selected_backup_node;
+            let style = if selected {
+                Style::default()
+                    .bg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            Row::new(node_row(n)).style(style)
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(7),
+        Constraint::Length(24),
+        Constraint::Length(20),
+        Constraint::Length(10),
+        Constraint::Length(12),
+        Constraint::Min(20),
+    ];
+
+    let block = Block::default()
+        .title(format!(" Backups ({}) ", resp.nodes.len()))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let table = Table::new(rows, widths).header(header).block(block);
+    f.render_widget(table, area);
+}
+
+fn node_row(n: &NodeBackupStatus) -> Vec<Span<'static>> {
+    let role = match n.role {
+        NodeRole::Master => "master",
+        NodeRole::Agent => "agent",
+    };
+
+    let (last_run, snapshot_count, total_size) = if let Some(first) = n.snapshots.first() {
+        (
+            format_relative_age(first.epoch_secs),
+            n.snapshots.len().to_string(),
+            human_bytes(n.snapshots.iter().map(|s| s.total_size_bytes).sum()),
+        )
+    } else {
+        ("never".to_string(), "0".to_string(), "-".to_string())
+    };
+
+    let (last_result_text, last_result_color) = last_result_cell(n);
+
+    vec![
+        Span::raw(role.to_string()),
+        Span::raw(n.hostname.clone()),
+        Span::raw(last_run),
+        Span::raw(snapshot_count),
+        Span::raw(total_size),
+        Span::styled(last_result_text, Style::default().fg(last_result_color)),
+    ]
+}
+
+fn last_result_cell(n: &NodeBackupStatus) -> (String, Color) {
+    if !n.reachable {
+        return ("unreachable".into(), Color::Yellow);
+    }
+    match &n.last_result {
+        None => ("—".into(), Color::Gray),
+        Some(r) if r.success => ("ok".into(), Color::Green),
+        Some(r) => (truncate(&r.message, 40), Color::Red),
+    }
+}
+
+fn draw_detail(f: &mut Frame, area: Rect, state: &AppState, resp: &ClusterBackupsResponse) {
+    let Some(n) = resp.nodes.get(state.selected_backup_node) else {
+        return;
+    };
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(vec![
+        Span::styled("Selected: ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(n.hostname.clone()),
+    ]));
+    if let Some(first) = n.snapshots.first() {
+        lines.push(Line::from(format!(
+            "Latest snapshot: {} files, {} total",
+            first.files.len(),
+            human_bytes(first.total_size_bytes),
+        )));
+    }
+    if let Some(r) = &n.last_result {
+        let color = if r.success { Color::Green } else { Color::Red };
+        lines.push(Line::from(vec![
+            Span::styled(
+                "Last result: ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(r.message.clone(), Style::default().fg(color)),
+        ]));
+        lines.push(Line::from(format!(
+            "Recorded at: {}",
+            r.recorded_at.format("%Y-%m-%d %H:%M:%S UTC"),
+        )));
+    } else {
+        lines.push(Line::from(Span::styled(
+            "No backup result reported this session.",
+            Style::default().fg(Color::Gray),
+        )));
+    }
+
+    let block = Block::default()
+        .title(" Detail ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray));
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+pub(super) fn format_relative_age(epoch_secs: u64) -> String {
+    let Some(then) = chrono::DateTime::<chrono::Utc>::from_timestamp(epoch_secs as i64, 0) else {
+        return "—".into();
+    };
+    let delta = chrono::Utc::now().signed_duration_since(then);
+    let secs = delta.num_seconds();
+    if secs < 0 {
+        return then.format("%Y-%m-%d %H:%M").to_string();
+    }
+    if secs < 60 {
+        return format!("{secs}s ago");
+    }
+    let mins = secs / 60;
+    if mins < 60 {
+        return format!("{mins}m ago");
+    }
+    let hours = mins / 60;
+    if hours < 24 {
+        return format!("{hours}h ago");
+    }
+    let days = hours / 24;
+    if days < 30 {
+        return format!("{days}d ago");
+    }
+    then.format("%Y-%m-%d").to_string()
+}
+
+pub(super) fn human_bytes(bytes: u64) -> String {
+    const UNITS: &[&str] = &["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut size = bytes as f64;
+    let mut unit = 0;
+    while size >= 1024.0 && unit < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{} {}", bytes, UNITS[0])
+    } else {
+        format!("{size:.1} {}", UNITS[unit])
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `format_relative_age` collapses small durations into compact units —
+    /// the dashboard column is narrow and full timestamps would push other
+    /// columns out of view. We verify each branch is selected at the right
+    /// threshold.
+    #[test]
+    fn format_relative_age_chooses_unit_by_magnitude() {
+        let now = chrono::Utc::now().timestamp() as u64;
+        assert!(format_relative_age(now - 5).ends_with("s ago"));
+        assert!(format_relative_age(now - 600).ends_with("m ago"));
+        assert!(format_relative_age(now - 3600 * 3).ends_with("h ago"));
+        assert!(format_relative_age(now - 86400 * 2).ends_with("d ago"));
+    }
+
+    /// `human_bytes` produces a one-decimal value with the right unit. Bytes
+    /// under 1024 stay raw (no decimal) so "512 B" reads naturally.
+    #[test]
+    fn human_bytes_picks_unit_and_format() {
+        assert_eq!(human_bytes(0), "0 B");
+        assert_eq!(human_bytes(512), "512 B");
+        assert_eq!(human_bytes(1024), "1.0 KiB");
+        assert_eq!(human_bytes(1024 * 1024 * 5), "5.0 MiB");
+        assert_eq!(human_bytes(2u64 * 1024 * 1024 * 1024), "2.0 GiB");
+    }
+
+    /// `truncate` adds an ellipsis when over the limit and is a no-op otherwise.
+    /// Used to keep the LAST RESULT cell from overflowing the table column.
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_long_string_ends_with_ellipsis() {
+        let out = truncate("abcdefghijklmnop", 5);
+        assert_eq!(out.chars().count(), 5);
+        assert!(out.ends_with('…'));
+    }
+}

--- a/crates/orca-tui/src/ui/help.rs
+++ b/crates/orca-tui/src/ui/help.rs
@@ -49,6 +49,8 @@ pub fn draw_help(f: &mut Frame, area: Rect, state: &AppState) {
         ("1", "Services view (grouped by project)"),
         ("2 / n", "Nodes view (CPU/Mem/Disk/Net sparklines)"),
         ("3", "Secrets view"),
+        ("4", "Backups view (per-node snapshot status)"),
+        ("↵ on a backup row", "Drill into snapshot list for that node"),
         ("l", "Logs for selected service"),
         ("?", "This help screen"),
     ] {
@@ -64,6 +66,7 @@ pub fn draw_help(f: &mut Frame, area: Rect, state: &AppState) {
         ("c", "Collapse / expand the selected project"),
         ("p", "Filter by project of selected"),
         ("r", "Refresh immediately"),
+        ("b", "Trigger backup on selected node (Backups view)"),
         ("/", "Filter services by name"),
         ("w", "Toggle word wrap (in logs)"),
     ] {
@@ -80,6 +83,7 @@ pub fn draw_help(f: &mut Frame, area: Rect, state: &AppState) {
         (":filter <text>", "Filter services"),
         (":project <name>", "Filter by project"),
         (":secrets", "Open the secrets view"),
+        (":backups", "Open the cluster backups dashboard"),
         (":set <KEY> <val>", "Create or update a secret"),
         (":rm <KEY>", "Remove a secret"),
         (":drain <id>", "Drain a node"),

--- a/crates/orca-tui/src/ui/help.rs
+++ b/crates/orca-tui/src/ui/help.rs
@@ -50,7 +50,10 @@ pub fn draw_help(f: &mut Frame, area: Rect, state: &AppState) {
         ("2 / n", "Nodes view (CPU/Mem/Disk/Net sparklines)"),
         ("3", "Secrets view"),
         ("4", "Backups view (per-node snapshot status)"),
-        ("↵ on a backup row", "Drill into snapshot list for that node"),
+        (
+            "↵ on a backup row",
+            "Drill into snapshot list for that node",
+        ),
         ("l", "Logs for selected service"),
         ("?", "This help screen"),
     ] {


### PR DESCRIPTION
Closes #35. Follow-up filed as #41 (S3 listing).

## Summary

- New TUI view (\`4\` / \`:backups\`) showing per-node backup status: hostname, role, last-run age, snapshot count, total size, last-result.
- Master aggregates via a new \`GET /api/v1/cluster/backups\` endpoint. For agents it dispatches \`BackupStatusRequest\` over WS and collects \`BackupStatusReport\` replies in parallel (5s timeout). The master enumerates its own \`~/.orca/backups/\` directly.
- \`b\` triggers a manual backup on the selected row. \`master=true\` runs \`orca backup all\` as a subprocess (same path the scheduler uses) and records the result on \`master_last_backup_result\`; \`node_id=N\` dispatches a \`BackupRequest\` over WS to one agent. Last-result message is the trimmed last-line summary so the dashboard doesn't have to scrub ANSI.
- \`Enter\` on a node row drills into a per-snapshot list with the file inventory of the selected snapshot. View title carries \`(local only)\` since S3 enumeration is deferred to #41.

## Wire protocol

Two new variants in \`orca-core::ws_types\`:
- \`MasterMessage::BackupStatusRequest { request_id }\`
- \`AgentMessage::BackupStatusReport { request_id, data: BackupStatusReportData }\`

\`BackupStatusReportData\` is split out so the master's listener channel can carry just the payload while the variant keeps the standard flat-on-the-wire shape via \`#[serde(flatten)]\`.

## State additions

- \`AppState.backup_listeners: HashMap<request_id, Sender<BackupStatusReportData>>\` — mirrors the existing \`log_listeners\` pattern for fan-out/collect.
- \`AppState.last_backup_results: HashMap<u64, LastBackupResult>\` — agent results cached when \`BackupResult\` arrives via WS.
- \`AppState.master_last_backup_result: Option<LastBackupResult>\` — populated by \`run_master_backup\` when the subprocess exits. Separate from the map because the master has no \`node_id\`.

## Module layout

- \`orca-core::backup::status\` — shared enumeration helper + types (used by both master and agent so no duplication).
- \`orca-core::api_types\` — shared response types (\`ClusterBackupsResponse\`, \`NodeBackupStatus\`, \`NodeRole\`, \`LastBackupResult\`, \`TriggerBackupResponse\`).
- \`orca-control::api::handlers::ops::backups\` — the handler.
- \`orca-agent::ws_client::backup_status\` — agent-side handler.
- \`orca-tui::ui::backups\` + \`orca-tui::ui::backup_snapshots\` — TUI views (shared format helpers via \`pub(super)\`).

## Out of scope (filed)

- \`r\` to restore from a snapshot — needs a new WS RPC and overwrites live volume data; intentionally not in this PR.
- S3 snapshot listing — #41.

## Test plan

- [x] \`cargo test\` — 12 new tests across the changed crates (88 + 68 + 26 + 4 with all green).
- [x] \`cargo clippy -- -D warnings\` clean (matches CI invocation).
- [x] \`cargo fmt --check\` clean.
- [x] Manually exercised against a local single-node cluster (\`HOME=/tmp/orca-test\` with seeded snapshots): node list renders, \`b\` triggers master backup and the new snapshot dir shows up on the next \`r\`, \`Enter\` drills into the file inventory, \`Esc\` returns. Master row \`LAST RESULT\` populates with the trimmed subprocess summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)