### PR TITLE
fix(tui): scroll secrets+networks views, parallelize agent network enum

### DIFF
--- a/crates/orca-agent/src/ws_client/network_status.rs
+++ b/crates/orca-agent/src/ws_client/network_status.rs
@@ -95,31 +95,31 @@ pub async fn enumerate_orca_networks(docker: &Docker) -> Vec<DockerNetwork> {
         }
     };
 
-    for summary in containers {
-        let Some(names) = summary.names else {
-            continue;
-        };
-        let Some(raw) = names.first() else {
-            continue;
-        };
-        // Docker returns container names with a leading slash.
+    // Inspect every orca-* container concurrently. Sequential per-container
+    // calls used to dominate the dashboard load time on boxes with many
+    // services — `inspect_container` round-trips to the Docker socket, and
+    // 20+ serial calls felt like a UI hang.
+    use futures_util::future::join_all;
+    let inspect_jobs = containers.into_iter().filter_map(|summary| {
+        let names = summary.names?;
+        let raw = names.first()?;
         let container_name = raw.trim_start_matches('/').to_string();
         if !container_name.starts_with("orca-") {
-            continue;
+            return None;
         }
-        let Some(id) = summary.id else {
-            continue;
-        };
+        let id = summary.id?;
+        Some(async move {
+            let detail = docker
+                .inspect_container(&id, None::<bollard::container::InspectContainerOptions>)
+                .await
+                .ok()?;
+            let nets = detail.network_settings.and_then(|s| s.networks)?;
+            Some((container_name, nets))
+        })
+    });
 
-        let Ok(detail) = docker
-            .inspect_container(&id, None::<bollard::container::InspectContainerOptions>)
-            .await
-        else {
-            continue;
-        };
-        let Some(nets) = detail.network_settings.and_then(|s| s.networks) else {
-            continue;
-        };
+    for result in join_all(inspect_jobs).await.into_iter().flatten() {
+        let (container_name, nets) = result;
         for (net_name, endpoint) in nets {
             if !net_name.starts_with("orca-") {
                 continue;

--- a/crates/orca-tui/src/keys.rs
+++ b/crates/orca-tui/src/keys.rs
@@ -92,6 +92,7 @@ pub async fn handle_normal_key(
                     state.selected_webhook += 1;
                 }
             }
+            View::Networks => state.network_scroll = state.network_scroll.saturating_add(1),
             _ => state.next_service(),
         },
         KeyCode::Char('k') | KeyCode::Up => match state.view {
@@ -111,6 +112,7 @@ pub async fn handle_normal_key(
                     state.selected_webhook -= 1;
                 }
             }
+            View::Networks => state.network_scroll = state.network_scroll.saturating_sub(1),
             _ => state.prev_service(),
         },
         KeyCode::Char('g') => match state.view {
@@ -118,6 +120,7 @@ pub async fn handle_normal_key(
             View::Backups => state.selected_backup_node = 0,
             View::BackupSnapshots { .. } => state.selected_backup_snapshot = 0,
             View::Webhooks => state.selected_webhook = 0,
+            View::Networks => state.network_scroll = 0,
             _ => state.selected_service = 0,
         },
         KeyCode::Char('G') => match state.view {
@@ -138,6 +141,11 @@ pub async fn handle_normal_key(
                 if !state.webhooks.is_empty() {
                     state.selected_webhook = state.webhooks.len() - 1;
                 }
+            }
+            View::Networks => {
+                // Snap to last line; render clamps to the visible window.
+                let total = super::ui::networks::rendered_line_count(state);
+                state.network_scroll = total.saturating_sub(1);
             }
             _ => {
                 let len = state.filtered_services().len();
@@ -215,6 +223,7 @@ pub async fn handle_normal_key(
         KeyCode::Char('5') => {}
         KeyCode::Char('6') if !matches!(state.view, View::Networks) => {
             super::refresh_networks(client, state).await;
+            state.network_scroll = 0;
             state.push_view(View::Networks);
         }
         KeyCode::Char('6') => {}
@@ -257,20 +266,24 @@ pub async fn handle_normal_key(
                 state.flash(format!("Word wrap {mode}"));
             }
         }
-        KeyCode::PageUp => {
-            if matches!(state.view, View::Logs { .. }) {
+        KeyCode::PageUp => match state.view {
+            View::Logs { .. } => {
                 state.service_scroll = state.service_scroll.saturating_add(20);
                 state.auto_refresh_logs = false;
             }
-        }
-        KeyCode::PageDown => {
-            if matches!(state.view, View::Logs { .. }) {
+            View::Networks => state.network_scroll = state.network_scroll.saturating_sub(10),
+            _ => {}
+        },
+        KeyCode::PageDown => match state.view {
+            View::Logs { .. } => {
                 state.service_scroll = state.service_scroll.saturating_sub(20);
                 if state.service_scroll == 0 {
                     state.auto_refresh_logs = true;
                 }
             }
-        }
+            View::Networks => state.network_scroll = state.network_scroll.saturating_add(10),
+            _ => {}
+        },
         _ => {}
     }
 }

--- a/crates/orca-tui/src/state.rs
+++ b/crates/orca-tui/src/state.rs
@@ -126,6 +126,9 @@ pub struct AppState {
     /// Cluster networks data (`GET /api/v1/cluster/networks`). Refreshed on
     /// entry and on `r`. `None` means we haven't fetched yet this session.
     pub networks: Option<ClusterNetworksResponse>,
+    /// Scroll offset (in rendered lines) for the Networks view. The view has
+    /// no selection cursor — j/k just shift the viewport.
+    pub network_scroll: usize,
 }
 
 impl Default for AppState {
@@ -176,6 +179,7 @@ impl AppState {
             webhook_invocations: Vec::new(),
             secrets_usage: Vec::new(),
             networks: None,
+            network_scroll: 0,
         }
     }
 

--- a/crates/orca-tui/src/ui/networks.rs
+++ b/crates/orca-tui/src/ui/networks.rs
@@ -19,6 +19,21 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 use crate::api::{NodeNetworks, NodeRole};
 use crate::state::AppState;
 
+/// Total rendered lines for the current networks data. Used by `keys.rs::G`
+/// to snap the scroll viewport to the last screen without having to peek at
+/// the frame area at key-handling time.
+pub fn rendered_line_count(state: &AppState) -> usize {
+    let Some(resp) = &state.networks else {
+        return 0;
+    };
+    let mut lines: Vec<Line> = Vec::new();
+    for node in &resp.nodes {
+        render_node(node, &mut lines);
+        lines.push(Line::from(""));
+    }
+    lines.len()
+}
+
 pub fn draw_networks(f: &mut Frame, area: Rect, state: &AppState) {
     let Some(resp) = &state.networks else {
         let block = Block::default()
@@ -41,8 +56,23 @@ pub fn draw_networks(f: &mut Frame, area: Rect, state: &AppState) {
         lines.push(Line::from(""));
     }
 
+    // Window the tree to keep `state.network_scroll` rows at the top. The
+    // view has no selection cursor — scroll is purely viewport offset that
+    // j/k/PgUp/PgDn move. 2 rows reserved for the top/bottom border of the
+    // surrounding Block.
+    let visible_rows = (area.height as usize).saturating_sub(2).max(1);
+    let max_scroll = lines.len().saturating_sub(visible_rows);
+    let scroll = state.network_scroll.min(max_scroll);
+    let end = (scroll + visible_rows).min(lines.len());
+    let view: Vec<Line> = lines[scroll..end].to_vec();
+
+    let scroll_indicator = if lines.len() > visible_rows {
+        format!(" [{}/{}] ", scroll + 1, lines.len())
+    } else {
+        String::new()
+    };
     let title = format!(
-        " Networks ({total_nodes} node{}, {total_bridges} bridge{}, {total_domains} domain{}) ",
+        " Networks ({total_nodes} node{}, {total_bridges} bridge{}, {total_domains} domain{}){scroll_indicator}",
         plural(total_nodes),
         plural(total_bridges),
         plural(total_domains),
@@ -51,7 +81,7 @@ pub fn draw_networks(f: &mut Frame, area: Rect, state: &AppState) {
         .title(title)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan));
-    f.render_widget(Paragraph::new(lines).block(block), area);
+    f.render_widget(Paragraph::new(view).block(block), area);
 }
 
 fn render_node(node: &NodeNetworks, out: &mut Vec<Line>) {

--- a/crates/orca-tui/src/ui/secrets.rs
+++ b/crates/orca-tui/src/ui/secrets.rs
@@ -37,19 +37,40 @@ pub fn draw_secrets(f: &mut Frame, area: Rect, state: &AppState) {
         .filter(|r| matches!(r, FlatRow::Key { .. }))
         .count();
 
-    let rows: Vec<Row> = rows_data
+    // Window the flat list so the selection cursor stays on screen. Without
+    // this the Table widget renders top-of-list only — moving the cursor
+    // past the bottom of the visible area appears to "freeze" it because
+    // the highlight is being drawn off-screen.
+    //
+    // Reserve 3 rows for the surrounding Block borders + header.
+    let visible_rows = (area.height as usize).saturating_sub(3).max(1);
+    let scroll = compute_scroll(state.selected_secret, visible_rows, rows_data.len());
+    let end = (scroll + visible_rows).min(rows_data.len());
+
+    let rows: Vec<Row> = rows_data[scroll..end]
         .iter()
         .enumerate()
-        .map(|(i, r)| {
-            let selected = i == state.selected_secret;
+        .map(|(offset, r)| {
+            let actual = scroll + offset;
+            let selected = actual == state.selected_secret;
             render_row(r, selected)
         })
         .collect();
 
     let widths = [Constraint::Min(40), Constraint::Length(14)];
 
+    let title = if rows_data.len() > visible_rows {
+        format!(
+            " Secrets ({total_keys}) [{}/{}] ",
+            (scroll + 1).min(rows_data.len()),
+            rows_data.len()
+        )
+    } else {
+        format!(" Secrets ({total_keys}) ")
+    };
+
     let block = Block::default()
-        .title(format!(" Secrets ({total_keys}) "))
+        .title(title)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan));
 
@@ -57,6 +78,20 @@ pub fn draw_secrets(f: &mut Frame, area: Rect, state: &AppState) {
         Row::new(vec!["KEY", "REFERENCES"]).style(Style::default().add_modifier(Modifier::BOLD));
     let table = Table::new(rows, widths).header(header).block(block);
     f.render_widget(table, area);
+}
+
+/// Keep `selected` inside the visible window of `visible` rows. Mirrors the
+/// services view's scroll logic in `ui/table.rs` so cursor movement feels
+/// consistent across the two list views.
+fn compute_scroll(selected: usize, visible: usize, total: usize) -> usize {
+    if total <= visible {
+        return 0;
+    }
+    if selected < visible / 2 {
+        return 0;
+    }
+    let ideal = selected.saturating_sub(visible / 2);
+    ideal.min(total.saturating_sub(visible))
 }
 
 /// One render slot in the flat list. Group headers and key rows interleave so


### PR DESCRIPTION
## Summary

Three TUI bugs found while testing 0.2.7-rc.1:

- **Secrets view didn't scroll** — moving the cursor past the visible area in `3` view left the highlight off-screen because the Table widget renders top-of-list only. Mirrored the services-view's `compute_scroll` and slice the flat row list to `[scroll..end]`. Title now shows `[N/total]` when content overflows.
- **Networks tab took seconds to load and blocked the TUI** — `enumerate_orca_networks` in the agent did `inspect_container` serially per orca-* container. 20 containers ≈ 20 sequential round-trips to the Docker socket. Replaced the loop with `futures::join_all` so inspects run concurrently.
- **Networks tab didn't scroll** — `draw_networks` rendered the whole tree as a Paragraph with no viewport. Added `state.network_scroll`, window the rendered Lines, and wired `j`/`k`/`g`/`G`/`PgUp`/`PgDn` in the key handler. View has no selection cursor — scroll is pure viewport offset.

## Files

- `crates/orca-agent/src/ws_client/network_status.rs` — parallelize inspect_container
- `crates/orca-tui/src/ui/secrets.rs` — window selection
- `crates/orca-tui/src/ui/networks.rs` — window viewport + `rendered_line_count` helper
- `crates/orca-tui/src/state.rs` — `network_scroll` field
- `crates/orca-tui/src/keys.rs` — j/k/g/G/PgUp/PgDn for Networks

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (unit + integration)
- [x] `cargo test -p orca-control --test e2e_cluster_networks_test -- --ignored`
- [ ] Local TUI smoke test against the test cluster — secrets `j` scrolls past screen edge; networks loads sub-second and scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)