### PR TITLE
feat(cli): wire orca alerts CLI to the alerts API (#24, PR 3/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.18",
@@ -1019,7 +1019,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -1167,6 +1167,22 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "email-encoding"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
+dependencies = [
+ "base64 0.22.1",
+ "memchr",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 
 [[package]]
 name = "embedded-io"
@@ -2101,6 +2117,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lettre"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "email-encoding",
+ "email_address",
+ "fastrand",
+ "futures-io",
+ "futures-util",
+ "httpdate",
+ "idna",
+ "mime",
+ "nom 8.0.0",
+ "percent-encoding",
+ "quoted_printable",
+ "rustls",
+ "socket2 0.6.3",
+ "tokio",
+ "tokio-rustls",
+ "url",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +2338,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2498,6 +2550,11 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "futures-util",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "lettre",
  "orca-core",
  "reqwest",
  "serde",
@@ -2908,7 +2965,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2945,9 +3002,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2958,6 +3015,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "quoted_printable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 
 [[package]]
 name = "r-efi"
@@ -3341,7 +3404,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -5727,7 +5790,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2584,6 +2584,7 @@ dependencies = [
  "http-body-util",
  "openraft",
  "orca-agent",
+ "orca-ai",
  "orca-core",
  "orca-proxy",
  "prost",

--- a/crates/orca-ai/Cargo.toml
+++ b/crates/orca-ai/Cargo.toml
@@ -19,3 +19,10 @@ reqwest = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
 async-trait = { workspace = true }
+futures-util = "0.3"
+lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls-tls", "builder", "ring"] }
+
+[dev-dependencies]
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio", "http1", "server"] }
+http-body-util = "0.1"

--- a/crates/orca-ai/src/backend.rs
+++ b/crates/orca-ai/src/backend.rs
@@ -30,6 +30,21 @@ pub trait LlmBackend: Send + Sync + 'static {
     fn name(&self) -> &str;
 }
 
+/// Forward `LlmBackend` through a `Box`, so callers can use
+/// `Box<dyn LlmBackend>` wherever `B: LlmBackend` is required. Without this,
+/// `ConversationEngine<Box<dyn LlmBackend>>` won't compile because async-trait
+/// does not emit a blanket impl for boxed trait objects.
+#[async_trait]
+impl LlmBackend for Box<dyn LlmBackend> {
+    async fn chat(&self, messages: &[ChatMessage]) -> anyhow::Result<ChatResponse> {
+        let inner: &dyn LlmBackend = self.as_ref();
+        inner.chat(messages).await
+    }
+    fn name(&self) -> &str {
+        self.as_ref().name()
+    }
+}
+
 /// OpenAI-compatible backend (works with LiteLLM, Ollama, vLLM, OpenAI, Anthropic proxy, etc.)
 pub struct OpenAiCompatibleBackend {
     client: reqwest::Client,

--- a/crates/orca-ai/src/channels/email.rs
+++ b/crates/orca-ai/src/channels/email.rs
@@ -1,0 +1,142 @@
+//! Email delivery via SMTP using `lettre`.
+//!
+//! Sends one plain-text email per alert event. STARTTLS by default
+//! (port 587); set `starttls = false` in cluster.toml for implicit TLS on
+//! port 465. Credentials resolve through the secrets store via
+//! `${secrets.SMTP_PASSWORD}` in cluster.toml.
+
+use async_trait::async_trait;
+use lettre::message::Message;
+use lettre::transport::smtp::AsyncSmtpTransport;
+use lettre::transport::smtp::authentication::Credentials;
+use lettre::{AsyncTransport, Tokio1Executor};
+use std::time::Duration;
+
+use orca_core::config::EmailChannelConfig;
+use orca_core::types::{AlertConversation, AlertSender, AlertSeverity};
+
+use super::{AlertEvent, Channel};
+
+pub struct EmailChannel {
+    cfg: EmailChannelConfig,
+    transport: AsyncSmtpTransport<Tokio1Executor>,
+}
+
+impl EmailChannel {
+    pub fn new(cfg: EmailChannelConfig) -> Self {
+        let creds = Credentials::new(cfg.username.clone(), cfg.password.clone());
+        let builder = if cfg.starttls {
+            AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&cfg.smtp_host)
+        } else {
+            AsyncSmtpTransport::<Tokio1Executor>::relay(&cfg.smtp_host)
+        };
+        let transport = builder
+            .expect("build SMTP transport")
+            .port(cfg.smtp_port)
+            .credentials(creds)
+            .timeout(Some(Duration::from_secs(15)))
+            .build();
+        Self { cfg, transport }
+    }
+
+    fn subject(conv: &AlertConversation, event: AlertEvent) -> String {
+        let sev = match conv.severity {
+            AlertSeverity::Critical => "[CRITICAL]",
+            AlertSeverity::Warning => "[WARN]",
+            AlertSeverity::Info => "[INFO]",
+        };
+        format!("{sev} {} — {}", event.label(), conv.service)
+    }
+
+    fn body(conv: &AlertConversation, event: AlertEvent) -> String {
+        let mut out = String::new();
+        out.push_str(&format!("Service: {}\n", conv.service));
+        out.push_str(&format!("Severity: {:?}\n", conv.severity));
+        out.push_str(&format!("State: {:?}\n", conv.state));
+        out.push_str(&format!("Event: {}\n", event.label()));
+        out.push_str(&format!("Started: {}\n", conv.started_at.to_rfc3339()));
+        if let Some(resolved) = conv.resolved_at {
+            out.push_str(&format!("Resolved: {}\n", resolved.to_rfc3339()));
+        }
+        out.push_str("\n--- Conversation ---\n");
+        for msg in &conv.messages {
+            let who = match msg.sender {
+                AlertSender::Orca => "orca",
+                AlertSender::Operator => "operator",
+                AlertSender::System => "system",
+            };
+            out.push_str(&format!(
+                "[{}] {}: {}\n",
+                msg.timestamp.format("%H:%M:%S"),
+                who,
+                msg.content
+            ));
+            if let Some(cmd) = &msg.suggested_command {
+                out.push_str(&format!("  fix: {cmd}\n"));
+            }
+        }
+        out
+    }
+}
+
+#[async_trait]
+impl Channel for EmailChannel {
+    fn name(&self) -> &'static str {
+        "email"
+    }
+
+    async fn deliver(&self, conv: &AlertConversation, event: AlertEvent) -> anyhow::Result<()> {
+        let subject = Self::subject(conv, event);
+        let body = Self::body(conv, event);
+        let mut builder = Message::builder()
+            .from(self.cfg.from.parse()?)
+            .subject(subject);
+        for recipient in &self.cfg.to {
+            builder = builder.to(recipient.parse()?);
+        }
+        let email = builder.body(body)?;
+        self.transport.send(email).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orca_core::types::{AlertMessage, AlertState};
+
+    fn fake_conv() -> AlertConversation {
+        AlertConversation {
+            id: uuid::Uuid::now_v7(),
+            service: "api".into(),
+            severity: AlertSeverity::Critical,
+            state: AlertState::AwaitingAction,
+            started_at: chrono::Utc::now(),
+            resolved_at: None,
+            messages: vec![AlertMessage {
+                timestamp: chrono::Utc::now(),
+                sender: AlertSender::Orca,
+                content: "OOM detected".into(),
+                suggested_command: Some("orca redeploy api".into()),
+            }],
+        }
+    }
+
+    #[test]
+    fn subject_includes_severity_event_and_service() {
+        let conv = fake_conv();
+        let s = EmailChannel::subject(&conv, AlertEvent::Opened);
+        assert!(s.contains("[CRITICAL]"));
+        assert!(s.contains("Opened"));
+        assert!(s.contains("api"));
+    }
+
+    #[test]
+    fn body_renders_messages_and_suggested_fix() {
+        let conv = fake_conv();
+        let body = EmailChannel::body(&conv, AlertEvent::Opened);
+        assert!(body.contains("Service: api"));
+        assert!(body.contains("OOM detected"));
+        assert!(body.contains("fix: orca redeploy api"));
+    }
+}

--- a/crates/orca-ai/src/channels/mod.rs
+++ b/crates/orca-ai/src/channels/mod.rs
@@ -1,0 +1,225 @@
+//! Alert delivery channels (Slack, generic webhook, email).
+//!
+//! `ConversationEngine` holds an optional [`Dispatcher`] that fans alert
+//! events to every configured channel in parallel. A failure in one channel
+//! does not block the others — each channel is awaited concurrently and
+//! errors are logged but swallowed so the engine's mutation completes.
+
+mod email;
+mod slack;
+mod webhook;
+
+use async_trait::async_trait;
+use futures_util::future::join_all;
+use tracing::warn;
+
+use orca_core::config::AlertDeliveryChannels;
+use orca_core::types::AlertConversation;
+
+pub use email::EmailChannel;
+pub use slack::SlackChannel;
+pub use webhook::WebhookChannel;
+
+/// What just happened to a conversation. Lets channels render differently
+/// for the opening shot vs ongoing updates vs the final state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertEvent {
+    /// First message — initial diagnosis from the AI.
+    Opened,
+    /// Operator replied or system pushed new context.
+    Updated,
+    /// Auto-remediation applied; conversation moves to Remediated state.
+    Remediated,
+    /// Issue self-resolved or operator marked it resolved.
+    Resolved,
+    /// Operator dismissed the alert.
+    Dismissed,
+}
+
+impl AlertEvent {
+    pub fn label(self) -> &'static str {
+        match self {
+            AlertEvent::Opened => "Opened",
+            AlertEvent::Updated => "Updated",
+            AlertEvent::Remediated => "Remediated",
+            AlertEvent::Resolved => "Resolved",
+            AlertEvent::Dismissed => "Dismissed",
+        }
+    }
+}
+
+#[async_trait]
+pub trait Channel: Send + Sync {
+    fn name(&self) -> &'static str;
+    async fn deliver(&self, conv: &AlertConversation, event: AlertEvent) -> anyhow::Result<()>;
+}
+
+/// Holds the configured delivery channels and fans events out in parallel.
+/// Construct via [`Dispatcher::from_config`]; an empty dispatcher is a no-op
+/// so callers don't need to special-case the unconfigured case.
+pub struct Dispatcher {
+    channels: Vec<Box<dyn Channel>>,
+}
+
+impl Dispatcher {
+    pub fn new(channels: Vec<Box<dyn Channel>>) -> Self {
+        Self { channels }
+    }
+
+    pub fn empty() -> Self {
+        Self {
+            channels: Vec::new(),
+        }
+    }
+
+    /// Build a dispatcher from the cluster.toml `[ai.alerts.channels]` block.
+    /// Channels with `None` config entries are skipped silently.
+    pub fn from_config(cfg: &AlertDeliveryChannels) -> Self {
+        let mut channels: Vec<Box<dyn Channel>> = Vec::new();
+        if let Some(url) = &cfg.slack {
+            channels.push(Box::new(SlackChannel::new(url.clone())));
+        }
+        if let Some(url) = &cfg.webhook {
+            channels.push(Box::new(WebhookChannel::new(url.clone())));
+        }
+        if let Some(email) = &cfg.email {
+            channels.push(Box::new(EmailChannel::new(email.clone())));
+        }
+        Self { channels }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.channels.is_empty()
+    }
+
+    pub fn channel_names(&self) -> Vec<&'static str> {
+        self.channels.iter().map(|c| c.name()).collect()
+    }
+
+    /// Fan the event out to every channel in parallel. Failures are logged
+    /// per-channel; this returns once all channels have either completed
+    /// or errored. The caller's mutation is independent of delivery — we
+    /// never make the engine's path fail because Slack is down.
+    pub async fn dispatch(&self, conv: &AlertConversation, event: AlertEvent) {
+        if self.channels.is_empty() {
+            return;
+        }
+        let futures = self.channels.iter().map(|ch| {
+            let name = ch.name();
+            async move {
+                if let Err(e) = ch.deliver(conv, event).await {
+                    warn!(channel = name, alert = %conv.service, event = ?event, error = %e, "alert delivery failed");
+                }
+            }
+        });
+        join_all(futures).await;
+    }
+}
+
+impl Default for Dispatcher {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orca_core::types::{AlertSeverity, AlertState};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Mutex;
+
+    struct CountingChannel {
+        name: &'static str,
+        count: Arc<AtomicUsize>,
+        events: Arc<Mutex<Vec<AlertEvent>>>,
+    }
+
+    #[async_trait]
+    impl Channel for CountingChannel {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        async fn deliver(&self, _: &AlertConversation, event: AlertEvent) -> anyhow::Result<()> {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            self.events.lock().await.push(event);
+            Ok(())
+        }
+    }
+
+    struct FailingChannel;
+    #[async_trait]
+    impl Channel for FailingChannel {
+        fn name(&self) -> &'static str {
+            "failing"
+        }
+        async fn deliver(&self, _: &AlertConversation, _: AlertEvent) -> anyhow::Result<()> {
+            anyhow::bail!("simulated channel failure")
+        }
+    }
+
+    fn fake_conv() -> AlertConversation {
+        AlertConversation {
+            id: uuid::Uuid::now_v7(),
+            service: "svc".into(),
+            severity: AlertSeverity::Warning,
+            state: AlertState::Investigating,
+            started_at: chrono::Utc::now(),
+            resolved_at: None,
+            messages: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatcher_fans_to_all_channels() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let d = Dispatcher::new(vec![
+            Box::new(CountingChannel {
+                name: "a",
+                count: count.clone(),
+                events: events.clone(),
+            }),
+            Box::new(CountingChannel {
+                name: "b",
+                count: count.clone(),
+                events: events.clone(),
+            }),
+        ]);
+
+        d.dispatch(&fake_conv(), AlertEvent::Opened).await;
+
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+        assert_eq!(events.lock().await.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn dispatcher_failure_in_one_does_not_block_others() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let d = Dispatcher::new(vec![
+            Box::new(FailingChannel),
+            Box::new(CountingChannel {
+                name: "good",
+                count: count.clone(),
+                events: events.clone(),
+            }),
+        ]);
+
+        d.dispatch(&fake_conv(), AlertEvent::Opened).await;
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "good channel must still receive the event when sibling fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_dispatcher_is_a_noop() {
+        let d = Dispatcher::empty();
+        assert!(d.is_empty());
+        d.dispatch(&fake_conv(), AlertEvent::Opened).await;
+    }
+}

--- a/crates/orca-ai/src/channels/slack.rs
+++ b/crates/orca-ai/src/channels/slack.rs
@@ -1,0 +1,168 @@
+//! Slack incoming-webhook delivery.
+//!
+//! Posts a Block Kit message per alert event. The webhook URL determines
+//! which workspace + channel the message lands in; no API token needed.
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::time::Duration;
+
+use orca_core::types::{AlertConversation, AlertSender, AlertSeverity};
+
+use super::{AlertEvent, Channel};
+
+pub struct SlackChannel {
+    webhook_url: String,
+    client: reqwest::Client,
+}
+
+impl SlackChannel {
+    pub fn new(webhook_url: String) -> Self {
+        Self {
+            webhook_url,
+            client: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(5))
+                .timeout(Duration::from_secs(15))
+                .build()
+                .expect("reqwest client"),
+        }
+    }
+
+    fn payload(conv: &AlertConversation, event: AlertEvent) -> Value {
+        let severity_emoji = match conv.severity {
+            AlertSeverity::Critical => ":rotating_light:",
+            AlertSeverity::Warning => ":warning:",
+            AlertSeverity::Info => ":information_source:",
+        };
+        let header = format!(
+            "{severity_emoji} {} — {} ({})",
+            event.label(),
+            conv.service,
+            severity_label(conv.severity)
+        );
+        let latest = conv
+            .messages
+            .iter()
+            .rev()
+            .find(|m| !matches!(m.sender, AlertSender::Operator))
+            .map(|m| m.content.clone())
+            .unwrap_or_default();
+
+        let mut blocks = vec![
+            json!({
+                "type": "header",
+                "text": { "type": "plain_text", "text": header, "emoji": true }
+            }),
+            json!({
+                "type": "section",
+                "text": { "type": "mrkdwn", "text": truncate(&latest, 2900) }
+            }),
+        ];
+        if let Some(cmd) = conv
+            .messages
+            .last()
+            .and_then(|m| m.suggested_command.as_ref())
+        {
+            blocks.push(json!({
+                "type": "section",
+                "text": { "type": "mrkdwn", "text": format!("Suggested fix:\n```{cmd}```") }
+            }));
+        }
+        json!({ "blocks": blocks, "text": header })
+    }
+}
+
+fn severity_label(s: AlertSeverity) -> &'static str {
+    match s {
+        AlertSeverity::Critical => "critical",
+        AlertSeverity::Warning => "warning",
+        AlertSeverity::Info => "info",
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        let mut out = s[..max].to_string();
+        out.push('…');
+        out
+    }
+}
+
+#[async_trait]
+impl Channel for SlackChannel {
+    fn name(&self) -> &'static str {
+        "slack"
+    }
+
+    async fn deliver(&self, conv: &AlertConversation, event: AlertEvent) -> anyhow::Result<()> {
+        let payload = Self::payload(conv, event);
+        let resp = self
+            .client
+            .post(&self.webhook_url)
+            .json(&payload)
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("slack webhook returned {status}: {body}");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orca_core::types::{AlertMessage, AlertSender, AlertState};
+
+    fn conv_with(suggested: Option<&str>) -> AlertConversation {
+        AlertConversation {
+            id: uuid::Uuid::now_v7(),
+            service: "api".into(),
+            severity: AlertSeverity::Critical,
+            state: AlertState::AwaitingAction,
+            started_at: chrono::Utc::now(),
+            resolved_at: None,
+            messages: vec![AlertMessage {
+                timestamp: chrono::Utc::now(),
+                sender: AlertSender::Orca,
+                content: "Service is crash-looping. OOM in last 5 minutes.".into(),
+                suggested_command: suggested.map(String::from),
+            }],
+        }
+    }
+
+    #[test]
+    fn payload_has_header_and_section_blocks() {
+        let payload = SlackChannel::payload(&conv_with(None), AlertEvent::Opened);
+        let blocks = payload["blocks"].as_array().expect("blocks array");
+        assert_eq!(blocks[0]["type"], "header");
+        assert_eq!(blocks[1]["type"], "section");
+        let header_text = blocks[0]["text"]["text"].as_str().unwrap();
+        assert!(header_text.contains("Opened"));
+        assert!(header_text.contains("api"));
+        assert!(header_text.contains("critical"));
+    }
+
+    #[test]
+    fn payload_includes_suggested_command_when_present() {
+        let payload =
+            SlackChannel::payload(&conv_with(Some("orca redeploy api")), AlertEvent::Opened);
+        let blocks = payload["blocks"].as_array().unwrap();
+        let last = blocks.last().unwrap()["text"]["text"].as_str().unwrap();
+        assert!(last.contains("orca redeploy api"));
+        assert!(last.contains("Suggested fix"));
+    }
+
+    #[test]
+    fn truncate_caps_long_strings() {
+        let long = "x".repeat(5000);
+        let out = truncate(&long, 100);
+        assert!(out.ends_with("…"));
+        // Char count check (truncate is byte-based + 3-byte ellipsis)
+        assert!(out.len() < 200);
+    }
+}

