### PR TITLE
feat(ai): alert delivery channels — Slack, webhook, email (#24, PR 1/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.18",
@@ -1019,7 +1019,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -1167,6 +1167,22 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "email-encoding"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
+dependencies = [
+ "base64 0.22.1",
+ "memchr",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 
 [[package]]
 name = "embedded-io"
@@ -2101,6 +2117,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lettre"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "email-encoding",
+ "email_address",
+ "fastrand",
+ "futures-io",
+ "futures-util",
+ "httpdate",
+ "idna",
+ "mime",
+ "nom 8.0.0",
+ "percent-encoding",
+ "quoted_printable",
+ "rustls",
+ "socket2 0.6.3",
+ "tokio",
+ "tokio-rustls",
+ "url",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +2338,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2498,6 +2550,11 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "futures-util",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "lettre",
  "orca-core",
  "reqwest",
  "serde",
@@ -2908,7 +2965,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2945,9 +3002,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2958,6 +3015,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "quoted_printable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 
 [[package]]
 name = "r-efi"
@@ -3341,7 +3404,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -5727,7 +5790,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
  "thiserror 2.0.18",

--- a/crates/orca-ai/Cargo.toml
+++ b/crates/orca-ai/Cargo.toml
@@ -19,3 +19,10 @@ reqwest = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
 async-trait = { workspace = true }
+futures-util = "0.3"
+lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls-tls", "builder", "ring"] }
+
+[dev-dependencies]
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio", "http1", "server"] }
+http-body-util = "0.1"

--- a/crates/orca-ai/src/channels/email.rs
+++ b/crates/orca-ai/src/channels/email.rs
@@ -1,0 +1,142 @@
+//! Email delivery via SMTP using `lettre`.
+//!
+//! Sends one plain-text email per alert event. STARTTLS by default
+//! (port 587); set `starttls = false` in cluster.toml for implicit TLS on
+//! port 465. Credentials resolve through the secrets store via
+//! `${secrets.SMTP_PASSWORD}` in cluster.toml.
+
+use async_trait::async_trait;
+use lettre::message::Message;
+use lettre::transport::smtp::AsyncSmtpTransport;
+use lettre::transport::smtp::authentication::Credentials;
+use lettre::{AsyncTransport, Tokio1Executor};
+use std::time::Duration;
+
+use orca_core::config::EmailChannelConfig;
+use orca_core::types::{AlertConversation, AlertSender, AlertSeverity};
+
+use super::{AlertEvent, Channel};
+
+pub struct EmailChannel {
+    cfg: EmailChannelConfig,
+    transport: AsyncSmtpTransport<Tokio1Executor>,
+}
+
+impl EmailChannel {
+    pub fn new(cfg: EmailChannelConfig) -> Self {
+        let creds = Credentials::new(cfg.username.clone(), cfg.password.clone());
+        let builder = if cfg.starttls {
+            AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&cfg.smtp_host)
+        } else {
+            AsyncSmtpTransport::<Tokio1Executor>::relay(&cfg.smtp_host)
+        };
+        let transport = builder
+            .expect("build SMTP transport")
+            .port(cfg.smtp_port)
+            .credentials(creds)
+            .timeout(Some(Duration::from_secs(15)))
+            .build();
+        Self { cfg, transport }
+    }
+
+    fn subject(conv: &AlertConversation, event: AlertEvent) -> String {
+        let sev = match conv.severity {
+            AlertSeverity::Critical => "[CRITICAL]",
+            AlertSeverity::Warning => "[WARN]",
+            AlertSeverity::Info => "[INFO]",
+        };
+        format!("{sev} {} — {}", event.label(), conv.service)
+    }
+
+    fn body(conv: &AlertConversation, event: AlertEvent) -> String {
+        let mut out = String::new();
+        out.push_str(&format!("Service: {}\n", conv.service));
+        out.push_str(&format!("Severity: {:?}\n", conv.severity));
+        out.push_str(&format!("State: {:?}\n", conv.state));
+        out.push_str(&format!("Event: {}\n", event.label()));
+        out.push_str(&format!("Started: {}\n", conv.started_at.to_rfc3339()));
+        if let Some(resolved) = conv.resolved_at {
+            out.push_str(&format!("Resolved: {}\n", resolved.to_rfc3339()));
+        }
+        out.push_str("\n--- Conversation ---\n");
+        for msg in &conv.messages {
+            let who = match msg.sender {
+                AlertSender::Orca => "orca",
+                AlertSender::Operator => "operator",
+                AlertSender::System => "system",
+            };
+            out.push_str(&format!(
+                "[{}] {}: {}\n",
+                msg.timestamp.format("%H:%M:%S"),
+                who,
+                msg.content
+            ));
+            if let Some(cmd) = &msg.suggested_command {
+                out.push_str(&format!("  fix: {cmd}\n"));
+            }
+        }
+        out
+    }
+}
+
+#[async_trait]
+impl Channel for EmailChannel {
+    fn name(&self) -> &'static str {
+        "email"
+    }
+
+    async fn deliver(&self, conv: &AlertConversation, event: AlertEvent) -> anyhow::Result<()> {
+        let subject = Self::subject(conv, event);
+        let body = Self::body(conv, event);
+        let mut builder = Message::builder()
+            .from(self.cfg.from.parse()?)
+            .subject(subject);
+        for recipient in &self.cfg.to {
+            builder = builder.to(recipient.parse()?);
+        }
+        let email = builder.body(body)?;
+        self.transport.send(email).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orca_core::types::{AlertMessage, AlertState};
+
+    fn fake_conv() -> AlertConversation {
+        AlertConversation {
+            id: uuid::Uuid::now_v7(),
+            service: "api".into(),
+            severity: AlertSeverity::Critical,
+            state: AlertState::AwaitingAction,
+            started_at: chrono::Utc::now(),
+            resolved_at: None,
+            messages: vec![AlertMessage {
+                timestamp: chrono::Utc::now(),
+                sender: AlertSender::Orca,
+                content: "OOM detected".into(),
+                suggested_command: Some("orca redeploy api".into()),
+            }],
+        }
+    }
+
+    #[test]
+    fn subject_includes_severity_event_and_service() {
+        let conv = fake_conv();
+        let s = EmailChannel::subject(&conv, AlertEvent::Opened);
+        assert!(s.contains("[CRITICAL]"));
+        assert!(s.contains("Opened"));
+        assert!(s.contains("api"));
+    }
+
+    #[test]
+    fn body_renders_messages_and_suggested_fix() {
+        let conv = fake_conv();
+        let body = EmailChannel::body(&conv, AlertEvent::Opened);
+        assert!(body.contains("Service: api"));
+        assert!(body.contains("OOM detected"));
+        assert!(body.contains("fix: orca redeploy api"));
+    }
+}

--- a/crates/orca-ai/src/channels/mod.rs
+++ b/crates/orca-ai/src/channels/mod.rs
@@ -1,0 +1,225 @@
+//! Alert delivery channels (Slack, generic webhook, email).
+//!
+//! `ConversationEngine` holds an optional [`Dispatcher`] that fans alert
+//! events to every configured channel in parallel. A failure in one channel
+//! does not block the others — each channel is awaited concurrently and
+//! errors are logged but swallowed so the engine's mutation completes.
+
+mod email;
+mod slack;
+mod webhook;
+
+use async_trait::async_trait;
+use futures_util::future::join_all;
+use tracing::warn;
+
+use orca_core::config::AlertDeliveryChannels;
+use orca_core::types::AlertConversation;
+
+pub use email::EmailChannel;
+pub use slack::SlackChannel;
+pub use webhook::WebhookChannel;
+
+/// What just happened to a conversation. Lets channels render differently
+/// for the opening shot vs ongoing updates vs the final state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertEvent {
+    /// First message — initial diagnosis from the AI.
+    Opened,
+    /// Operator replied or system pushed new context.
+    Updated,
+    /// Auto-remediation applied; conversation moves to Remediated state.
+    Remediated,
+    /// Issue self-resolved or operator marked it resolved.
+    Resolved,
+    /// Operator dismissed the alert.
+    Dismissed,
+}
+
+impl AlertEvent {
+    pub fn label(self) -> &'static str {
+        match self {
+            AlertEvent::Opened => "Opened",
+            AlertEvent::Updated => "Updated",
+            AlertEvent::Remediated => "Remediated",
+            AlertEvent::Resolved => "Resolved",
+            AlertEvent::Dismissed => "Dismissed",
+        }
+    }
+}
+
+#[async_trait]
+pub trait Channel: Send + Sync {
+    fn name(&self) -> &'static str;
+    async fn deliver(&self, conv: &AlertConversation, event: AlertEvent) -> anyhow::Result<()>;
+}
+
+/// Holds the configured delivery channels and fans events out in parallel.
+/// Construct via [`Dispatcher::from_config`]; an empty dispatcher is a no-op
+/// so callers don't need to special-case the unconfigured case.
+pub struct Dispatcher {
+    channels: Vec<Box<dyn Channel>>,
+}
+
+impl Dispatcher {
+    pub fn new(channels: Vec<Box<dyn Channel>>) -> Self {
+        Self { channels }
+    }
+
+    pub fn empty() -> Self {
+        Self {
+            channels: Vec::new(),
+        }
+    }
+
+    /// Build a dispatcher from the cluster.toml `[ai.alerts.channels]` block.
+    /// Channels with `None` config entries are skipped silently.
+    pub fn from_config(cfg: &AlertDeliveryChannels) -> Self {
+        let mut channels: Vec<Box<dyn Channel>> = Vec::new();
+        if let Some(url) = &cfg.slack {
+            channels.push(Box::new(SlackChannel::new(url.clone())));
+        }
+        if let Some(url) = &cfg.webhook {
+            channels.push(Box::new(WebhookChannel::new(url.clone())));
+        }
+        if let Some(email) = &cfg.email {
+            channels.push(Box::new(EmailChannel::new(email.clone())));
+        }
+        Self { channels }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.channels.is_empty()
+    }
+
+    pub fn channel_names(&self) -> Vec<&'static str> {
+        self.channels.iter().map(|c| c.name()).collect()
+    }
+
+    /// Fan the event out to every channel in parallel. Failures are logged
+    /// per-channel; this returns once all channels have either completed
+    /// or errored. The caller's mutation is independent of delivery — we
+    /// never make the engine's path fail because Slack is down.
+    pub async fn dispatch(&self, conv: &AlertConversation, event: AlertEvent) {
+        if self.channels.is_empty() {
+            return;
+        }
+        let futures = self.channels.iter().map(|ch| {
+            let name = ch.name();
+            async move {
+                if let Err(e) = ch.deliver(conv, event).await {
+                    warn!(channel = name, alert = %conv.service, event = ?event, error = %e, "alert delivery failed");
+                }
+            }
+        });
+        join_all(futures).await;
+    }
+}
+
+impl Default for Dispatcher {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orca_core::types::{AlertSeverity, AlertState};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Mutex;
+
+    struct CountingChannel {
+        name: &'static str,
+        count: Arc<AtomicUsize>,
+        events: Arc<Mutex<Vec<AlertEvent>>>,
+    }
+
+    #[async_trait]
+    impl Channel for CountingChannel {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        async fn deliver(&self, _: &AlertConversation, event: AlertEvent) -> anyhow::Result<()> {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            self.events.lock().await.push(event);
+            Ok(())
+        }
+    }
+
+    struct FailingChannel;
+    #[async_trait]
+    impl Channel for FailingChannel {
+        fn name(&self) -> &'static str {
+            "failing"
+        }
+        async fn deliver(&self, _: &AlertConversation, _: AlertEvent) -> anyhow::Result<()> {
+            anyhow::bail!("simulated channel failure")
+        }
+    }
+
+    fn fake_conv() -> AlertConversation {
+        AlertConversation {
+            id: uuid::Uuid::now_v7(),
+            service: "svc".into(),
+            severity: AlertSeverity::Warning,
+            state: AlertState::Investigating,
+            started_at: chrono::Utc::now(),
+            resolved_at: None,
+            messages: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatcher_fans_to_all_channels() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let d = Dispatcher::new(vec![
+            Box::new(CountingChannel {
+                name: "a",
+                count: count.clone(),
+                events: events.clone(),
+            }),
+            Box::new(CountingChannel {
+                name: "b",
+                count: count.clone(),
+                events: events.clone(),
+            }),
+        ]);
+
+        d.dispatch(&fake_conv(), AlertEvent::Opened).await;
+
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+        assert_eq!(events.lock().await.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn dispatcher_failure_in_one_does_not_block_others() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let d = Dispatcher::new(vec![
+            Box::new(FailingChannel),
+            Box::new(CountingChannel {
+                name: "good",
+                count: count.clone(),
+                events: events.clone(),
+            }),
+        ]);
+
+        d.dispatch(&fake_conv(), AlertEvent::Opened).await;
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "good channel must still receive the event when sibling fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_dispatcher_is_a_noop() {
+        let d = Dispatcher::empty();
+        assert!(d.is_empty());
+        d.dispatch(&fake_conv(), AlertEvent::Opened).await;
+    }
+}

--- a/crates/orca-ai/src/channels/slack.rs
+++ b/crates/orca-ai/src/channels/slack.rs
@@ -1,0 +1,168 @@
+//! Slack incoming-webhook delivery.
+//!
+//! Posts a Block Kit message per alert event. The webhook URL determines
+//! which workspace + channel the message lands in; no API token needed.
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::time::Duration;
+
+use orca_core::types::{AlertConversation, AlertSender, AlertSeverity};
+
+use super::{AlertEvent, Channel};
+
+pub struct SlackChannel {
+    webhook_url: String,
+    client: reqwest::Client,
+}
+
+impl SlackChannel {
+    pub fn new(webhook_url: String) -> Self {
+        Self {
+            webhook_url,
+            client: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(5))
+                .timeout(Duration::from_secs(15))
+                .build()
+                .expect("reqwest client"),
+        }
+    }
+
+    fn payload(conv: &AlertConversation, event: AlertEvent) -> Value {
+        let severity_emoji = match conv.severity {
+            AlertSeverity::Critical => ":rotating_light:",
+            AlertSeverity::Warning => ":warning:",
+            AlertSeverity::Info => ":information_source:",
+        };
+        let header = format!(
+            "{severity_emoji} {} — {} ({})",
+            event.label(),
+            conv.service,
+            severity_label(conv.severity)
+        );
+        let latest = conv
+            .messages
+            .iter()
+            .rev()
+            .find(|m| !matches!(m.sender, AlertSender::Operator))
+            .map(|m| m.content.clone())
+            .unwrap_or_default();
+
+        let mut blocks = vec![
+            json!({
+                "type": "header",
+                "text": { "type": "plain_text", "text": header, "emoji": true }
+            }),
+            json!({
+                "type": "section",
+                "text": { "type": "mrkdwn", "text": truncate(&latest, 2900) }
+            }),
+        ];
+        if let Some(cmd) = conv
+            .messages
+            .last()
+            .and_then(|m| m.suggested_command.as_ref())
+        {
+            blocks.push(json!({
+                "type": "section",
+                "text": { "type": "mrkdwn", "text": format!("Suggested fix:\n```{cmd}```") }
+            }));
+        }
+        json!({ "blocks": blocks, "text": header })
+    }
+}
+
+fn severity_label(s: AlertSeverity) -> &'static str {
+    match s {
+        AlertSeverity::Critical => "critical",
+        AlertSeverity::Warning => "warning",
+        AlertSeverity::Info => "info",
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        let mut out = s[..max].to_string();
+        out.push('…');
+        out
+    }
+}
+
+#[async_trait]
+impl Channel for SlackChannel {
+    fn name(&self) -> &'static str {
+        "slack"
+    }
+
+    async fn deliver(&self, conv: &AlertConversation, event: AlertEvent) -> anyhow::Result<()> {
+        let payload = Self::payload(conv, event);
+        let resp = self
+            .client
+            .post(&self.webhook_url)
+            .json(&payload)
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("slack webhook returned {status}: {body}");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orca_core::types::{AlertMessage, AlertSender, AlertState};
+
+    fn conv_with(suggested: Option<&str>) -> AlertConversation {
+        AlertConversation {
+            id: uuid::Uuid::now_v7(),
+            service: "api".into(),
+            severity: AlertSeverity::Critical,
+            state: AlertState::AwaitingAction,
+            started_at: chrono::Utc::now(),
+            resolved_at: None,
+            messages: vec![AlertMessage {
+                timestamp: chrono::Utc::now(),
+                sender: AlertSender::Orca,
+                content: "Service is crash-looping. OOM in last 5 minutes.".into(),
+                suggested_command: suggested.map(String::from),
+            }],
+        }
+    }
+
+    #[test]
+    fn payload_has_header_and_section_blocks() {
+        let payload = SlackChannel::payload(&conv_with(None), AlertEvent::Opened);
+        let blocks = payload["blocks"].as_array().expect("blocks array");
+        assert_eq!(blocks[0]["type"], "header");
+        assert_eq!(blocks[1]["type"], "section");
+        let header_text = blocks[0]["text"]["text"].as_str().unwrap();
+        assert!(header_text.contains("Opened"));
+        assert!(header_text.contains("api"));
+        assert!(header_text.contains("critical"));
+    }
+
+    #[test]
+    fn payload_includes_suggested_command_when_present() {
+        let payload =
+            SlackChannel::payload(&conv_with(Some("orca redeploy api")), AlertEvent::Opened);
+        let blocks = payload["blocks"].as_array().unwrap();
+        let last = blocks.last().unwrap()["text"]["text"].as_str().unwrap();
+        assert!(last.contains("orca redeploy api"));
+        assert!(last.contains("Suggested fix"));
+    }
+
+    #[test]
+    fn truncate_caps_long_strings() {
+        let long = "x".repeat(5000);
+        let out = truncate(&long, 100);
+        assert!(out.ends_with("…"));
+        // Char count check (truncate is byte-based + 3-byte ellipsis)
+        assert!(out.len() < 200);
+    }
+}

