### PR TITLE
feat(control): wire alert pipeline — monitor spawn + HTTP API (#24, PR 2/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2584,6 +2584,7 @@ dependencies = [
  "http-body-util",
  "openraft",
  "orca-agent",
+ "orca-ai",
  "orca-core",
  "orca-proxy",
  "prost",

--- a/crates/orca-ai/src/backend.rs
+++ b/crates/orca-ai/src/backend.rs
@@ -30,6 +30,21 @@ pub trait LlmBackend: Send + Sync + 'static {
     fn name(&self) -> &str;
 }
 
+/// Forward `LlmBackend` through a `Box`, so callers can use
+/// `Box<dyn LlmBackend>` wherever `B: LlmBackend` is required. Without this,
+/// `ConversationEngine<Box<dyn LlmBackend>>` won't compile because async-trait
+/// does not emit a blanket impl for boxed trait objects.
+#[async_trait]
+impl LlmBackend for Box<dyn LlmBackend> {
+    async fn chat(&self, messages: &[ChatMessage]) -> anyhow::Result<ChatResponse> {
+        let inner: &dyn LlmBackend = self.as_ref();
+        inner.chat(messages).await
+    }
+    fn name(&self) -> &str {
+        self.as_ref().name()
+    }
+}
+
 /// OpenAI-compatible backend (works with LiteLLM, Ollama, vLLM, OpenAI, Anthropic proxy, etc.)
 pub struct OpenAiCompatibleBackend {
     client: reqwest::Client,

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -11,6 +11,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 [dependencies]
 orca-core = { workspace = true }
 orca-agent = { path = "../orca-agent", version = "0.2.8" }
+orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/orca-control/src/alerts.rs
+++ b/crates/orca-control/src/alerts.rs
@@ -1,0 +1,207 @@
+//! AI alert pipeline integration for the control plane.
+//!
+//! Builds a `ConversationEngine` from `cluster.toml` `[ai]`, implements
+//! `ContextProvider` against `AppState`, and spawns the `AiMonitor` as
+//! a background task. The engine is held in `Option<SharedAlertEngine>`
+//! on `AppState` so handlers can mutate it for replies / dismiss / etc.
+//!
+//! Conversation persistence is in-memory only — a server restart wipes
+//! active alerts. The TUI (PR3) re-fetches via the HTTP API on startup.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use orca_ai::backend::{LlmBackend, OpenAiCompatibleBackend};
+use orca_ai::channels::Dispatcher;
+use orca_ai::context::{ClusterContext, NodeSummary, ServiceSummary};
+use orca_ai::conversation::ConversationEngine;
+use orca_ai::monitor::{AiMonitor, ContextProvider};
+use orca_core::config::AiConfig;
+use orca_core::types::{RuntimeKind, WorkloadStatus};
+
+use crate::state::AppState;
+
+pub type AlertEngine = ConversationEngine<Box<dyn LlmBackend>>;
+pub type SharedAlertEngine = Arc<RwLock<AlertEngine>>;
+
+/// Build the alert engine if `[ai]` is configured with endpoint + model.
+/// Returns `None` when AI is unconfigured so the caller can degrade
+/// gracefully without erroring out the whole server startup.
+pub fn try_build_alert_engine(cfg: Option<&AiConfig>) -> Option<SharedAlertEngine> {
+    let ai = cfg?;
+    let endpoint = ai.endpoint.as_ref()?;
+    let model = ai.model.as_ref()?;
+
+    let backend: Box<dyn LlmBackend> = Box::new(OpenAiCompatibleBackend::new(
+        endpoint.clone(),
+        model.clone(),
+        ai.api_key.clone(),
+    ));
+
+    let dispatcher = ai
+        .alerts
+        .as_ref()
+        .and_then(|a| a.channels.as_ref())
+        .map(Dispatcher::from_config)
+        .unwrap_or_default();
+    let names = dispatcher.channel_names();
+    if !names.is_empty() {
+        info!("Alert delivery channels configured: {names:?}");
+    }
+
+    Some(Arc::new(RwLock::new(ConversationEngine::with_dispatcher(
+        backend, dispatcher,
+    ))))
+}
+
+/// Spawn `AiMonitor::run` as a background task. No-op when alerts are
+/// disabled or the engine isn't built.
+pub fn spawn_alert_monitor(state: Arc<AppState>) -> Option<tokio::task::JoinHandle<()>> {
+    let engine = state.alerts.as_ref()?.clone();
+    let ai = state.cluster_config.ai.as_ref()?;
+    let alerts_cfg = ai.alerts.as_ref()?;
+    if !alerts_cfg.enabled {
+        return None;
+    }
+    let interval = alerts_cfg.analysis_interval_secs;
+    let provider: Arc<dyn ContextProvider> =
+        Arc::new(StateContextProvider::for_state(state.clone()));
+    info!("Spawning AI alert monitor (interval: {interval}s)");
+    Some(tokio::spawn(async move {
+        let monitor = AiMonitor::new(engine, interval);
+        monitor.run(provider).await;
+    }))
+}
+
+/// Reads `AppState` snapshots into a `ClusterContext` the AI can reason about.
+/// Kept deliberately lean: services + nodes (CPU/mem) are the signal that
+/// matters for the current monitor heuristics. Logs / error counts / GPU
+/// summaries can be enriched later as the heuristics need them.
+pub struct StateContextProvider {
+    state: Arc<AppState>,
+}
+
+impl StateContextProvider {
+    pub fn for_state(state: Arc<AppState>) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ContextProvider for StateContextProvider {
+    async fn snapshot(&self) -> anyhow::Result<ClusterContext> {
+        let cluster_name = self.state.cluster_config.cluster.name.clone();
+
+        let services = self.state.services.read().await;
+        let services: Vec<ServiceSummary> = services
+            .values()
+            .map(|svc| {
+                let running = svc
+                    .instances
+                    .iter()
+                    .filter(|i| matches!(i.status, WorkloadStatus::Running))
+                    .count() as u32;
+                let status = if svc.instances.is_empty() {
+                    "stopped".into()
+                } else if running == svc.desired_replicas {
+                    "healthy".into()
+                } else {
+                    "degraded".into()
+                };
+                ServiceSummary {
+                    name: svc.config.name.clone(),
+                    runtime: match svc.config.runtime {
+                        RuntimeKind::Container => "container".into(),
+                        RuntimeKind::Wasm => "wasm".into(),
+                    },
+                    replicas_running: running,
+                    replicas_desired: svc.desired_replicas,
+                    status,
+                    uses_gpu: false,
+                    recent_logs: Vec::new(),
+                    error_count_1h: 0,
+                    restart_count_24h: 0,
+                }
+            })
+            .collect();
+
+        let nodes = self.state.registered_nodes.read().await;
+        let nodes: Vec<NodeSummary> = nodes
+            .values()
+            .map(|n| NodeSummary {
+                id: n.node_id.to_string(),
+                address: n.address.clone(),
+                status: if n.drain {
+                    "draining".into()
+                } else {
+                    "healthy".into()
+                },
+                cpu_percent: n.cpu_percent,
+                memory_percent: if n.memory_total > 0 {
+                    (n.memory_bytes as f64 / n.memory_total as f64) * 100.0
+                } else {
+                    0.0
+                },
+                gpu_summary: Vec::new(),
+            })
+            .collect();
+
+        Ok(ClusterContext {
+            cluster_name,
+            nodes,
+            services,
+            recent_events: Vec::new(),
+            active_alerts: Vec::new(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orca_core::config::ClusterConfig;
+
+    #[test]
+    fn try_build_returns_none_when_no_ai_config() {
+        assert!(try_build_alert_engine(None).is_none());
+    }
+
+    #[test]
+    fn try_build_returns_none_when_endpoint_missing() {
+        let ai = AiConfig {
+            provider: "ollama".into(),
+            endpoint: None,
+            model: Some("llama3".into()),
+            api_key: None,
+            alerts: None,
+            auto_remediate: None,
+        };
+        assert!(try_build_alert_engine(Some(&ai)).is_none());
+    }
+
+    #[test]
+    fn try_build_returns_engine_when_minimum_config_set() {
+        let ai = AiConfig {
+            provider: "ollama".into(),
+            endpoint: Some("http://127.0.0.1:11434".into()),
+            model: Some("llama3".into()),
+            api_key: None,
+            alerts: None,
+            auto_remediate: None,
+        };
+        assert!(try_build_alert_engine(Some(&ai)).is_some());
+    }
+
+    // Sanity that ClusterConfig::default() is still constructible; we don't
+    // wire spawn_alert_monitor here because it requires an Arc<AppState>
+    // with a configured AI backend that we can't easily fake in a unit test.
+    #[test]
+    fn default_cluster_config_has_no_ai() {
+        let cfg = ClusterConfig::default();
+        assert!(cfg.ai.is_none());
+        assert!(try_build_alert_engine(cfg.ai.as_ref()).is_none());
+    }
+}

--- a/crates/orca-control/src/api/handlers/alerts.rs
+++ b/crates/orca-control/src/api/handlers/alerts.rs
@@ -1,0 +1,174 @@
+//! HTTP handlers for `/api/v1/alerts/*`.
+//!
+//! Surface the in-memory `ConversationEngine` over JSON so the CLI/TUI can
+//! list, view, reply to, dismiss, or resolve an alert conversation.
+//!
+//! All routes 503 when `[ai]` is unconfigured (no engine on `AppState`).
+//! Reply / dismiss / resolve dispatch through `ConversationEngine` which
+//! also fires the configured delivery channels.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use orca_ai::context::ClusterContext;
+use orca_ai::monitor::ContextProvider;
+use orca_core::types::AlertConversation;
+
+use crate::alerts::{SharedAlertEngine, StateContextProvider};
+use crate::state::AppState;
+
+#[derive(Debug, Deserialize, Default)]
+pub(crate) struct ListQuery {
+    #[serde(default)]
+    all: bool,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ListResponse {
+    alerts: Vec<AlertConversation>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct ReplyBody {
+    message: String,
+}
+
+fn unconfigured() -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "error": "AI alerts are not configured; add an [ai] block to cluster.toml"
+        })),
+    )
+}
+
+fn not_found(id: Uuid) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({ "error": format!("alert {id} not found") })),
+    )
+}
+
+fn engine(state: &Arc<AppState>) -> Option<SharedAlertEngine> {
+    state.alerts.clone()
+}
+
+/// Build a fresh `ClusterContext` from `AppState`. The engine needs this on
+/// every operator interaction so the LLM responds with current cluster state
+/// rather than the snapshot taken when the alert was first opened.
+async fn current_context(state: &Arc<AppState>) -> ClusterContext {
+    let provider = StateContextProvider::for_state(state.clone());
+    provider
+        .snapshot()
+        .await
+        .unwrap_or_else(|_| ClusterContext {
+            cluster_name: state.cluster_config.cluster.name.clone(),
+            nodes: Vec::new(),
+            services: Vec::new(),
+            recent_events: Vec::new(),
+            active_alerts: Vec::new(),
+        })
+}
+
+pub(crate) async fn list(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ListQuery>,
+) -> impl IntoResponse {
+    let Some(engine) = engine(&state) else {
+        return unconfigured().into_response();
+    };
+    let guard = engine.read().await;
+    let alerts: Vec<AlertConversation> = if query.all {
+        guard.all_conversations().to_vec()
+    } else {
+        guard.active_conversations().into_iter().cloned().collect()
+    };
+    Json(ListResponse { alerts }).into_response()
+}
+
+pub(crate) async fn view(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+) -> impl IntoResponse {
+    let Some(engine) = engine(&state) else {
+        return unconfigured().into_response();
+    };
+    let guard = engine.read().await;
+    match guard.get_conversation(id) {
+        Some(c) => Json(c.clone()).into_response(),
+        None => not_found(id).into_response(),
+    }
+}
+
+pub(crate) async fn reply(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<ReplyBody>,
+) -> impl IntoResponse {
+    let Some(engine) = engine(&state) else {
+        return unconfigured().into_response();
+    };
+    let ctx = current_context(&state).await;
+    let mut guard = engine.write().await;
+    match guard.operator_reply(id, &body.message, &ctx).await {
+        Ok(c) => Json(c.clone()).into_response(),
+        Err(e) => {
+            let msg = format!("{e}");
+            if msg.contains("conversation not found") {
+                not_found(id).into_response()
+            } else {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": msg })),
+                )
+                    .into_response()
+            }
+        }
+    }
+}
+
+pub(crate) async fn dismiss(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+) -> impl IntoResponse {
+    inline_reply(state, id, "dismiss").await
+}
+
+pub(crate) async fn resolve(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+) -> impl IntoResponse {
+    inline_reply(state, id, "resolve").await
+}
+
+/// Issue a built-in operator message ("dismiss" / "resolve") through the
+/// engine. The engine's existing special-command path translates these into
+/// state transitions + channel dispatches.
+async fn inline_reply(state: Arc<AppState>, id: Uuid, marker: &str) -> axum::response::Response {
+    let Some(engine) = engine(&state) else {
+        return unconfigured().into_response();
+    };
+    let ctx = current_context(&state).await;
+    let mut guard = engine.write().await;
+    match guard.operator_reply(id, marker, &ctx).await {
+        Ok(c) => Json(c.clone()).into_response(),
+        Err(e) => {
+            let msg = format!("{e}");
+            if msg.contains("conversation not found") {
+                not_found(id).into_response()
+            } else {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": msg })),
+                )
+                    .into_response()
+            }
+        }
+    }
+}