--- a/crates/orca-ai/src/channels/webhook.rs
+++ b/crates/orca-ai/src/channels/webhook.rs
@@ -1,0 +1,88 @@
+//! Generic webhook delivery — POSTs JSON `{event, conversation}` to a URL.
+//!
+//! No signature/auth out of the box (callers should run behind their own
+//! auth proxy or accept the public path). A future iteration can add
+//! HMAC-signed payloads — orca already has the helpers from #36.
+
+use async_trait::async_trait;
+use serde::Serialize;
+use std::time::Duration;
+
+use orca_core::types::AlertConversation;
+
+use super::{AlertEvent, Channel};
+
+pub struct WebhookChannel {
+    url: String,
+    client: reqwest::Client,
+}
+
+#[derive(Serialize)]
+struct Payload<'a> {
+    event: &'a str,
+    conversation: &'a AlertConversation,
+}
+
+impl WebhookChannel {
+    pub fn new(url: String) -> Self {
+        Self {
+            url,
+            client: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(5))
+                .timeout(Duration::from_secs(15))
+                .build()
+                .expect("reqwest client"),
+        }
+    }
+}
+
+#[async_trait]
+impl Channel for WebhookChannel {
+    fn name(&self) -> &'static str {
+        "webhook"
+    }
+
+    async fn deliver(&self, conv: &AlertConversation, event: AlertEvent) -> anyhow::Result<()> {
+        let payload = Payload {
+            event: event.label(),
+            conversation: conv,
+        };
+        let resp = self.client.post(&self.url).json(&payload).send().await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("webhook returned {status}: {body}");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orca_core::types::{AlertSeverity, AlertState};
+
+    fn fake_conv() -> AlertConversation {
+        AlertConversation {
+            id: uuid::Uuid::now_v7(),
+            service: "svc".into(),
+            severity: AlertSeverity::Warning,
+            state: AlertState::Investigating,
+            started_at: chrono::Utc::now(),
+            resolved_at: None,
+            messages: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn payload_serializes_event_label_and_conversation() {
+        let conv = fake_conv();
+        let payload = Payload {
+            event: AlertEvent::Opened.label(),
+            conversation: &conv,
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["event"], "Opened");
+        assert_eq!(json["conversation"]["service"], "svc");
+    }
+}

--- a/crates/orca-ai/src/conversation.rs
+++ b/crates/orca-ai/src/conversation.rs
@@ -2,6 +2,7 @@ use chrono::Utc;
 use uuid::Uuid;
 
 use crate::backend::{ChatMessage, LlmBackend, Role};
+use crate::channels::{AlertEvent, Dispatcher};
 use crate::context::ClusterContext;
 use orca_core::types::{
     AlertConversation, AlertMessage, AlertSender, AlertSeverity, AlertState, ConversationId,
@@ -12,6 +13,7 @@ use orca_core::types::{
 pub struct ConversationEngine<B: LlmBackend> {
     backend: B,
     conversations: Vec<AlertConversation>,
+    dispatcher: Dispatcher,
 }
 
 impl<B: LlmBackend> ConversationEngine<B> {
@@ -19,6 +21,15 @@ impl<B: LlmBackend> ConversationEngine<B> {
         Self {
             backend,
             conversations: Vec::new(),
+            dispatcher: Dispatcher::empty(),
+        }
+    }
+
+    pub fn with_dispatcher(backend: B, dispatcher: Dispatcher) -> Self {
+        Self {
+            backend,
+            conversations: Vec::new(),
+            dispatcher,
         }
     }
 
@@ -78,8 +89,14 @@ impl<B: LlmBackend> ConversationEngine<B> {
             ],
         };
 
+        let id = conversation.id;
         self.conversations.push(conversation);
-        Ok(self.conversations.last().unwrap())
+        self.dispatch_for(id, AlertEvent::Opened).await;
+        Ok(self
+            .conversations
+            .iter()
+            .find(|c| c.id == id)
+            .expect("just pushed"))
     }
 
     /// Operator responds to an alert conversation (ask follow-up, approve fix, dismiss).
@@ -113,7 +130,13 @@ impl<B: LlmBackend> ConversationEngine<B> {
                 content: "Alert dismissed by operator.".to_string(),
                 suggested_command: None,
             });
-            return Ok(conv);
+            self.dispatch_for(conversation_id, AlertEvent::Dismissed)
+                .await;
+            return Ok(self
+                .conversations
+                .iter()
+                .find(|c| c.id == conversation_id)
+                .expect("just mutated"));
         }
 
         if lower == "resolve" || lower == "resolved" {
@@ -125,7 +148,13 @@ impl<B: LlmBackend> ConversationEngine<B> {
                 content: "Alert marked as resolved by operator.".to_string(),
                 suggested_command: None,
             });
-            return Ok(conv);
+            self.dispatch_for(conversation_id, AlertEvent::Resolved)
+                .await;
+            return Ok(self
+                .conversations
+                .iter()
+                .find(|c| c.id == conversation_id)
+                .expect("just mutated"));
         }
 
         // Build chat history for continued conversation
