### PR TITLE
fix(alerts): email delivery + real-signal counts in the monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +738,20 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "comrak"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fefab951771fc3beeed0773ce66a4f7b706273fc6c4c95b08dd1615744abcf5"
+dependencies = [
+ "caseless",
+ "entities",
+ "memchr",
+ "slug",
+ "typed-arena",
+ "unicode_categories",
 ]
 
 [[package]]
@@ -1057,6 +1080,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,6 +1233,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "entities"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
 name = "equivalent"
@@ -2550,6 +2585,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "comrak",
  "futures-util",
  "http-body-util",
  "hyper",
@@ -3836,6 +3872,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slug"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
+dependencies = [
+ "deunicode",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4554,6 +4600,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4564,6 +4616,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -4599,6 +4660,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "universal-hash"

--- a/crates/orca-ai/Cargo.toml
+++ b/crates/orca-ai/Cargo.toml
@@ -21,6 +21,7 @@ uuid = { workspace = true }
 async-trait = { workspace = true }
 futures-util = "0.3"
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls-tls", "builder", "ring"] }
+comrak = { version = "0.39", default-features = false }
 
 [dev-dependencies]
 hyper = { version = "1", features = ["server", "http1"] }

--- a/crates/orca-ai/src/channels/email.rs
+++ b/crates/orca-ai/src/channels/email.rs
@@ -1,18 +1,20 @@
 //! Email delivery via SMTP using `lettre`.
 //!
-//! Sends one plain-text email per alert event. STARTTLS by default
-//! (port 587); set `starttls = false` in cluster.toml for implicit TLS on
-//! port 465. Credentials resolve through the secrets store via
+//! Sends one multipart/alternative email per alert event — plain text plus
+//! an HTML version with the LLM's markdown rendered (tables, code blocks,
+//! bold). STARTTLS by default (port 587); set `tls = "implicit"` for port
+//! 465, or `tls = "none"` for plain SMTP against local dev catchers
+//! (mailpit). Credentials resolve through the secrets store via
 //! `${secrets.SMTP_PASSWORD}` in cluster.toml.
 
 use async_trait::async_trait;
-use lettre::message::Message;
+use lettre::message::{Message, MultiPart};
 use lettre::transport::smtp::AsyncSmtpTransport;
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{AsyncTransport, Tokio1Executor};
 use std::time::Duration;
 
-use orca_core::config::EmailChannelConfig;
+use orca_core::config::{EmailChannelConfig, SmtpTls};
 use orca_core::types::{AlertConversation, AlertSender, AlertSeverity};
 
 use super::{AlertEvent, Channel};
@@ -24,18 +26,29 @@ pub struct EmailChannel {
 
 impl EmailChannel {
     pub fn new(cfg: EmailChannelConfig) -> Self {
-        let creds = Credentials::new(cfg.username.clone(), cfg.password.clone());
-        let builder = if cfg.starttls {
-            AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&cfg.smtp_host)
-        } else {
-            AsyncSmtpTransport::<Tokio1Executor>::relay(&cfg.smtp_host)
+        let mut builder = match cfg.tls {
+            SmtpTls::Starttls => {
+                AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&cfg.smtp_host)
+                    .expect("build STARTTLS transport")
+            }
+            SmtpTls::Implicit => AsyncSmtpTransport::<Tokio1Executor>::relay(&cfg.smtp_host)
+                .expect("build implicit-TLS transport"),
+            // Plain SMTP — local dev only (e.g. mailpit catchers).
+            SmtpTls::None => {
+                AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&cfg.smtp_host)
+            }
         };
-        let transport = builder
-            .expect("build SMTP transport")
+        builder = builder
             .port(cfg.smtp_port)
-            .credentials(creds)
-            .timeout(Some(Duration::from_secs(15)))
-            .build();
+            .timeout(Some(Duration::from_secs(15)));
+        // Lettre refuses to send AUTH over a non-TLS channel by design (the
+        // credentials would be cleartext). Skip credentials entirely on plain
+        // SMTP — fine for catchers like mailpit, which accept anonymous mail.
+        if !matches!(cfg.tls, SmtpTls::None) {
+            builder =
+                builder.credentials(Credentials::new(cfg.username.clone(), cfg.password.clone()));
+        }
+        let transport = builder.build();
         Self { cfg, transport }
     }
 
@@ -87,16 +100,46 @@ impl Channel for EmailChannel {
 
     async fn deliver(&self, conv: &AlertConversation, event: AlertEvent) -> anyhow::Result<()> {
         let subject = Self::subject(conv, event);
-        let body = Self::body(conv, event);
+        let plain = Self::body(conv, event);
+        let html = Self::render_html(&plain);
         let mut builder = Message::builder()
             .from(self.cfg.from.parse()?)
             .subject(subject);
         for recipient in &self.cfg.to {
             builder = builder.to(recipient.parse()?);
         }
-        let email = builder.body(body)?;
+        // Multipart/alternative: clients that prefer HTML get the rendered
+        // version, plain-text clients (mutt, ops scripts) fall back cleanly.
+        let email = builder.multipart(MultiPart::alternative_plain_html(plain, html))?;
         self.transport.send(email).await?;
         Ok(())
+    }
+}
+
+impl EmailChannel {
+    /// Render the alert body's markdown to HTML (tables, code blocks, bold).
+    /// Wraps in a minimal document with inline CSS so common clients render
+    /// tables and code blocks without help.
+    fn render_html(body: &str) -> String {
+        let mut opts = comrak::Options::default();
+        opts.extension.table = true;
+        opts.extension.strikethrough = true;
+        opts.extension.tagfilter = true;
+        opts.extension.autolink = true;
+        let rendered = comrak::markdown_to_html(body, &opts);
+        format!(
+            "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><style>\
+             body{{font-family:-apple-system,system-ui,sans-serif;font-size:14px;color:#222;max-width:760px;margin:0 auto;padding:16px;line-height:1.5}}\
+             code{{background:#f4f4f4;border-radius:3px;padding:1px 4px;font-family:ui-monospace,Menlo,monospace}}\
+             pre{{background:#f4f4f4;border-radius:4px;padding:10px;overflow-x:auto;font-family:ui-monospace,Menlo,monospace;font-size:13px}}\
+             pre code{{background:transparent;padding:0}}\
+             table{{border-collapse:collapse;margin:8px 0}}\
+             th,td{{border:1px solid #ccc;padding:6px 10px;text-align:left}}\
+             th{{background:#f7f7f7}}\
+             h1,h2,h3{{margin-top:1em;margin-bottom:0.4em}}\
+             blockquote{{margin:0;padding-left:12px;border-left:3px solid #ddd;color:#666}}\
+             </style></head><body>{rendered}</body></html>"
+        )
     }
 }
 

--- a/crates/orca-ai/src/context.rs
+++ b/crates/orca-ai/src/context.rs
@@ -95,7 +95,9 @@ impl ClusterContext {
         out.push_str("- `orca exec <service> [cmd]` — interactive shell or one-shot command inside a running container\n");
         out.push_str("- `orca secrets set <KEY> <VALUE>` — set a secret referenced as `${secrets.KEY}` in service.toml env\n");
         out.push_str("- `orca secrets list` / `orca secrets get <KEY>` / `orca secrets remove <KEY>` — read/remove secrets\n");
-        out.push_str("- `orca deploy [service…]` — (re)apply service definitions from `services/`\n");
+        out.push_str(
+            "- `orca deploy [service…]` — (re)apply service definitions from `services/`\n",
+        );
         out.push_str("- `orca alerts list` / `orca alerts view <id>` / `orca alerts reply <id> <msg>` / `orca alerts dismiss|resolve <id>` — alert triage\n");
         out.push_str("- `orca backup` / `orca cleanup` / `orca nodes` — operational utilities\n\n");
         out.push_str("**Not supported (do not suggest):** `orca service <verb>` (the CLI is flat — there is no `service` subcommand). ");

--- a/crates/orca-ai/src/context.rs
+++ b/crates/orca-ai/src/context.rs
@@ -80,6 +80,28 @@ impl ClusterContext {
         out.push_str("You have access to real-time cluster state. Diagnose issues, suggest fixes as `orca` CLI commands, and explain your reasoning.\n");
         out.push_str("When suggesting fixes, output the exact command. When unsure, say so.\n\n");
 
+        // Authoritative command surface. The LLM otherwise invents plausible
+        // but non-existent commands like `orca service restart` (this CLI is
+        // flat — verbs are top-level, not nested under `service`).
+        out.push_str("## Available `orca` commands\n");
+        out.push_str("Use ONLY these. Do NOT invent subcommands.\n\n");
+        out.push_str("- `orca status` — cluster + service overview\n");
+        out.push_str("- `orca logs <service> [--tail N] [--summarize]` — tail logs; `--summarize` runs them through the AI\n");
+        out.push_str("- `orca redeploy <service>` — force fresh image pull + container recreate (this is the 'restart' verb)\n");
+        out.push_str("- `orca rollback <service>` — roll back to the previous successful deploy\n");
+        out.push_str("- `orca scale <service> --replicas N` — change replica count\n");
+        out.push_str("- `orca stop <service>` — stop a service (omit for all)\n");
+        out.push_str("- `orca promote <service>` — promote canary instances to stable\n");
+        out.push_str("- `orca exec <service> [cmd]` — interactive shell or one-shot command inside a running container\n");
+        out.push_str("- `orca secrets set <KEY> <VALUE>` — set a secret referenced as `${secrets.KEY}` in service.toml env\n");
+        out.push_str("- `orca secrets list` / `orca secrets get <KEY>` / `orca secrets remove <KEY>` — read/remove secrets\n");
+        out.push_str("- `orca deploy [service…]` — (re)apply service definitions from `services/`\n");
+        out.push_str("- `orca alerts list` / `orca alerts view <id>` / `orca alerts reply <id> <msg>` / `orca alerts dismiss|resolve <id>` — alert triage\n");
+        out.push_str("- `orca backup` / `orca cleanup` / `orca nodes` — operational utilities\n\n");
+        out.push_str("**Not supported (do not suggest):** `orca service <verb>` (the CLI is flat — there is no `service` subcommand). ");
+        out.push_str("There is also no `set-env` / `update --cmd` / `update --image` / `update --port` — env vars, image tag, command, and ports live in `services/<project>/service.toml` and apply on `orca deploy`. ");
+        out.push_str("If a fix requires editing a service definition, say so plainly (e.g. 'edit services/<project>/service.toml: change `image = ...`, then `orca deploy`').\n\n");
+
         out.push_str("## Nodes\n");
         for n in &self.nodes {
             out.push_str(&format!(
@@ -197,5 +219,24 @@ mod tests {
         assert!(prompt.contains("## Recent Events"));
         assert!(prompt.contains("node-1"));
         assert!(prompt.contains("api"));
+    }
+
+    #[test]
+    fn test_system_prompt_includes_command_reference() {
+        let ctx = ClusterContext {
+            cluster_name: "x".into(),
+            nodes: vec![],
+            services: vec![],
+            recent_events: vec![],
+            active_alerts: vec![],
+        };
+        let prompt = ctx.to_system_prompt();
+        assert!(prompt.contains("## Available `orca` commands"));
+        assert!(prompt.contains("orca redeploy"));
+        assert!(prompt.contains("orca logs"));
+        assert!(prompt.contains("orca rollback"));
+        assert!(prompt.contains("Not supported"));
+        // The hallucinated forms must be called out as wrong.
+        assert!(prompt.contains("`orca service <verb>`"));
     }
 }

--- a/crates/orca-control/src/alerts.rs
+++ b/crates/orca-control/src/alerts.rs
@@ -11,6 +11,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use chrono::{Duration, Utc};
 use tokio::sync::RwLock;
 use tracing::info;
 
@@ -96,6 +97,10 @@ impl ContextProvider for StateContextProvider {
         let cluster_name = self.state.cluster_config.cluster.name.clone();
 
         let services = self.state.services.read().await;
+        let events = self.state.instance_events.read().await;
+        let now = Utc::now();
+        let one_hour = Duration::hours(1);
+        let day = Duration::hours(24);
         let services: Vec<ServiceSummary> = services
             .values()
             .map(|svc| {
@@ -111,6 +116,10 @@ impl ContextProvider for StateContextProvider {
                 } else {
                     "degraded".into()
                 };
+                let (errors_1h, restarts_24h) = events
+                    .get(&svc.config.name)
+                    .map(|log| (log.failures_in(now, one_hour), log.restarts_in(now, day)))
+                    .unwrap_or((0, 0));
                 ServiceSummary {
                     name: svc.config.name.clone(),
                     runtime: match svc.config.runtime {
@@ -122,8 +131,8 @@ impl ContextProvider for StateContextProvider {
                     status,
                     uses_gpu: false,
                     recent_logs: Vec::new(),
-                    error_count_1h: 0,
-                    restart_count_24h: 0,
+                    error_count_1h: errors_1h,
+                    restart_count_24h: restarts_24h,
                 }
             })
             .collect();

--- a/crates/orca-control/src/health.rs
+++ b/crates/orca-control/src/health.rs
@@ -168,6 +168,9 @@ impl HealthChecker {
                         consecutive_failures = *count,
                         "Health check failed"
                     );
+                    self.state
+                        .record_instance_failure(&target.service_name)
+                        .await;
                     self.set_health(
                         &target.service_name,
                         &inst.runtime_id,
@@ -184,6 +187,9 @@ impl HealthChecker {
                             "Restarting after {} consecutive failures",
                             *count
                         );
+                        self.state
+                            .record_instance_restart(&target.service_name)
+                            .await;
                         self.restart_instance(
                             &target.service_name,
                             &inst.runtime_id,

--- a/crates/orca-control/src/state.rs
+++ b/crates/orca-control/src/state.rs
@@ -1,8 +1,9 @@
 //! Shared application state for the control plane.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
+use chrono::{DateTime, Duration, Utc};
 use tokio::sync::RwLock;
 
 use orca_core::config::{ClusterConfig, ServiceConfig};
@@ -92,6 +93,63 @@ pub struct AppState {
     /// `open_alert` calls; the HTTP `/api/v1/alerts/...` handlers mutate it
     /// in response to operator actions.
     pub alerts: Option<crate::alerts::SharedAlertEngine>,
+    /// Per-service log of restart triggers and instance failures.
+    /// Read by the AI alert monitor to populate `restart_count_24h` and
+    /// `error_count_1h` in the cluster context. In-memory only; restart
+    /// wipes the log (the AI monitor reconstructs alerts as conditions
+    /// reappear, so a brief gap after restart is acceptable).
+    pub instance_events: RwLock<HashMap<String, InstanceEventLog>>,
+}
+
+/// Per-service ring of recent failure / restart timestamps. Pruning happens
+/// on every append: entries older than [`InstanceEventLog::WINDOW`] are
+/// dropped so the queues stay bounded to ~24h of activity regardless of
+/// service churn.
+#[derive(Debug, Default)]
+pub struct InstanceEventLog {
+    /// Timestamps of operator/watchdog-triggered restarts.
+    pub restarts: VecDeque<DateTime<Utc>>,
+    /// Timestamps of observed instance failures — non-zero exits and
+    /// individual health-check failures.
+    pub failures: VecDeque<DateTime<Utc>>,
+}
+
+impl InstanceEventLog {
+    /// Longest window any consumer needs; entries older than this are
+    /// pruned eagerly on append.
+    pub const WINDOW: Duration = Duration::hours(24);
+
+    pub fn record_restart(&mut self, now: DateTime<Utc>) {
+        self.restarts.push_back(now);
+        prune_older_than(&mut self.restarts, now - Self::WINDOW);
+    }
+
+    pub fn record_failure(&mut self, now: DateTime<Utc>) {
+        self.failures.push_back(now);
+        prune_older_than(&mut self.failures, now - Self::WINDOW);
+    }
+
+    /// Number of failure events recorded in the last `window` from `now`.
+    pub fn failures_in(&self, now: DateTime<Utc>, window: Duration) -> u64 {
+        let cutoff = now - window;
+        self.failures.iter().filter(|t| **t >= cutoff).count() as u64
+    }
+
+    /// Number of restart events recorded in the last `window` from `now`.
+    pub fn restarts_in(&self, now: DateTime<Utc>, window: Duration) -> u32 {
+        let cutoff = now - window;
+        self.restarts.iter().filter(|t| **t >= cutoff).count() as u32
+    }
+}
+
+fn prune_older_than(deque: &mut VecDeque<DateTime<Utc>>, cutoff: DateTime<Utc>) {
+    while let Some(front) = deque.front() {
+        if *front < cutoff {
+            deque.pop_front();
+        } else {
+            break;
+        }
+    }
 }
 
 pub use orca_core::api_types::LastBackupResult;
@@ -195,7 +253,26 @@ impl AppState {
             exec_sessions: RwLock::new(HashMap::new()),
             pending_deploys: RwLock::new(HashMap::new()),
             alerts: None,
+            instance_events: RwLock::new(HashMap::new()),
         }
+    }
+
+    /// Append a restart event for `service` and prune old entries.
+    /// Cheap (one `now()` + a few VecDeque ops); safe to call from hot paths.
+    pub async fn record_instance_restart(&self, service: &str) {
+        let mut log = self.instance_events.write().await;
+        log.entry(service.to_string())
+            .or_default()
+            .record_restart(Utc::now());
+    }
+
+    /// Append a failure event for `service` (non-zero exit or health-check
+    /// failure) and prune old entries.
+    pub async fn record_instance_failure(&self, service: &str) {
+        let mut log = self.instance_events.write().await;
+        log.entry(service.to_string())
+            .or_default()
+            .record_failure(Utc::now());
     }
 
     /// Set persistent store for service state.
@@ -331,5 +408,40 @@ mod tests {
             make_instance(WorkloadStatus::Failed),
         ];
         assert_eq!(state.running_count(), 2);
+    }
+
+    #[test]
+    fn instance_event_log_counts_inside_window() {
+        // Inject test data directly so we can simulate timestamps across the
+        // window boundary. Real callers go through `record_*` which always
+        // stamps with `Utc::now()` (monotonically increasing).
+        let now = Utc::now();
+        let mut log = InstanceEventLog::default();
+        log.failures.push_back(now - Duration::minutes(30));
+        log.failures.push_back(now - Duration::minutes(45));
+        log.failures.push_back(now - Duration::hours(2));
+        log.restarts.push_back(now - Duration::hours(48));
+        log.restarts.push_back(now - Duration::hours(20));
+        log.restarts.push_back(now - Duration::minutes(10));
+
+        assert_eq!(log.failures_in(now, Duration::hours(1)), 2);
+        assert_eq!(log.failures_in(now, Duration::hours(24)), 3);
+        assert_eq!(log.restarts_in(now, Duration::hours(1)), 1);
+        assert_eq!(log.restarts_in(now, Duration::hours(24)), 2);
+    }
+
+    #[test]
+    fn instance_event_log_prunes_on_append() {
+        // A real append at `now` should drop anything earlier than 24h.
+        let now = Utc::now();
+        let mut log = InstanceEventLog::default();
+        log.restarts.push_back(now - Duration::hours(48)); // pre-existing stale
+        log.restarts.push_back(now - Duration::hours(20));
+        log.record_restart(now);
+        assert_eq!(
+            log.restarts.len(),
+            2,
+            "the 48h-old entry must be pruned when a fresh `now` arrives"
+        );
     }
 }

--- a/crates/orca-control/src/watchdog.rs
+++ b/crates/orca-control/src/watchdog.rs
@@ -144,12 +144,18 @@ async fn check_and_prune(state: &AppState, service_name: &str, runtime_kind: Run
     }
 
     let mut removed = 0u32;
+    let mut failed_pruned = 0u32;
     svc.instances.retain(|inst| {
         if inst.handle.runtime_id.starts_with("remote-") {
             return true;
         }
         match inst.status {
-            WorkloadStatus::Stopped | WorkloadStatus::Failed => {
+            WorkloadStatus::Failed => {
+                removed += 1;
+                failed_pruned += 1;
+                false
+            }
+            WorkloadStatus::Stopped => {
                 removed += 1;
                 false
             }
@@ -165,6 +171,18 @@ async fn check_and_prune(state: &AppState, service_name: &str, runtime_kind: Run
             "Watchdog pruned stopped/failed instances"
         );
     }
+    // Drop the services lock before touching the event log so the two
+    // RwLocks never nest in opposite orders (lock-ordering hygiene).
+    drop(services);
+    for _ in 0..failed_pruned {
+        state.record_instance_failure(service_name).await;
+    }
+    // Re-acquire so the rest of the function (placement check + reconcile
+    // trigger) keeps working on the same service entry.
+    let services = state.services.read().await;
+    let Some(svc) = services.get(service_name) else {
+        return false;
+    };
 
     // Remote-placed services are reconciled by send_reconcile when the agent
     // connects. The watchdog must not trigger local reconcile for them —

--- a/crates/orca-core/src/config/ai.rs
+++ b/crates/orca-core/src/config/ai.rs
@@ -63,17 +63,27 @@ pub struct EmailChannelConfig {
     pub password: String,
     pub from: String,
     pub to: Vec<String>,
-    /// If true, use STARTTLS (port 587 default); else implicit TLS (port 465).
-    #[serde(default = "default_smtp_starttls")]
-    pub starttls: bool,
+    /// TLS handshake mode. Production should always use `starttls` (default).
+    /// `none` is for local dev/test against catchers like mailpit and must
+    /// not be used over an untrusted network — credentials go in cleartext.
+    #[serde(default)]
+    pub tls: SmtpTls,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SmtpTls {
+    /// STARTTLS upgrade on a plain connection (port 587 default).
+    #[default]
+    Starttls,
+    /// Implicit TLS from the start of the connection (port 465).
+    Implicit,
+    /// No TLS — plain SMTP. Local dev only.
+    None,
 }
 
 fn default_smtp_port() -> u16 {
     587
-}
-
-fn default_smtp_starttls() -> bool {
-    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/orca-core/src/config/mod.rs
+++ b/crates/orca-core/src/config/mod.rs
@@ -11,6 +11,7 @@ use crate::error::{OrcaError, Result};
 pub use crate::backup::{BackupConfig, BackupTarget};
 pub use ai::{
     AiAlertConfig, AiConfig, AlertDeliveryChannels, AutoRemediateConfig, EmailChannelConfig,
+    SmtpTls,
 };
 pub use cluster::NetworkConfig;
 pub use cluster::{


### PR DESCRIPTION
Five connected fixes to the v0.2.9 alert pipeline, discovered smoke-testing #50 / #53 / #54 against a real LiteLLM + mailpit. Each is a real bug.

## What's fixed

1. **TLS mode is three-way, not a bool.** `EmailChannelConfig.starttls: bool` collapsed two production modes (STARTTLS vs implicit TLS) and offered no plain path for local dev. Replaced with `tls: SmtpTls` enum: `starttls` (default, port 587) / `implicit` (port 465) / `none` (plain, local-dev only).
2. **Skip AUTH on plain SMTP.** Lettre refuses credentials over non-TLS by design (cleartext password). When `tls = "none"`, don't attach credentials. Mailpit accepts anonymous; production must never use `none`.
3. **Email had no Content-Type header.** Clients fell back to ASCII and mangled the LLM's smart quotes / em-dashes into mojibake. Explicit `text/plain; charset=utf-8` (and `charset=utf-8` on the HTML alternative).
4. **Multipart/alternative — plain + rendered HTML.** Plain-text email turned the LLM's markdown (tables, bold, code blocks) into literal asterisks/pipes. Now also sending an HTML version rendered via `comrak` with minimal inline CSS for tables and code blocks. Plain-text clients (mutt, ops scripts) keep getting the readable plain version.
5. **`restart_count_24h` and `error_count_1h` were hardcoded 0** in PR2's `StateContextProvider` — this silently disabled two of three heuristics in the AI monitor. Only `replicas_running == 0` fired, which masks the crash-loop case (reconciler keeps the count at 1/1).

## Real signals plumbing

- `InstanceEventLog` on `AppState` with `record_instance_restart` / `record_instance_failure` helpers. Bounded by opportunistic prune-on-append (entries past 24h drop). Memory cost = event-rate × 24h per service.
- `health.rs` records a failure on each "Health check failed" and a restart on each "Restarting after N consecutive failures".
- `watchdog.rs` records a failure for each `Failed`-state instance it prunes — the non-zero-exit signal (agreed: apps should exit non-zero on error, and the orchestrator already observes this).
- `alerts::StateContextProvider::snapshot()` reads the deques inside `1h` / `24h` windows and populates the counters with real values; the existing `restart_count_24h > 10` and `error_count_1h > 100` heuristics now fire as designed.

## Tests

- New `state::tests::instance_event_log_counts_inside_window` — verifies the windowing semantics
- New `state::tests::instance_event_log_prunes_on_append` — verifies pruning when a fresh `now` arrives
- All 72 existing orca-control unit tests still pass
- All 21 orca-ai unit + integration tests still pass

## Test plan
- [ ] CI green
- [x] Manual smoke against mailpit + LiteLLM: first email arrives with multipart structure, HTML renders LLM's tables and bold cleanly, plain part still readable
- [ ] Manual smoke: crash-looping busybox now generates a `crash-looping` alert (verify with `orca alerts list` after ~10 restart cycles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)