--- a/crates/orca-control/src/api/handlers/mod.rs
+++ b/crates/orca-control/src/api/handlers/mod.rs
@@ -11,6 +11,7 @@ use orca_core::api_types::{DeployRequest, DeployResponse, ServiceStatus, StatusR
 use crate::reconciler;
 use crate::state::AppState;
 
+pub(crate) mod alerts;
 pub(crate) mod exec;
 mod ops;
 pub(crate) mod secrets;

--- a/crates/orca-control/src/api/mod.rs
+++ b/crates/orca-control/src/api/mod.rs
@@ -41,6 +41,17 @@ pub fn router(state: Arc<AppState>) -> Router {
             post(handlers::trigger_cluster_backup),
         )
         .route("/api/v1/cluster/networks", get(handlers::cluster_networks))
+        .route("/api/v1/alerts", get(handlers::alerts::list))
+        .route("/api/v1/alerts/{id}", get(handlers::alerts::view))
+        .route("/api/v1/alerts/{id}/reply", post(handlers::alerts::reply))
+        .route(
+            "/api/v1/alerts/{id}/dismiss",
+            post(handlers::alerts::dismiss),
+        )
+        .route(
+            "/api/v1/alerts/{id}/resolve",
+            post(handlers::alerts::resolve),
+        )
         .route("/api/v1/secrets", get(handlers::secrets::list_secrets))
         .route(
             "/api/v1/secrets/usage",

--- a/crates/orca-control/src/lib.rs
+++ b/crates/orca-control/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod alerts;
 pub mod api;
 pub mod auth;
 pub mod backup_scheduler;
@@ -80,6 +81,10 @@ pub async fn run_server_with_acme(
         app_state = app_state.with_acme(acme, resolver);
     }
 
+    if let Some(engine) = alerts::try_build_alert_engine(cluster_config.ai.as_ref()) {
+        app_state = app_state.with_alerts(engine);
+    }
+
     // Open persistent store
     let store_path = dirs_next::home_dir()
         .unwrap_or_else(|| ".".into())
@@ -132,6 +137,10 @@ pub async fn run_server_with_acme(
         && cleanup_scheduler::spawn_cleanup_scheduler(cleanup_cfg, state.clone()).is_some()
     {
         info!("Cleanup scheduler started");
+    }
+
+    if alerts::spawn_alert_monitor(state.clone()).is_some() {
+        info!("AI alert monitor started");
     }
 
     let app = api::router(state.clone());

--- a/crates/orca-control/src/state.rs
+++ b/crates/orca-control/src/state.rs
@@ -87,6 +87,11 @@ pub struct AppState {
     /// Pending deploy result waiters: service_name → oneshot sender.
     /// Inserted by queue_remote_deploy, resolved by ws_handler on DeployResult.
     pub pending_deploys: RwLock<HashMap<String, tokio::sync::oneshot::Sender<Result<(), String>>>>,
+    /// AI conversational-alert engine. `None` when `[ai]` is not configured.
+    /// `AiMonitor::run` (spawned in `lib::run_server_with_acme`) feeds it
+    /// `open_alert` calls; the HTTP `/api/v1/alerts/...` handlers mutate it
+    /// in response to operator actions.
+    pub alerts: Option<crate::alerts::SharedAlertEngine>,
 }
 
 pub use orca_core::api_types::LastBackupResult;
@@ -189,12 +194,20 @@ impl AppState {
             webhook_invocations: RwLock::new(HashMap::new()),
             exec_sessions: RwLock::new(HashMap::new()),
             pending_deploys: RwLock::new(HashMap::new()),
+            alerts: None,
         }
     }
 
     /// Set persistent store for service state.
     pub fn with_store(mut self, store: Arc<crate::store::ClusterStore>) -> Self {
         self.store = Some(store);
+        self
+    }
+
+    /// Attach the AI alert engine. Builder-style so startup code can wire it
+    /// only when `[ai]` is configured.
+    pub fn with_alerts(mut self, engine: crate::alerts::SharedAlertEngine) -> Self {
+        self.alerts = Some(engine);
         self
     }
 


### PR DESCRIPTION
Second slice of #24 Path Y. Replaces #51 (auto-closed when its base branch `feat/alert-channels` was deleted during the #50 merge).

With this PR, alerts actually fire on a running `orca server`: the monitor analyzes cluster state, opens conversations via the LLM, and delivers them through the channels from #50.

## What lands

- **`crates/orca-control/src/alerts.rs`** — builds `ConversationEngine<Box<dyn LlmBackend>>` from `cluster.toml [ai]`, holds it on `AppState`, implements `ContextProvider` against the state, and spawns `AiMonitor::run` as a background task when `[ai.alerts].enabled`.
- **`/api/v1/alerts`** endpoints: list, view, reply, dismiss, resolve. All return 503 with a clean JSON error when `[ai]` is unconfigured.
- **`orca-ai::backend::LlmBackend`** gains a manual `impl LlmBackend for Box<dyn LlmBackend>` blanket — `#[async_trait]` doesn't emit one and `ConversationEngine<Box<dyn LlmBackend>>` won't compile without it.

## Tests
4 unit tests in `alerts.rs` covering the engine constructor's None/Some paths. HTTP integration test deferred to pair with PR3's CLI smoke.

## Stack
- #50 — channels (merged ✓)
- **This** — monitor + API (PR 2/3)
- #52 — CLI (PR 3/3, currently based on the old plumbing branch, will need similar fresh-PR treatment after this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)