@@ -160,7 +189,13 @@ impl<B: LlmBackend> ConversationEngine<B> {
             suggested_command,
         });
 
-        Ok(conv)
+        self.dispatch_for(conversation_id, AlertEvent::Updated)
+            .await;
+        Ok(self
+            .conversations
+            .iter()
+            .find(|c| c.id == conversation_id)
+            .expect("just mutated"))
     }
 
     /// Feed new data into an existing conversation (e.g., the issue got worse, or metrics changed).
@@ -180,12 +215,12 @@ impl<B: LlmBackend> ConversationEngine<B> {
     }
 
     /// Mark an alert as remediated (auto-fix was applied).
-    pub fn mark_remediated(&mut self, conversation_id: ConversationId, action_taken: &str) {
-        if let Some(conv) = self
+    pub async fn mark_remediated(&mut self, conversation_id: ConversationId, action_taken: &str) {
+        let found = self
             .conversations
             .iter_mut()
-            .find(|c| c.id == conversation_id)
-        {
+            .find(|c| c.id == conversation_id);
+        if let Some(conv) = found {
             conv.state = AlertState::Remediated;
             conv.resolved_at = Some(Utc::now());
             conv.messages.push(AlertMessage {
@@ -194,6 +229,20 @@ impl<B: LlmBackend> ConversationEngine<B> {
                 content: format!("Auto-remediation applied: {action_taken}"),
                 suggested_command: None,
             });
+            self.dispatch_for(conversation_id, AlertEvent::Remediated)
+                .await;
+        }
+    }
+
+    /// Fan a delivery event for the conversation with `id`. Looks the
+    /// conversation up by id and clones a snapshot so we don't hold a borrow
+    /// across the dispatcher's await.
+    async fn dispatch_for(&self, id: ConversationId, event: AlertEvent) {
+        if self.dispatcher.is_empty() {
+            return;
+        }
+        if let Some(snapshot) = self.conversations.iter().find(|c| c.id == id).cloned() {
+            self.dispatcher.dispatch(&snapshot, event).await;
         }
     }
 

--- a/crates/orca-ai/src/lib.rs
+++ b/crates/orca-ai/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod backend;
+pub mod channels;
 pub(crate) mod command_parser;
 pub mod context;
 pub mod conversation;

--- a/crates/orca-ai/src/monitor.rs
+++ b/crates/orca-ai/src/monitor.rs
@@ -215,7 +215,9 @@ impl<B: LlmBackend> AiMonitor<B> {
                     && svc.error_count_1h == 0
                     && svc.restart_count_24h < 3
                 {
-                    engine.mark_remediated(id, "Issue self-resolved — metrics returned to normal");
+                    engine
+                        .mark_remediated(id, "Issue self-resolved — metrics returned to normal")
+                        .await;
                 }
             }
         }

--- a/crates/orca-ai/tests/channels_integration_test.rs
+++ b/crates/orca-ai/tests/channels_integration_test.rs
@@ -1,0 +1,160 @@
+//! Integration test: Slack + webhook channels actually POST to a live HTTP
+//! endpoint. Spawns a hyper server that captures the bodies it receives,
+//! constructs the channels pointing at it, fires an event, and asserts the
+//! captured bodies look right.
+//!
+//! Email is not covered here because the SMTP path needs an SMTP server in
+//! the test environment; the email rendering is covered by unit tests.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use http_body_util::BodyExt;
+use hyper::body::Incoming;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+
+use orca_ai::channels::{AlertEvent, Channel, SlackChannel, WebhookChannel};
+use orca_core::types::{AlertConversation, AlertMessage, AlertSender, AlertSeverity, AlertState};
+
+type CapturedBodies = Arc<Mutex<Vec<(String, String)>>>;
+
+/// Spawn a hyper server that captures every request's (path, body). Returns
+/// the bound address and the shared capture list.
+async fn spawn_capture_server() -> (SocketAddr, CapturedBodies) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let captured: CapturedBodies = Arc::new(Mutex::new(Vec::new()));
+    let captured_for_loop = captured.clone();
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            let captured = captured_for_loop.clone();
+            tokio::spawn(async move {
+                let io = TokioIo::new(stream);
+                let svc = service_fn(move |req: Request<Incoming>| {
+                    let captured = captured.clone();
+                    async move {
+                        let path = req.uri().path().to_string();
+                        let body_bytes = req.into_body().collect().await.unwrap().to_bytes();
+                        let body = String::from_utf8_lossy(&body_bytes).to_string();
+                        captured.lock().await.push((path, body));
+                        Ok::<_, hyper::Error>(Response::new(http_body_util::Full::new(
+                            hyper::body::Bytes::from("ok"),
+                        )))
+                    }
+                });
+                let _ = http1::Builder::new().serve_connection(io, svc).await;
+            });
+        }
+    });
+    (addr, captured)
+}
+
+fn fake_conv() -> AlertConversation {
+    AlertConversation {
+        id: uuid::Uuid::now_v7(),
+        service: "api".into(),
+        severity: AlertSeverity::Critical,
+        state: AlertState::AwaitingAction,
+        started_at: chrono::Utc::now(),
+        resolved_at: None,
+        messages: vec![AlertMessage {
+            timestamp: chrono::Utc::now(),
+            sender: AlertSender::Orca,
+            content: "OOM in last 5 minutes".into(),
+            suggested_command: Some("orca redeploy api".into()),
+        }],
+    }
+}
+
+#[tokio::test]
+async fn slack_channel_posts_block_kit_payload() {
+    let (addr, captured) = spawn_capture_server().await;
+    let url = format!("http://{addr}/slack/incoming");
+    let channel = SlackChannel::new(url);
+
+    channel
+        .deliver(&fake_conv(), AlertEvent::Opened)
+        .await
+        .unwrap();
+
+    // Give the server a moment to flush the capture.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let cap = captured.lock().await;
+    assert_eq!(cap.len(), 1, "expected exactly one POST to slack url");
+    let (path, body) = &cap[0];
+    assert_eq!(path, "/slack/incoming");
+    let parsed: serde_json::Value = serde_json::from_str(body).expect("slack body is JSON");
+    let blocks = parsed["blocks"].as_array().expect("has blocks");
+    assert!(blocks.iter().any(|b| b["type"] == "header"));
+    let header_text = blocks.iter().find(|b| b["type"] == "header").unwrap()["text"]["text"]
+        .as_str()
+        .unwrap();
+    assert!(header_text.contains("Opened"));
+    assert!(header_text.contains("api"));
+}
+
+#[tokio::test]
+async fn webhook_channel_posts_event_plus_conversation_json() {
+    let (addr, captured) = spawn_capture_server().await;
+    let url = format!("http://{addr}/hook");
+    let channel = WebhookChannel::new(url);
+
+    channel
+        .deliver(&fake_conv(), AlertEvent::Remediated)
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let cap = captured.lock().await;
+    assert_eq!(cap.len(), 1);
+    let (path, body) = &cap[0];
+    assert_eq!(path, "/hook");
+    let parsed: serde_json::Value = serde_json::from_str(body).expect("webhook body is JSON");
+    assert_eq!(parsed["event"], "Remediated");
+    assert_eq!(parsed["conversation"]["service"], "api");
+    assert_eq!(parsed["conversation"]["severity"], "critical");
+}
+
+#[tokio::test]
+async fn slack_channel_surfaces_non_2xx_as_error() {
+    // Spawn a server that always returns 500.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = listener.accept().await.unwrap();
+            tokio::spawn(async move {
+                let io = TokioIo::new(stream);
+                let svc = service_fn(|_req: Request<Incoming>| async {
+                    let mut r =
+                        Response::new(http_body_util::Full::new(hyper::body::Bytes::from("nope")));
+                    *r.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                    Ok::<_, hyper::Error>(r)
+                });
+                let _ = http1::Builder::new().serve_connection(io, svc).await;
+            });
+        }
+    });
+
+    let url = format!("http://{addr}/");
+    let channel = SlackChannel::new(url);
+    let err = channel
+        .deliver(&fake_conv(), AlertEvent::Opened)
+        .await
+        .expect_err("non-2xx must surface as Err");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("500"),
+        "error msg should mention status, got: {msg}"
+    );
+}

