### PR TITLE
feat(cli): wire orca alerts CLI to the alerts API (#24, PR 3/3)

### DIFF
--- a/crates/orca-cli/src/client.rs
+++ b/crates/orca-cli/src/client.rs
@@ -4,6 +4,8 @@ use orca_core::api_types::{
     DeployRequest, DeployResponse, ScaleRequest, ScaleResponse, StatusResponse,
 };
 use orca_core::config::ServicesConfig;
+use orca_core::types::AlertConversation;
+use serde::Deserialize;
 
 /// Client for the orca control plane API.
 pub struct OrcaClient {
@@ -121,6 +123,65 @@ impl OrcaClient {
         Ok(())
     }
 
+    pub async fn alerts_list(&self, all: bool) -> anyhow::Result<Vec<AlertConversation>> {
+        let path = format!("/api/v1/alerts?all={all}");
+        let resp = self.auth(self.client.get(self.url(&path))).send().await?;
+        let resp = unwrap_alert_error(resp).await?;
+        #[derive(Deserialize)]
+        struct ListResp {
+            alerts: Vec<AlertConversation>,
+        }
+        let body: ListResp = resp.json().await?;
+        Ok(body.alerts)
+    }
+
+    pub async fn alerts_view(&self, id: &str) -> anyhow::Result<AlertConversation> {
+        let resp = self
+            .auth(self.client.get(self.url(&format!("/api/v1/alerts/{id}"))))
+            .send()
+            .await?;
+        let resp = unwrap_alert_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn alerts_reply(&self, id: &str, message: &str) -> anyhow::Result<AlertConversation> {
+        let body = serde_json::json!({ "message": message });
+        let resp = self
+            .auth(
+                self.client
+                    .post(self.url(&format!("/api/v1/alerts/{id}/reply"))),
+            )
+            .json(&body)
+            .send()
+            .await?;
+        let resp = unwrap_alert_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn alerts_dismiss(&self, id: &str) -> anyhow::Result<AlertConversation> {
+        let resp = self
+            .auth(
+                self.client
+                    .post(self.url(&format!("/api/v1/alerts/{id}/dismiss"))),
+            )
+            .send()
+            .await?;
+        let resp = unwrap_alert_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn alerts_resolve(&self, id: &str) -> anyhow::Result<AlertConversation> {
+        let resp = self
+            .auth(
+                self.client
+                    .post(self.url(&format!("/api/v1/alerts/{id}/resolve"))),
+            )
+            .send()
+            .await?;
+        let resp = unwrap_alert_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
     pub async fn promote(&self, service: &str) -> anyhow::Result<()> {
         self.auth(
             self.client
@@ -184,4 +245,26 @@ impl OrcaClient {
             .error_for_status()?;
         Ok(resp.json().await?)
     }
+}
+
+/// Translate 503 (`[ai]` unconfigured) and 404 (unknown id) into clean
+/// anyhow errors so the CLI can print one-line messages instead of raw
+/// HTTP status codes.
+async fn unwrap_alert_error(resp: reqwest::Response) -> anyhow::Result<reqwest::Response> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp);
+    }
+    let body: serde_json::Value = resp.json().await.unwrap_or_default();
+    let msg = body
+        .get("error")
+        .and_then(|e| e.as_str())
+        .unwrap_or("(no error message in response)");
+    if status.as_u16() == 503 {
+        anyhow::bail!("{msg}");
+    }
+    if status.as_u16() == 404 {
+        anyhow::bail!("{msg}");
+    }
+    anyhow::bail!("alerts API returned HTTP {status}: {msg}")
 }

--- a/crates/orca-cli/src/handlers/ops.rs
+++ b/crates/orca-cli/src/handlers/ops.rs
@@ -116,19 +116,123 @@ pub async fn handle_scale(service: String, replicas: u32, api: String) -> anyhow
     Ok(())
 }
 
-pub fn handle_alerts(action: AlertsAction) {
+pub async fn handle_alerts(action: AlertsAction, api: String) -> anyhow::Result<()> {
+    let client = OrcaClient::new(api);
     match action {
         AlertsAction::List { all } => {
-            let scope = if all { "all" } else { "active" };
-            println!("No {scope} alert conversations.");
+            let alerts = client.alerts_list(all).await?;
+            if alerts.is_empty() {
+                let scope = if all { "all" } else { "active" };
+                println!("No {scope} alert conversations.");
+                return Ok(());
+            }
+            println!(
+                "{:<36}  {:<20}  {:<9}  {:<16}  Started",
+                "ID", "Service", "Severity", "State"
+            );
+            for a in alerts {
+                println!(
+                    "{:<36}  {:<20}  {:<9?}  {:<16?}  {}",
+                    a.id,
+                    truncate(&a.service, 20),
+                    a.severity,
+                    a.state,
+                    a.started_at.format("%Y-%m-%d %H:%M:%S")
+                );
+            }
         }
-        AlertsAction::View { id } => println!("Alert {id}: not yet connected."),
+        AlertsAction::View { id } => {
+            let conv = client.alerts_view(&id).await?;
+            print_conversation(&conv);
+        }
         AlertsAction::Reply { id, message } => {
             let msg = message.join(" ");
-            println!("Reply to alert {id}: {msg}");
+            if msg.trim().is_empty() {
+                anyhow::bail!("reply message cannot be empty");
+            }
+            let conv = client.alerts_reply(&id, &msg).await?;
+            println!("Reply sent. Latest exchange:");
+            print_latest_exchange(&conv);
         }
-        AlertsAction::Dismiss { id } => println!("Dismissed alert {id}."),
-        AlertsAction::Fix { id } => println!("Applying fix for alert {id}..."),
+        AlertsAction::Dismiss { id } => {
+            client.alerts_dismiss(&id).await?;
+            println!("Dismissed alert {id}.");
+        }
+        AlertsAction::Resolve { id } => {
+            client.alerts_resolve(&id).await?;
+            println!("Resolved alert {id}.");
+        }
+        AlertsAction::Fix { id } => {
+            let conv = client.alerts_view(&id).await?;
+            let cmd = conv
+                .messages
+                .iter()
+                .rev()
+                .find_map(|m| m.suggested_command.as_deref());
+            match cmd {
+                Some(c) => {
+                    println!("Suggested fix for alert {id}:\n  {c}");
+                    println!(
+                        "\nReview before running. To apply: `orca alerts reply {id} approve` once interactive\n\
+                         confirm is wired, or run the command directly."
+                    );
+                }
+                None => println!("No suggested command on alert {id}."),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_conversation(conv: &orca_core::types::AlertConversation) {
+    println!("Alert {} — {}", conv.id, conv.service);
+    println!(
+        "Severity: {:?}  State: {:?}  Started: {}",
+        conv.severity,
+        conv.state,
+        conv.started_at.format("%Y-%m-%d %H:%M:%S")
+    );
+    if let Some(resolved) = conv.resolved_at {
+        println!("Resolved: {}", resolved.format("%Y-%m-%d %H:%M:%S"));
+    }
+    println!("\nConversation:");
+    for msg in &conv.messages {
+        let who = match msg.sender {
+            orca_core::types::AlertSender::Orca => "orca",
+            orca_core::types::AlertSender::Operator => "you",
+            orca_core::types::AlertSender::System => "system",
+        };
+        println!(
+            "  [{} {}] {}",
+            msg.timestamp.format("%H:%M:%S"),
+            who,
+            msg.content
+        );
+        if let Some(cmd) = &msg.suggested_command {
+            println!("    fix: {cmd}");
+        }
+    }
+}
+
+fn print_latest_exchange(conv: &orca_core::types::AlertConversation) {
+    for msg in conv.messages.iter().rev().take(2).rev() {
+        let who = match msg.sender {
+            orca_core::types::AlertSender::Orca => "orca",
+            orca_core::types::AlertSender::Operator => "you",
+            orca_core::types::AlertSender::System => "system",
+        };
+        println!("  [{who}] {}", msg.content);
+        if let Some(cmd) = &msg.suggested_command {
+            println!("    fix: {cmd}");
+        }
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max.saturating_sub(1)])
     }
 }
 

--- a/crates/orca-cli/src/main.rs
+++ b/crates/orca-cli/src/main.rs
@@ -94,7 +94,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Command::Ask { question } => handlers::ai_ops::handle_ask(question, cli.api).await?,
         Command::Generate { description } => handlers::ai_ops::handle_generate(description).await?,
-        Command::Alerts { action } => handlers::ops::handle_alerts(action),
+        Command::Alerts { action } => handlers::ops::handle_alerts(action, cli.api).await?,
         Command::Secrets { action } => handlers::ops::handle_secrets(action),
         Command::Import { source } => handlers::import::handle_import(source),
         Command::Webhooks { action } => handlers::ops::handle_webhooks(action, cli.api).await?,

--- a/crates/orca-cli/src/subcommands.rs
+++ b/crates/orca-cli/src/subcommands.rs
@@ -16,6 +16,9 @@ pub enum AlertsAction {
     Dismiss {
         id: String,
     },
+    Resolve {
+        id: String,
+    },
     Fix {
         id: String,
     },


### PR DESCRIPTION
Final slice of #24 Path Y. Replaces #52 (auto-closed when its base branch was deleted during the #53 merge).

Together with the channels module (#50) and the monitor + API (#53), this closes #24 end-to-end: AI monitor opens alerts → channels deliver → operator triages via `orca alerts ...`.

## CLI surface

- `orca alerts list [--all]` — active or all conversations, table
- `orca alerts view <id>` — full transcript with timestamps + suggested-command inlined
- `orca alerts reply <id> <message...>` — operator follow-up; prints the latest pair
- `orca alerts dismiss <id>` — channels fire `Dismissed`
- `orca alerts resolve <id>` — new variant; channels fire `Resolved`
- `orca alerts fix <id>` — prints the most recent `suggested_command` with a "review before running" hint. Auto-execute intentionally deferred — running an LLM-suggested shell command without operator confirm is a foot-gun

## What changed

- `crates/orca-cli/src/client.rs` — `alerts_list/view/reply/dismiss/resolve` methods; `unwrap_alert_error` translates 503/404 JSON bodies into clean anyhow messages
- `crates/orca-cli/src/handlers/ops.rs` — `handle_alerts` now async + `anyhow::Result<()>`; pretty-printers render messages as `[HH:MM:SS who] content` with indented `fix:` lines
- `crates/orca-cli/src/subcommands.rs` — new `Resolve` variant
- `crates/orca-cli/src/main.rs` — awaits handle_alerts with `cli.api`

## Tests
All 41 mallorca unit tests pass. Alerts CLI E2E was scoped out because it needs a fake `LlmBackend` to drive the engine end-to-end through a spawned server. Manual smoke (real Ollama + Slack webhook) is the planned validation once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)