--- a/crates/orca-ai/src/channels/webhook.rs
+++ b/crates/orca-ai/src/channels/webhook.rs
@@ -1,0 +1,88 @@
+//! Generic webhook delivery — POSTs JSON `{event, conversation}` to a URL.
+//!
+//! No signature/auth out of the box (callers should run behind their own
+//! auth proxy or accept the public path). A future iteration can add
+//! HMAC-signed payloads — orca already has the helpers from #36.
+
+use async_trait::async_trait;
+use serde::Serialize;
+use std::time::Duration;
+
+use orca_core::types::AlertConversation;
+
+use super::{AlertEvent, Channel};
+
+pub struct WebhookChannel {
+    url: String,
+    client: reqwest::Client,
+}
+
+#[derive(Serialize)]
+struct Payload<'a> {
+    event: &'a str,
+    conversation: &'a AlertConversation,
+}
+
+impl WebhookChannel {
+    pub fn new(url: String) -> Self {
+        Self {
+            url,
+            client: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(5))
+                .timeout(Duration::from_secs(15))
+                .build()
+                .expect("reqwest client"),
+        }
+    }
+}
+
+#[async_trait]
+impl Channel for WebhookChannel {
+    fn name(&self) -> &'static str {
+        "webhook"
+    }
+
+    async fn deliver(&self, conv: &AlertConversation, event: AlertEvent) -> anyhow::Result<()> {
+        let payload = Payload {
+            event: event.label(),
+            conversation: conv,
+        };
+        let resp = self.client.post(&self.url).json(&payload).send().await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("webhook returned {status}: {body}");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orca_core::types::{AlertSeverity, AlertState};
+
+    fn fake_conv() -> AlertConversation {
+        AlertConversation {
+            id: uuid::Uuid::now_v7(),
+            service: "svc".into(),
+            severity: AlertSeverity::Warning,
+            state: AlertState::Investigating,
+            started_at: chrono::Utc::now(),
+            resolved_at: None,
+            messages: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn payload_serializes_event_label_and_conversation() {
+        let conv = fake_conv();
+        let payload = Payload {
+            event: AlertEvent::Opened.label(),
+            conversation: &conv,
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["event"], "Opened");
+        assert_eq!(json["conversation"]["service"], "svc");
+    }
+}

--- a/crates/orca-ai/src/conversation.rs
+++ b/crates/orca-ai/src/conversation.rs
@@ -2,6 +2,7 @@ use chrono::Utc;
 use uuid::Uuid;
 
 use crate::backend::{ChatMessage, LlmBackend, Role};
+use crate::channels::{AlertEvent, Dispatcher};
 use crate::context::ClusterContext;
 use orca_core::types::{
     AlertConversation, AlertMessage, AlertSender, AlertSeverity, AlertState, ConversationId,
@@ -12,6 +13,7 @@ use orca_core::types::{
 pub struct ConversationEngine<B: LlmBackend> {
     backend: B,
     conversations: Vec<AlertConversation>,
+    dispatcher: Dispatcher,
 }
 
 impl<B: LlmBackend> ConversationEngine<B> {
@@ -19,6 +21,15 @@ impl<B: LlmBackend> ConversationEngine<B> {
         Self {
             backend,
             conversations: Vec::new(),
+            dispatcher: Dispatcher::empty(),
+        }
+    }
+
+    pub fn with_dispatcher(backend: B, dispatcher: Dispatcher) -> Self {
+        Self {
+            backend,
+            conversations: Vec::new(),
+            dispatcher,
         }
     }
 
@@ -78,8 +89,14 @@ impl<B: LlmBackend> ConversationEngine<B> {
             ],
         };
 
+        let id = conversation.id;
         self.conversations.push(conversation);
-        Ok(self.conversations.last().unwrap())
+        self.dispatch_for(id, AlertEvent::Opened).await;
+        Ok(self
+            .conversations
+            .iter()
+            .find(|c| c.id == id)
+            .expect("just pushed"))
     }
 
     /// Operator responds to an alert conversation (ask follow-up, approve fix, dismiss).
@@ -113,7 +130,13 @@ impl<B: LlmBackend> ConversationEngine<B> {
                 content: "Alert dismissed by operator.".to_string(),
                 suggested_command: None,
             });
-            return Ok(conv);
+            self.dispatch_for(conversation_id, AlertEvent::Dismissed)
+                .await;
+            return Ok(self
+                .conversations
+                .iter()
+                .find(|c| c.id == conversation_id)
+                .expect("just mutated"));
         }
 
         if lower == "resolve" || lower == "resolved" {
@@ -125,7 +148,13 @@ impl<B: LlmBackend> ConversationEngine<B> {
                 content: "Alert marked as resolved by operator.".to_string(),
                 suggested_command: None,
             });
-            return Ok(conv);
+            self.dispatch_for(conversation_id, AlertEvent::Resolved)
+                .await;
+            return Ok(self
+                .conversations
+                .iter()
+                .find(|c| c.id == conversation_id)
+                .expect("just mutated"));
         }
 
         // Build chat history for continued conversation