--- a/crates/orca-cli/src/client.rs
+++ b/crates/orca-cli/src/client.rs
@@ -4,6 +4,8 @@ use orca_core::api_types::{
     DeployRequest, DeployResponse, ScaleRequest, ScaleResponse, StatusResponse,
 };
 use orca_core::config::ServicesConfig;
+use orca_core::types::AlertConversation;
+use serde::Deserialize;
 
 /// Client for the orca control plane API.
 pub struct OrcaClient {
@@ -121,6 +123,65 @@ impl OrcaClient {
         Ok(())
     }
 
+    pub async fn alerts_list(&self, all: bool) -> anyhow::Result<Vec<AlertConversation>> {
+        let path = format!("/api/v1/alerts?all={all}");
+        let resp = self.auth(self.client.get(self.url(&path))).send().await?;
+        let resp = unwrap_alert_error(resp).await?;
+        #[derive(Deserialize)]
+        struct ListResp {
+            alerts: Vec<AlertConversation>,
+        }
+        let body: ListResp = resp.json().await?;
+        Ok(body.alerts)
+    }
+
+    pub async fn alerts_view(&self, id: &str) -> anyhow::Result<AlertConversation> {
+        let resp = self
+            .auth(self.client.get(self.url(&format!("/api/v1/alerts/{id}"))))
+            .send()
+            .await?;
+        let resp = unwrap_alert_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn alerts_reply(&self, id: &str, message: &str) -> anyhow::Result<AlertConversation> {
+        let body = serde_json::json!({ "message": message });
+        let resp = self
+            .auth(
+                self.client
+                    .post(self.url(&format!("/api/v1/alerts/{id}/reply"))),
+            )
+            .json(&body)
+            .send()
+            .await?;
+        let resp = unwrap_alert_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn alerts_dismiss(&self, id: &str) -> anyhow::Result<AlertConversation> {
+        let resp = self
+            .auth(
+                self.client
+                    .post(self.url(&format!("/api/v1/alerts/{id}/dismiss"))),
+            )
+            .send()
+            .await?;
+        let resp = unwrap_alert_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn alerts_resolve(&self, id: &str) -> anyhow::Result<AlertConversation> {
+        let resp = self
+            .auth(
+                self.client
+                    .post(self.url(&format!("/api/v1/alerts/{id}/resolve"))),
+            )
+            .send()
+            .await?;
+        let resp = unwrap_alert_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
     pub async fn promote(&self, service: &str) -> anyhow::Result<()> {
         self.auth(
             self.client
@@ -184,4 +245,26 @@ impl OrcaClient {
             .error_for_status()?;
         Ok(resp.json().await?)
     }
+}
+
+/// Translate 503 (`[ai]` unconfigured) and 404 (unknown id) into clean
+/// anyhow errors so the CLI can print one-line messages instead of raw
+/// HTTP status codes.
+async fn unwrap_alert_error(resp: reqwest::Response) -> anyhow::Result<reqwest::Response> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp);
+    }
+    let body: serde_json::Value = resp.json().await.unwrap_or_default();
+    let msg = body
+        .get("error")
+        .and_then(|e| e.as_str())
+        .unwrap_or("(no error message in response)");
+    if status.as_u16() == 503 {
+        anyhow::bail!("{msg}");
+    }
+    if status.as_u16() == 404 {
+        anyhow::bail!("{msg}");
+    }
+    anyhow::bail!("alerts API returned HTTP {status}: {msg}")
 }

--- a/crates/orca-cli/src/handlers/ops.rs
+++ b/crates/orca-cli/src/handlers/ops.rs
@@ -116,19 +116,123 @@ pub async fn handle_scale(service: String, replicas: u32, api: String) -> anyhow
     Ok(())
 }
 
-pub fn handle_alerts(action: AlertsAction) {
+pub async fn handle_alerts(action: AlertsAction, api: String) -> anyhow::Result<()> {
+    let client = OrcaClient::new(api);
     match action {
         AlertsAction::List { all } => {
-            let scope = if all { "all" } else { "active" };
-            println!("No {scope} alert conversations.");
+            let alerts = client.alerts_list(all).await?;
+            if alerts.is_empty() {
+                let scope = if all { "all" } else { "active" };
+                println!("No {scope} alert conversations.");
+                return Ok(());
+            }
+            println!(
+                "{:<36}  {:<20}  {:<9}  {:<16}  Started",
+                "ID", "Service", "Severity", "State"
+            );
+            for a in alerts {
+                println!(
+                    "{:<36}  {:<20}  {:<9?}  {:<16?}  {}",
+                    a.id,
+                    truncate(&a.service, 20),
+                    a.severity,
+                    a.state,
+                    a.started_at.format("%Y-%m-%d %H:%M:%S")
+                );
+            }
         }
-        AlertsAction::View { id } => println!("Alert {id}: not yet connected."),
+        AlertsAction::View { id } => {
+            let conv = client.alerts_view(&id).await?;
+            print_conversation(&conv);
+        }
         AlertsAction::Reply { id, message } => {
             let msg = message.join(" ");
-            println!("Reply to alert {id}: {msg}");
+            if msg.trim().is_empty() {
+                anyhow::bail!("reply message cannot be empty");
+            }
+            let conv = client.alerts_reply(&id, &msg).await?;
+            println!("Reply sent. Latest exchange:");
+            print_latest_exchange(&conv);
         }
-        AlertsAction::Dismiss { id } => println!("Dismissed alert {id}."),
-        AlertsAction::Fix { id } => println!("Applying fix for alert {id}..."),
+        AlertsAction::Dismiss { id } => {
+            client.alerts_dismiss(&id).await?;
+            println!("Dismissed alert {id}.");
+        }
+        AlertsAction::Resolve { id } => {
+            client.alerts_resolve(&id).await?;
+            println!("Resolved alert {id}.");
+        }
+        AlertsAction::Fix { id } => {
+            let conv = client.alerts_view(&id).await?;
+            let cmd = conv
+                .messages
+                .iter()
+                .rev()
+                .find_map(|m| m.suggested_command.as_deref());
+            match cmd {
+                Some(c) => {
+                    println!("Suggested fix for alert {id}:\n  {c}");
+                    println!(
+                        "\nReview before running. To apply: `orca alerts reply {id} approve` once interactive\n\
+                         confirm is wired, or run the command directly."
+                    );
+                }
+                None => println!("No suggested command on alert {id}."),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_conversation(conv: &orca_core::types::AlertConversation) {
+    println!("Alert {} — {}", conv.id, conv.service);
+    println!(
+        "Severity: {:?}  State: {:?}  Started: {}",
+        conv.severity,
+        conv.state,
+        conv.started_at.format("%Y-%m-%d %H:%M:%S")
+    );
+    if let Some(resolved) = conv.resolved_at {
+        println!("Resolved: {}", resolved.format("%Y-%m-%d %H:%M:%S"));
+    }
+    println!("\nConversation:");
+    for msg in &conv.messages {
+        let who = match msg.sender {
+            orca_core::types::AlertSender::Orca => "orca",
+            orca_core::types::AlertSender::Operator => "you",
+            orca_core::types::AlertSender::System => "system",
+        };
+        println!(
+            "  [{} {}] {}",
+            msg.timestamp.format("%H:%M:%S"),
+            who,
+            msg.content
+        );
+        if let Some(cmd) = &msg.suggested_command {
+            println!("    fix: {cmd}");
+        }
+    }
+}
+
+fn print_latest_exchange(conv: &orca_core::types::AlertConversation) {
+    for msg in conv.messages.iter().rev().take(2).rev() {
+        let who = match msg.sender {
+            orca_core::types::AlertSender::Orca => "orca",
+            orca_core::types::AlertSender::Operator => "you",
+            orca_core::types::AlertSender::System => "system",
+        };
+        println!("  [{who}] {}", msg.content);
+        if let Some(cmd) = &msg.suggested_command {
+            println!("    fix: {cmd}");
+        }
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max.saturating_sub(1)])
     }
 }
 

--- a/crates/orca-cli/src/main.rs
+++ b/crates/orca-cli/src/main.rs
@@ -94,7 +94,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Command::Ask { question } => handlers::ai_ops::handle_ask(question, cli.api).await?,
         Command::Generate { description } => handlers::ai_ops::handle_generate(description).await?,
-        Command::Alerts { action } => handlers::ops::handle_alerts(action),
+        Command::Alerts { action } => handlers::ops::handle_alerts(action, cli.api).await?,
         Command::Secrets { action } => handlers::ops::handle_secrets(action),
         Command::Import { source } => handlers::import::handle_import(source),
         Command::Webhooks { action } => handlers::ops::handle_webhooks(action, cli.api).await?,

--- a/crates/orca-cli/src/subcommands.rs
+++ b/crates/orca-cli/src/subcommands.rs
@@ -16,6 +16,9 @@ pub enum AlertsAction {
     Dismiss {
         id: String,
     },
+    Resolve {
+        id: String,
+    },
     Fix {
         id: String,
     },

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -11,6 +11,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 [dependencies]
 orca-core = { workspace = true }
 orca-agent = { path = "../orca-agent", version = "0.2.8" }
+orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/orca-control/src/alerts.rs
+++ b/crates/orca-control/src/alerts.rs
@@ -1,0 +1,207 @@
+//! AI alert pipeline integration for the control plane.
+//!
+//! Builds a `ConversationEngine` from `cluster.toml` `[ai]`, implements
+//! `ContextProvider` against `AppState`, and spawns the `AiMonitor` as
+//! a background task. The engine is held in `Option<SharedAlertEngine>`
+//! on `AppState` so handlers can mutate it for replies / dismiss / etc.
+//!
+//! Conversation persistence is in-memory only — a server restart wipes
+//! active alerts. The TUI (PR3) re-fetches via the HTTP API on startup.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use orca_ai::backend::{LlmBackend, OpenAiCompatibleBackend};
+use orca_ai::channels::Dispatcher;
+use orca_ai::context::{ClusterContext, NodeSummary, ServiceSummary};
+use orca_ai::conversation::ConversationEngine;
+use orca_ai::monitor::{AiMonitor, ContextProvider};
+use orca_core::config::AiConfig;
+use orca_core::types::{RuntimeKind, WorkloadStatus};
+
+use crate::state::AppState;
+
+pub type AlertEngine = ConversationEngine<Box<dyn LlmBackend>>;
+pub type SharedAlertEngine = Arc<RwLock<AlertEngine>>;
+
+/// Build the alert engine if `[ai]` is configured with endpoint + model.
+/// Returns `None` when AI is unconfigured so the caller can degrade
+/// gracefully without erroring out the whole server startup.
+pub fn try_build_alert_engine(cfg: Option<&AiConfig>) -> Option<SharedAlertEngine> {
+    let ai = cfg?;
+    let endpoint = ai.endpoint.as_ref()?;
+    let model = ai.model.as_ref()?;
+
+    let backend: Box<dyn LlmBackend> = Box::new(OpenAiCompatibleBackend::new(
+        endpoint.clone(),
+        model.clone(),
+        ai.api_key.clone(),
+    ));
+
+    let dispatcher = ai
+        .alerts
+        .as_ref()
+        .and_then(|a| a.channels.as_ref())
+        .map(Dispatcher::from_config)
+        .unwrap_or_default();
+    let names = dispatcher.channel_names();
+    if !names.is_empty() {
+        info!("Alert delivery channels configured: {names:?}");
+    }
+
+    Some(Arc::new(RwLock::new(ConversationEngine::with_dispatcher(
+        backend, dispatcher,
+    ))))
+}
+
+/// Spawn `AiMonitor::run` as a background task. No-op when alerts are
+/// disabled or the engine isn't built.
+pub fn spawn_alert_monitor(state: Arc<AppState>) -> Option<tokio::task::JoinHandle<()>> {
+    let engine = state.alerts.as_ref()?.clone();
+    let ai = state.cluster_config.ai.as_ref()?;
+    let alerts_cfg = ai.alerts.as_ref()?;
+    if !alerts_cfg.enabled {
+        return None;
+    }
+    let interval = alerts_cfg.analysis_interval_secs;
+    let provider: Arc<dyn ContextProvider> =
+        Arc::new(StateContextProvider::for_state(state.clone()));
+    info!("Spawning AI alert monitor (interval: {interval}s)");
+    Some(tokio::spawn(async move {
+        let monitor = AiMonitor::new(engine, interval);
+        monitor.run(provider).await;
+    }))
+}
+
+/// Reads `AppState` snapshots into a `ClusterContext` the AI can reason about.
+/// Kept deliberately lean: services + nodes (CPU/mem) are the signal that
+/// matters for the current monitor heuristics. Logs / error counts / GPU
+/// summaries can be enriched later as the heuristics need them.
+pub struct StateContextProvider {
+    state: Arc<AppState>,
+}
+
+impl StateContextProvider {
+    pub fn for_state(state: Arc<AppState>) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ContextProvider for StateContextProvider {
+    async fn snapshot(&self) -> anyhow::Result<ClusterContext> {
+        let cluster_name = self.state.cluster_config.cluster.name.clone();
+
+        let services = self.state.services.read().await;
+        let services: Vec<ServiceSummary> = services
+            .values()
+            .map(|svc| {
+                let running = svc
+                    .instances
+                    .iter()
+                    .filter(|i| matches!(i.status, WorkloadStatus::Running))
+                    .count() as u32;
+                let status = if svc.instances.is_empty() {
+                    "stopped".into()
+                } else if running == svc.desired_replicas {
+                    "healthy".into()
+                } else {
+                    "degraded".into()
+                };
+                ServiceSummary {
+                    name: svc.config.name.clone(),
+                    runtime: match svc.config.runtime {
+                        RuntimeKind::Container => "container".into(),
+                        RuntimeKind::Wasm => "wasm".into(),
+                    },
+                    replicas_running: running,
+                    replicas_desired: svc.desired_replicas,
+                    status,
+                    uses_gpu: false,
+                    recent_logs: Vec::new(),
+                    error_count_1h: 0,
+                    restart_count_24h: 0,
+                }
+            })
+            .collect();
+
+        let nodes = self.state.registered_nodes.read().await;
+        let nodes: Vec<NodeSummary> = nodes
+            .values()
+            .map(|n| NodeSummary {
+                id: n.node_id.to_string(),
+                address: n.address.clone(),
+                status: if n.drain {
+                    "draining".into()
+                } else {
+                    "healthy".into()
+                },
+                cpu_percent: n.cpu_percent,
+                memory_percent: if n.memory_total > 0 {
+                    (n.memory_bytes as f64 / n.memory_total as f64) * 100.0
+                } else {
+                    0.0
+                },
+                gpu_summary: Vec::new(),
+            })
+            .collect();
+
+        Ok(ClusterContext {
+            cluster_name,
+            nodes,
+            services,
+            recent_events: Vec::new(),
+            active_alerts: Vec::new(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orca_core::config::ClusterConfig;
+
+    #[test]
+    fn try_build_returns_none_when_no_ai_config() {
+        assert!(try_build_alert_engine(None).is_none());
+    }
+
+    #[test]
+    fn try_build_returns_none_when_endpoint_missing() {
+        let ai = AiConfig {
+            provider: "ollama".into(),
+            endpoint: None,
+            model: Some("llama3".into()),
+            api_key: None,
+            alerts: None,
+            auto_remediate: None,
+        };
+        assert!(try_build_alert_engine(Some(&ai)).is_none());
+    }
+
+    #[test]
+    fn try_build_returns_engine_when_minimum_config_set() {
+        let ai = AiConfig {
+            provider: "ollama".into(),
+            endpoint: Some("http://127.0.0.1:11434".into()),
+            model: Some("llama3".into()),
+            api_key: None,
+            alerts: None,
+            auto_remediate: None,
+        };
+        assert!(try_build_alert_engine(Some(&ai)).is_some());
+    }
+
+    // Sanity that ClusterConfig::default() is still constructible; we don't
+    // wire spawn_alert_monitor here because it requires an Arc<AppState>
+    // with a configured AI backend that we can't easily fake in a unit test.
+    #[test]
+    fn default_cluster_config_has_no_ai() {
+        let cfg = ClusterConfig::default();
+        assert!(cfg.ai.is_none());
+        assert!(try_build_alert_engine(cfg.ai.as_ref()).is_none());
+    }
+}

--- a/crates/orca-control/src/api/handlers/alerts.rs
+++ b/crates/orca-control/src/api/handlers/alerts.rs
@@ -1,0 +1,174 @@
+//! HTTP handlers for `/api/v1/alerts/*`.
+//!
+//! Surface the in-memory `ConversationEngine` over JSON so the CLI/TUI can
+//! list, view, reply to, dismiss, or resolve an alert conversation.
+//!
+//! All routes 503 when `[ai]` is unconfigured (no engine on `AppState`).
+//! Reply / dismiss / resolve dispatch through `ConversationEngine` which
+//! also fires the configured delivery channels.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use orca_ai::context::ClusterContext;
+use orca_ai::monitor::ContextProvider;
+use orca_core::types::AlertConversation;
+
+use crate::alerts::{SharedAlertEngine, StateContextProvider};
+use crate::state::AppState;
+
+#[derive(Debug, Deserialize, Default)]
+pub(crate) struct ListQuery {
+    #[serde(default)]
+    all: bool,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ListResponse {
+    alerts: Vec<AlertConversation>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct ReplyBody {
+    message: String,
+}
+
+fn unconfigured() -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "error": "AI alerts are not configured; add an [ai] block to cluster.toml"
+        })),
+    )
+}
+
+fn not_found(id: Uuid) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({ "error": format!("alert {id} not found") })),
+    )
+}
+
+fn engine(state: &Arc<AppState>) -> Option<SharedAlertEngine> {
+    state.alerts.clone()
+}
+
+/// Build a fresh `ClusterContext` from `AppState`. The engine needs this on
+/// every operator interaction so the LLM responds with current cluster state
+/// rather than the snapshot taken when the alert was first opened.
+async fn current_context(state: &Arc<AppState>) -> ClusterContext {
+    let provider = StateContextProvider::for_state(state.clone());
+    provider
+        .snapshot()
+        .await
+        .unwrap_or_else(|_| ClusterContext {
+            cluster_name: state.cluster_config.cluster.name.clone(),
+            nodes: Vec::new(),
+            services: Vec::new(),
+            recent_events: Vec::new(),
+            active_alerts: Vec::new(),
+        })
+}
+
+pub(crate) async fn list(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ListQuery>,
+) -> impl IntoResponse {
+    let Some(engine) = engine(&state) else {
+        return unconfigured().into_response();
+    };
+    let guard = engine.read().await;
+    let alerts: Vec<AlertConversation> = if query.all {
+        guard.all_conversations().to_vec()
+    } else {
+        guard.active_conversations().into_iter().cloned().collect()
+    };
+    Json(ListResponse { alerts }).into_response()
+}
+
+pub(crate) async fn view(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+) -> impl IntoResponse {
+    let Some(engine) = engine(&state) else {
+        return unconfigured().into_response();
+    };
+    let guard = engine.read().await;
+    match guard.get_conversation(id) {
+        Some(c) => Json(c.clone()).into_response(),
+        None => not_found(id).into_response(),
+    }
+}
+
+pub(crate) async fn reply(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<ReplyBody>,
+) -> impl IntoResponse {
+    let Some(engine) = engine(&state) else {
+        return unconfigured().into_response();
+    };
+    let ctx = current_context(&state).await;
+    let mut guard = engine.write().await;
+    match guard.operator_reply(id, &body.message, &ctx).await {
+        Ok(c) => Json(c.clone()).into_response(),
+        Err(e) => {
+            let msg = format!("{e}");
+            if msg.contains("conversation not found") {
+                not_found(id).into_response()
+            } else {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": msg })),
+                )
+                    .into_response()
+            }
+        }
+    }
+}
+
+pub(crate) async fn dismiss(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+) -> impl IntoResponse {
+    inline_reply(state, id, "dismiss").await
+}
+
+pub(crate) async fn resolve(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+) -> impl IntoResponse {
+    inline_reply(state, id, "resolve").await
+}
+
+/// Issue a built-in operator message ("dismiss" / "resolve") through the
+/// engine. The engine's existing special-command path translates these into
+/// state transitions + channel dispatches.
+async fn inline_reply(state: Arc<AppState>, id: Uuid, marker: &str) -> axum::response::Response {
+    let Some(engine) = engine(&state) else {
+        return unconfigured().into_response();
+    };
+    let ctx = current_context(&state).await;
+    let mut guard = engine.write().await;
+    match guard.operator_reply(id, marker, &ctx).await {
+        Ok(c) => Json(c.clone()).into_response(),
+        Err(e) => {
+            let msg = format!("{e}");
+            if msg.contains("conversation not found") {
+                not_found(id).into_response()
+            } else {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": msg })),
+                )
+                    .into_response()
+            }
+        }
+    }
+}

--- a/crates/orca-control/src/api/handlers/mod.rs
+++ b/crates/orca-control/src/api/handlers/mod.rs
@@ -11,6 +11,7 @@ use orca_core::api_types::{DeployRequest, DeployResponse, ServiceStatus, StatusR
 use crate::reconciler;
 use crate::state::AppState;
 
+pub(crate) mod alerts;
 pub(crate) mod exec;
 mod ops;
 pub(crate) mod secrets;

--- a/crates/orca-control/src/api/mod.rs
+++ b/crates/orca-control/src/api/mod.rs
@@ -41,6 +41,17 @@ pub fn router(state: Arc<AppState>) -> Router {
             post(handlers::trigger_cluster_backup),
         )
         .route("/api/v1/cluster/networks", get(handlers::cluster_networks))
+        .route("/api/v1/alerts", get(handlers::alerts::list))
+        .route("/api/v1/alerts/{id}", get(handlers::alerts::view))
+        .route("/api/v1/alerts/{id}/reply", post(handlers::alerts::reply))
+        .route(
+            "/api/v1/alerts/{id}/dismiss",
+            post(handlers::alerts::dismiss),
+        )
+        .route(
+            "/api/v1/alerts/{id}/resolve",
+            post(handlers::alerts::resolve),
+        )
         .route("/api/v1/secrets", get(handlers::secrets::list_secrets))
         .route(
             "/api/v1/secrets/usage",

--- a/crates/orca-control/src/lib.rs
+++ b/crates/orca-control/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod alerts;
 pub mod api;
 pub mod auth;
 pub mod backup_scheduler;
@@ -80,6 +81,10 @@ pub async fn run_server_with_acme(
         app_state = app_state.with_acme(acme, resolver);
     }
 
+    if let Some(engine) = alerts::try_build_alert_engine(cluster_config.ai.as_ref()) {
+        app_state = app_state.with_alerts(engine);
+    }
+
     // Open persistent store
     let store_path = dirs_next::home_dir()
         .unwrap_or_else(|| ".".into())
@@ -132,6 +137,10 @@ pub async fn run_server_with_acme(
         && cleanup_scheduler::spawn_cleanup_scheduler(cleanup_cfg, state.clone()).is_some()
     {
         info!("Cleanup scheduler started");
+    }
+
+    if alerts::spawn_alert_monitor(state.clone()).is_some() {
+        info!("AI alert monitor started");
     }
 
     let app = api::router(state.clone());

--- a/crates/orca-control/src/state.rs
+++ b/crates/orca-control/src/state.rs
@@ -87,6 +87,11 @@ pub struct AppState {
     /// Pending deploy result waiters: service_name → oneshot sender.
     /// Inserted by queue_remote_deploy, resolved by ws_handler on DeployResult.
     pub pending_deploys: RwLock<HashMap<String, tokio::sync::oneshot::Sender<Result<(), String>>>>,
+    /// AI conversational-alert engine. `None` when `[ai]` is not configured.
+    /// `AiMonitor::run` (spawned in `lib::run_server_with_acme`) feeds it
+    /// `open_alert` calls; the HTTP `/api/v1/alerts/...` handlers mutate it
+    /// in response to operator actions.
+    pub alerts: Option<crate::alerts::SharedAlertEngine>,
 }
 
 pub use orca_core::api_types::LastBackupResult;
@@ -189,12 +194,20 @@ impl AppState {
             webhook_invocations: RwLock::new(HashMap::new()),
             exec_sessions: RwLock::new(HashMap::new()),
             pending_deploys: RwLock::new(HashMap::new()),
+            alerts: None,
         }
     }
 
     /// Set persistent store for service state.
     pub fn with_store(mut self, store: Arc<crate::store::ClusterStore>) -> Self {
         self.store = Some(store);
+        self
+    }
+
+    /// Attach the AI alert engine. Builder-style so startup code can wire it
+    /// only when `[ai]` is configured.
+    pub fn with_alerts(mut self, engine: crate::alerts::SharedAlertEngine) -> Self {
+        self.alerts = Some(engine);
         self
     }
 

--- a/crates/orca-core/src/config/ai.rs
+++ b/crates/orca-core/src/config/ai.rs
@@ -43,14 +43,37 @@ fn default_analysis_interval() -> u64 {
     60
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AlertDeliveryChannels {
-    /// Webhook URL for alert conversation updates.
+    /// Generic webhook URL — receives JSON POST per alert event.
     pub webhook: Option<String>,
-    /// Slack webhook for threaded alert conversations.
+    /// Slack incoming-webhook URL — receives a formatted block per alert event.
     pub slack: Option<String>,
-    /// Email for alert digests.
-    pub email: Option<String>,
+    /// Email delivery via SMTP — sends one email per alert event.
+    pub email: Option<EmailChannelConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmailChannelConfig {
+    pub smtp_host: String,
+    #[serde(default = "default_smtp_port")]
+    pub smtp_port: u16,
+    pub username: String,
+    /// SMTP password. Use `${secrets.SMTP_PASSWORD}` to resolve from the secrets store.
+    pub password: String,
+    pub from: String,
+    pub to: Vec<String>,
+    /// If true, use STARTTLS (port 587 default); else implicit TLS (port 465).
+    #[serde(default = "default_smtp_starttls")]
+    pub starttls: bool,
+}
+
+fn default_smtp_port() -> u16 {
+    587
+}
+
+fn default_smtp_starttls() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/orca-core/src/config/mod.rs
+++ b/crates/orca-core/src/config/mod.rs
@@ -9,7 +9,9 @@ use crate::error::{OrcaError, Result};
 // -- Re-exports --
 
 pub use crate::backup::{BackupConfig, BackupTarget};
-pub use ai::{AiAlertConfig, AiConfig, AlertDeliveryChannels, AutoRemediateConfig};
+pub use ai::{
+    AiAlertConfig, AiConfig, AlertDeliveryChannels, AutoRemediateConfig, EmailChannelConfig,
+};
 pub use cluster::NetworkConfig;
 pub use cluster::{
     AlertChannelConfig, ApiToken, CleanupConfig, ClusterConfig, ClusterMeta, FallbackConfig,
@@ -48,6 +50,16 @@ impl ClusterConfig {
         if let Some(ai) = &mut self.ai {
             resolve(&mut ai.api_key);
             resolve(&mut ai.endpoint);
+            if let Some(alerts) = &mut ai.alerts
+                && let Some(channels) = &mut alerts.channels
+                && let Some(email) = &mut channels.email
+            {
+                let mut p = Some(email.password.clone());
+                resolve(&mut p);
+                if let Some(resolved) = p {
+                    email.password = resolved;
+                }
+            }
         }
         // Network config
         if let Some(net) = &mut self.network {


### PR DESCRIPTION
Final slice of #24 Path Y. **Stacks on top of #51 (PR2)** — base branch is \`feat/alert-plumbing\`. When PR1 (#50) and PR2 (#51) merge I'll retarget this to \`main\`.

Together with PR1 (channels) and PR2 (monitor + API), this closes #24 end-to-end: the AI monitor opens alerts, channels deliver them, and the CLI lets the operator triage them.

## CLI surface

- \`orca alerts list [--all]\` — table of active (or all) conversations
- \`orca alerts view <id>\` — full transcript with timestamps + suggested-command inlined under each Orca message
- \`orca alerts reply <id> <message...>\` — operator follow-up; prints the latest pair
- \`orca alerts dismiss <id>\` — channels fire \`Dismissed\`
- \`orca alerts resolve <id>\` — new variant; channels fire \`Resolved\`
- \`orca alerts fix <id>\` — prints the most recent \`suggested_command\` with a "review before running" hint. **Auto-execute deferred on purpose** — running an LLM-suggested shell command without operator confirm is a foot-gun; pairs naturally with a future interactive-confirm UX

## What changed

**\`crates/orca-cli/src/client.rs\`**
- New methods: \`alerts_list\`, \`alerts_view\`, \`alerts_reply\`, \`alerts_dismiss\`, \`alerts_resolve\` — bearer-authed via the existing helper
- New helper \`unwrap_alert_error\` translates the API's 503 / 404 JSON bodies into clean one-line anyhow messages so the CLI prints \`Error: AI alerts are not configured; add an [ai] block to cluster.toml\` instead of raw HTTP

**\`crates/orca-cli/src/handlers/ops.rs\`**
- \`handle_alerts\` now async + \`anyhow::Result<()>\`; main.rs awaits it like every other subcommand
- Picks up \`cli.api\` from the global flag
- Pretty-printers render messages as \`[HH:MM:SS who] content\` with an indented \`fix:\` line when an Orca message proposes a command

## Tests

All 41 existing mallorca unit tests pass; nothing in this PR's pretty-print / table-format path warrants a new unit test that wouldn't just re-test serde. An alerts CLI E2E test was scoped out for now because it needs a fake \`LlmBackend\` to drive the engine end-to-end through a spawned server. Once the cycle merges, **manual smoke** (real Ollama + Slack webhook) is the planned validation.

## Test plan
- [ ] CI green
- [ ] After all three PRs merge: run \`orca server\` locally with a configured \`[ai]\` + Slack webhook → trigger a service crash → \`orca alerts list\` shows the conversation, Slack receives the Block Kit message

🤖 Generated with [Claude Code](https://claude.com/claude-code)