@@ -160,7 +189,13 @@ impl<B: LlmBackend> ConversationEngine<B> {
             suggested_command,
         });
 
-        Ok(conv)
+        self.dispatch_for(conversation_id, AlertEvent::Updated)
+            .await;
+        Ok(self
+            .conversations
+            .iter()
+            .find(|c| c.id == conversation_id)
+            .expect("just mutated"))
     }
 
     /// Feed new data into an existing conversation (e.g., the issue got worse, or metrics changed).
@@ -180,12 +215,12 @@ impl<B: LlmBackend> ConversationEngine<B> {
     }
 
     /// Mark an alert as remediated (auto-fix was applied).
-    pub fn mark_remediated(&mut self, conversation_id: ConversationId, action_taken: &str) {
-        if let Some(conv) = self
+    pub async fn mark_remediated(&mut self, conversation_id: ConversationId, action_taken: &str) {
+        let found = self
             .conversations
             .iter_mut()
-            .find(|c| c.id == conversation_id)
-        {
+            .find(|c| c.id == conversation_id);
+        if let Some(conv) = found {
             conv.state = AlertState::Remediated;
             conv.resolved_at = Some(Utc::now());
             conv.messages.push(AlertMessage {
@@ -194,6 +229,20 @@ impl<B: LlmBackend> ConversationEngine<B> {
                 content: format!("Auto-remediation applied: {action_taken}"),
                 suggested_command: None,
             });
+            self.dispatch_for(conversation_id, AlertEvent::Remediated)
+                .await;
+        }
+    }
+
+    /// Fan a delivery event for the conversation with `id`. Looks the
+    /// conversation up by id and clones a snapshot so we don't hold a borrow
+    /// across the dispatcher's await.
+    async fn dispatch_for(&self, id: ConversationId, event: AlertEvent) {
+        if self.dispatcher.is_empty() {
+            return;
+        }
+        if let Some(snapshot) = self.conversations.iter().find(|c| c.id == id).cloned() {
+            self.dispatcher.dispatch(&snapshot, event).await;
         }
     }
 

--- a/crates/orca-ai/src/lib.rs
+++ b/crates/orca-ai/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod backend;
+pub mod channels;
 pub(crate) mod command_parser;
 pub mod context;
 pub mod conversation;

--- a/crates/orca-ai/src/monitor.rs
+++ b/crates/orca-ai/src/monitor.rs
@@ -215,7 +215,9 @@ impl<B: LlmBackend> AiMonitor<B> {
                     && svc.error_count_1h == 0
                     && svc.restart_count_24h < 3
                 {
-                    engine.mark_remediated(id, "Issue self-resolved — metrics returned to normal");
+                    engine
+                        .mark_remediated(id, "Issue self-resolved — metrics returned to normal")
+                        .await;
                 }
             }
         }

--- a/crates/orca-ai/tests/channels_integration_test.rs
+++ b/crates/orca-ai/tests/channels_integration_test.rs
@@ -1,0 +1,160 @@
+//! Integration test: Slack + webhook channels actually POST to a live HTTP
+//! endpoint. Spawns a hyper server that captures the bodies it receives,
+//! constructs the channels pointing at it, fires an event, and asserts the
+//! captured bodies look right.
+//!
+//! Email is not covered here because the SMTP path needs an SMTP server in
+//! the test environment; the email rendering is covered by unit tests.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use http_body_util::BodyExt;
+use hyper::body::Incoming;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+
+use orca_ai::channels::{AlertEvent, Channel, SlackChannel, WebhookChannel};
+use orca_core::types::{AlertConversation, AlertMessage, AlertSender, AlertSeverity, AlertState};
+
+type CapturedBodies = Arc<Mutex<Vec<(String, String)>>>;
+
+/// Spawn a hyper server that captures every request's (path, body). Returns
+/// the bound address and the shared capture list.
+async fn spawn_capture_server() -> (SocketAddr, CapturedBodies) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let captured: CapturedBodies = Arc::new(Mutex::new(Vec::new()));
+    let captured_for_loop = captured.clone();
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            let captured = captured_for_loop.clone();
+            tokio::spawn(async move {
+                let io = TokioIo::new(stream);
+                let svc = service_fn(move |req: Request<Incoming>| {
+                    let captured = captured.clone();
+                    async move {
+                        let path = req.uri().path().to_string();
+                        let body_bytes = req.into_body().collect().await.unwrap().to_bytes();
+                        let body = String::from_utf8_lossy(&body_bytes).to_string();
+                        captured.lock().await.push((path, body));
+                        Ok::<_, hyper::Error>(Response::new(http_body_util::Full::new(
+                            hyper::body::Bytes::from("ok"),
+                        )))
+                    }
+                });
+                let _ = http1::Builder::new().serve_connection(io, svc).await;
+            });
+        }
+    });
+    (addr, captured)
+}
+
+fn fake_conv() -> AlertConversation {
+    AlertConversation {
+        id: uuid::Uuid::now_v7(),
+        service: "api".into(),
+        severity: AlertSeverity::Critical,
+        state: AlertState::AwaitingAction,
+        started_at: chrono::Utc::now(),
+        resolved_at: None,
+        messages: vec![AlertMessage {
+            timestamp: chrono::Utc::now(),
+            sender: AlertSender::Orca,
+            content: "OOM in last 5 minutes".into(),
+            suggested_command: Some("orca redeploy api".into()),
+        }],
+    }
+}
+
+#[tokio::test]
+async fn slack_channel_posts_block_kit_payload() {
+    let (addr, captured) = spawn_capture_server().await;
+    let url = format!("http://{addr}/slack/incoming");
+    let channel = SlackChannel::new(url);
+
+    channel
+        .deliver(&fake_conv(), AlertEvent::Opened)
+        .await
+        .unwrap();
+
+    // Give the server a moment to flush the capture.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let cap = captured.lock().await;
+    assert_eq!(cap.len(), 1, "expected exactly one POST to slack url");
+    let (path, body) = &cap[0];
+    assert_eq!(path, "/slack/incoming");
+    let parsed: serde_json::Value = serde_json::from_str(body).expect("slack body is JSON");
+    let blocks = parsed["blocks"].as_array().expect("has blocks");
+    assert!(blocks.iter().any(|b| b["type"] == "header"));
+    let header_text = blocks.iter().find(|b| b["type"] == "header").unwrap()["text"]["text"]
+        .as_str()
+        .unwrap();
+    assert!(header_text.contains("Opened"));
+    assert!(header_text.contains("api"));
+}
+
+#[tokio::test]
+async fn webhook_channel_posts_event_plus_conversation_json() {
+    let (addr, captured) = spawn_capture_server().await;
+    let url = format!("http://{addr}/hook");
+    let channel = WebhookChannel::new(url);
+
+    channel
+        .deliver(&fake_conv(), AlertEvent::Remediated)
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let cap = captured.lock().await;
+    assert_eq!(cap.len(), 1);
+    let (path, body) = &cap[0];
+    assert_eq!(path, "/hook");
+    let parsed: serde_json::Value = serde_json::from_str(body).expect("webhook body is JSON");
+    assert_eq!(parsed["event"], "Remediated");
+    assert_eq!(parsed["conversation"]["service"], "api");
+    assert_eq!(parsed["conversation"]["severity"], "critical");
+}
+
+#[tokio::test]
+async fn slack_channel_surfaces_non_2xx_as_error() {
+    // Spawn a server that always returns 500.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = listener.accept().await.unwrap();
+            tokio::spawn(async move {
+                let io = TokioIo::new(stream);
+                let svc = service_fn(|_req: Request<Incoming>| async {
+                    let mut r =
+                        Response::new(http_body_util::Full::new(hyper::body::Bytes::from("nope")));
+                    *r.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                    Ok::<_, hyper::Error>(r)
+                });
+                let _ = http1::Builder::new().serve_connection(io, svc).await;
+            });
+        }
+    });
+
+    let url = format!("http://{addr}/");
+    let channel = SlackChannel::new(url);
+    let err = channel
+        .deliver(&fake_conv(), AlertEvent::Opened)
+        .await
+        .expect_err("non-2xx must surface as Err");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("500"),
+        "error msg should mention status, got: {msg}"
+    );
+}

--- a/crates/orca-core/src/config/ai.rs
+++ b/crates/orca-core/src/config/ai.rs
@@ -43,14 +43,37 @@ fn default_analysis_interval() -> u64 {
     60
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AlertDeliveryChannels {
-    /// Webhook URL for alert conversation updates.
+    /// Generic webhook URL — receives JSON POST per alert event.
     pub webhook: Option<String>,
-    /// Slack webhook for threaded alert conversations.
+    /// Slack incoming-webhook URL — receives a formatted block per alert event.
     pub slack: Option<String>,
-    /// Email for alert digests.
-    pub email: Option<String>,
+    /// Email delivery via SMTP — sends one email per alert event.
+    pub email: Option<EmailChannelConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmailChannelConfig {
+    pub smtp_host: String,
+    #[serde(default = "default_smtp_port")]
+    pub smtp_port: u16,
+    pub username: String,
+    /// SMTP password. Use `${secrets.SMTP_PASSWORD}` to resolve from the secrets store.
+    pub password: String,
+    pub from: String,
+    pub to: Vec<String>,
+    /// If true, use STARTTLS (port 587 default); else implicit TLS (port 465).
+    #[serde(default = "default_smtp_starttls")]
+    pub starttls: bool,
+}
+
+fn default_smtp_port() -> u16 {
+    587
+}
+
+fn default_smtp_starttls() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/orca-core/src/config/mod.rs
+++ b/crates/orca-core/src/config/mod.rs
@@ -9,7 +9,9 @@ use crate::error::{OrcaError, Result};
 // -- Re-exports --
 
 pub use crate::backup::{BackupConfig, BackupTarget};
-pub use ai::{AiAlertConfig, AiConfig, AlertDeliveryChannels, AutoRemediateConfig};
+pub use ai::{
+    AiAlertConfig, AiConfig, AlertDeliveryChannels, AutoRemediateConfig, EmailChannelConfig,
+};
 pub use cluster::NetworkConfig;
 pub use cluster::{
     AlertChannelConfig, ApiToken, CleanupConfig, ClusterConfig, ClusterMeta, FallbackConfig,
@@ -48,6 +50,16 @@ impl ClusterConfig {
         if let Some(ai) = &mut self.ai {
             resolve(&mut ai.api_key);
             resolve(&mut ai.endpoint);
+            if let Some(alerts) = &mut ai.alerts
+                && let Some(channels) = &mut alerts.channels
+                && let Some(email) = &mut channels.email
+            {
+                let mut p = Some(email.password.clone());
+                resolve(&mut p);
+                if let Some(resolved) = p {
+                    email.password = resolved;
+                }
+            }
         }
         // Network config
         if let Some(net) = &mut self.network {


### PR DESCRIPTION
First slice of #24 Path Y. PR2 will wire `AiMonitor::run` + `/api/v1/alerts` endpoints; PR3 will wire the CLI.

## What lands

- `orca_ai::channels` module: `Channel` trait, `AlertEvent` enum (Opened/Updated/Remediated/Resolved/Dismissed), and a `Dispatcher` that fans an event to every configured channel in parallel. One channel's failure does not block the others — errors are logged per-channel.
- **SlackChannel** — Block Kit JSON to an incoming-webhook URL.
- **WebhookChannel** — `{event, conversation}` JSON to a configured URL.
- **EmailChannel** — SMTP via `lettre`. STARTTLS default (587); `starttls = false` for implicit TLS (465). Plain-text body with the full conversation transcript.
- `ConversationEngine` gains an optional `Dispatcher` and fires an event after every state-changing method (`open_alert` → Opened, `operator_reply` → Dismissed/Resolved/Updated depending on the special-command lower-case match, `mark_remediated` → Remediated — now async).
- `AlertDeliveryChannels` expanded in `orca-core`: the `email` field becomes a structured `EmailChannelConfig` (smtp host/port/user/password/from/to). Existing `cluster.toml.example` only ever documented slack + webhook, so no live config breaks.
- SMTP password resolves through the existing `${secrets.X}` path on `ClusterConfig::load`.

## Tests (21 in orca-ai, up from 9)

- Dispatcher fan-out across channels + failure isolation + empty-dispatcher no-op
- Slack payload rendering (header/section blocks, suggested fix, severity, truncation)
- Webhook JSON serialization
- Email subject/body rendering
- **Integration tests** against a live hyper capture server: Slack actually POSTs the expected JSON to the right path, webhook POSTs the expected shape, non-2xx surfaces as `Err`

## Note on dead code

The `Dispatcher` is constructed but never spawned on main yet — the producer side (`AiMonitor::run` + API + CLI) lands in PR2 + PR3. The unit + integration tests prove the channels work in isolation; the full pipeline goes green when PR3 lands.

## Test plan
- [ ] CI green
- [ ] Local smoke test against a real Slack webhook (manual, before merging the 3-PR cycle)
- [ ] Local smoke test against a real SMTP relay (manual, before merging the cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)