### PR TITLE
feat(tui): alerts view — list + drill-down + reply/dismiss/resolve (#39)

### DIFF
--- a/crates/orca-tui/src/api.rs
+++ b/crates/orca-tui/src/api.rs
@@ -10,6 +10,7 @@ pub use orca_core::api_types::{
     SecretsUsageResponse, TriggerBackupResponse, WebhookEntry, WebhookInvocation,
     WebhookInvocationsResponse, WebhookListResponse,
 };
+pub use orca_core::types::{AlertConversation, AlertSender, AlertSeverity, AlertState};
 
 /// Fetches cluster data from the orca API.
 /// Cheaply cloneable so background tasks (chat dispatch) can own a handle
@@ -418,5 +419,55 @@ impl ApiClient {
         .await?
         .error_for_status()?;
         Ok(())
+    }
+
+    /// Fetch alert conversations. Returns `Ok(None)` when the server has no
+    /// `[ai]` configured (HTTP 503) so the caller can render a friendly
+    /// "not configured" state instead of treating it as an error.
+    pub async fn alerts_list(&self, all: bool) -> anyhow::Result<Option<Vec<AlertConversation>>> {
+        let url = format!("{}/api/v1/alerts?all={}", self.base_url, all);
+        let resp = self.auth(self.client.get(&url)).send().await?;
+        if resp.status().as_u16() == 503 {
+            return Ok(None);
+        }
+        let resp = resp.error_for_status()?;
+        #[derive(Deserialize)]
+        struct ListResp {
+            alerts: Vec<AlertConversation>,
+        }
+        let body: ListResp = resp.json().await?;
+        Ok(Some(body.alerts))
+    }
+
+    pub async fn alerts_reply(&self, id: &str, message: &str) -> anyhow::Result<AlertConversation> {
+        let url = format!("{}/api/v1/alerts/{}/reply", self.base_url, id);
+        let body = serde_json::json!({ "message": message });
+        let resp = self
+            .auth(self.client.post(&url))
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn alerts_dismiss(&self, id: &str) -> anyhow::Result<AlertConversation> {
+        let url = format!("{}/api/v1/alerts/{}/dismiss", self.base_url, id);
+        let resp = self
+            .auth(self.client.post(&url))
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn alerts_resolve(&self, id: &str) -> anyhow::Result<AlertConversation> {
+        let url = format!("{}/api/v1/alerts/{}/resolve", self.base_url, id);
+        let resp = self
+            .auth(self.client.post(&url))
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(resp.json().await?)
     }
 }

--- a/crates/orca-tui/src/chat_dispatch.rs
+++ b/crates/orca-tui/src/chat_dispatch.rs
@@ -1,8 +1,9 @@
-//! Background dispatch + completion polling for the chat view.
+//! Background dispatch + completion polling for the chat view, plus the
+//! shared alert dismiss/resolve action used by both the keymap and command
+//! dispatcher.
 //!
-//! Pulled out of `lib.rs` so the chat lifecycle (send → spawn → drain) is
-//! one focused thing to read and `lib.rs` stays under the file-size
-//! ceiling.
+//! Pulled out of `lib.rs` / `keys.rs` so each stays under the file-size
+//! ceiling and the related logic is one focused thing to read.
 
 use crate::api::ApiClient;
 use crate::state::{AppState, ChatRole, ChatTaskResult, ChatTurn};
@@ -86,4 +87,46 @@ pub(crate) fn drain_chat_result(state: &mut AppState) {
             state.chat_pending = false;
         }
     }
+}
+
+/// Dismiss or resolve the currently-targeted alert. Returns `true` if any
+/// action was attempted (so the caller can suppress the default key
+/// handler). Used by both the `d` / `R` keys and `:dismiss` / `:resolve`.
+pub(crate) async fn alert_action(
+    state: &mut AppState,
+    client: &ApiClient,
+    action: AlertAction,
+) -> bool {
+    let Some(id) = crate::ui::alerts::current_alert_id(state) else {
+        return false;
+    };
+    let result = match action {
+        AlertAction::Dismiss => client.alerts_dismiss(&id).await,
+        AlertAction::Resolve => client.alerts_resolve(&id).await,
+    };
+    match result {
+        Ok(_) => {
+            state.flash(match action {
+                AlertAction::Dismiss => "Dismissed.".into(),
+                AlertAction::Resolve => "Resolved.".into(),
+            });
+            crate::refresh_alerts(client, state).await;
+        }
+        Err(e) => {
+            state.error = Some(format!(
+                "{} failed: {e}",
+                match action {
+                    AlertAction::Dismiss => "Dismiss",
+                    AlertAction::Resolve => "Resolve",
+                }
+            ));
+        }
+    }
+    true
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum AlertAction {
+    Dismiss,
+    Resolve,
 }

--- a/crates/orca-tui/src/commands.rs
+++ b/crates/orca-tui/src/commands.rs
@@ -51,11 +51,63 @@ pub async fn execute_command(state: &mut AppState, client: &ApiClient, cmd: &str
             crate::refresh_networks(client, state).await;
             state.push_view(View::Networks);
         }
+        Some("alerts") => {
+            crate::refresh_alerts(client, state).await;
+            state.selected_alert = 0;
+            state.push_view(View::Alerts);
+        }
+        Some("reply") => cmd_alert_reply(state, client, &parts).await,
+        Some("dismiss") => cmd_alert_action(state, client, "dismiss").await,
+        Some("resolve") => cmd_alert_action(state, client, "resolve").await,
         Some("webhook-add") => cmd_webhook_add(state, client, &parts).await,
         Some("webhook-edit") => cmd_webhook_edit(state, client, &parts).await,
         Some("webhook-rm") => cmd_webhook_rm(state, client, &parts).await,
         Some(other) => state.flash(format!("Unknown command: {other}")),
         None => {}
+    }
+}
+
+/// `:reply <message...>` — operator follow-up turn on the currently-targeted
+/// alert conversation. The engine appends the operator message, re-runs the
+/// LLM with the full history + current context, and the AI's response shows
+/// up on the next state refresh.
+async fn cmd_alert_reply(state: &mut AppState, client: &ApiClient, parts: &[&str]) {
+    let Some(id) = crate::ui::alerts::current_alert_id(state) else {
+        state.flash(":reply must be used from the Alerts view".into());
+        return;
+    };
+    if parts.len() < 2 {
+        state.flash("Usage: :reply <message...>".into());
+        return;
+    }
+    let message = parts[1..].join(" ");
+    match client.alerts_reply(&id, &message).await {
+        Ok(_) => {
+            state.flash("Reply sent — waiting for AI response.".into());
+            crate::refresh_alerts(client, state).await;
+        }
+        Err(e) => state.error = Some(format!("Reply failed: {e}")),
+    }
+}
+
+/// `:dismiss` / `:resolve` — same semantics as the `d` / `R` keys, but
+/// also reachable from any view via command mode.
+async fn cmd_alert_action(state: &mut AppState, client: &ApiClient, action: &str) {
+    let Some(id) = crate::ui::alerts::current_alert_id(state) else {
+        state.flash(format!(":{action} must be used from the Alerts view"));
+        return;
+    };
+    let result = match action {
+        "dismiss" => client.alerts_dismiss(&id).await,
+        "resolve" => client.alerts_resolve(&id).await,
+        _ => return,
+    };
+    match result {
+        Ok(_) => {
+            state.flash(format!("Alert {action}ed."));
+            crate::refresh_alerts(client, state).await;
+        }
+        Err(e) => state.error = Some(format!("{action} failed: {e}")),
     }
 }
 

--- a/crates/orca-tui/src/keys.rs
+++ b/crates/orca-tui/src/keys.rs
@@ -97,6 +97,14 @@ pub async fn handle_normal_key(
                 }
             }
             View::Networks => state.network_scroll = state.network_scroll.saturating_add(1),
+            View::Alerts => {
+                if !state.alerts.is_empty() && state.selected_alert + 1 < state.alerts.len() {
+                    state.selected_alert += 1;
+                }
+            }
+            View::AlertDetail { .. } => {
+                state.alert_detail_scroll = state.alert_detail_scroll.saturating_add(1);
+            }
             _ => state.next_service(),
         },
         KeyCode::Char('k') | KeyCode::Up => match state.view {
@@ -117,6 +125,14 @@ pub async fn handle_normal_key(
                 }
             }
             View::Networks => state.network_scroll = state.network_scroll.saturating_sub(1),
+            View::Alerts => {
+                if state.selected_alert > 0 {
+                    state.selected_alert -= 1;
+                }
+            }
+            View::AlertDetail { .. } => {
+                state.alert_detail_scroll = state.alert_detail_scroll.saturating_sub(1);
+            }
             _ => state.prev_service(),
         },
         KeyCode::Char('g') => match state.view {
@@ -125,6 +141,8 @@ pub async fn handle_normal_key(
             View::BackupSnapshots { .. } => state.selected_backup_snapshot = 0,
             View::Webhooks => state.selected_webhook = 0,
             View::Networks => state.network_scroll = 0,
+            View::Alerts => state.selected_alert = 0,
+            View::AlertDetail { .. } => state.alert_detail_scroll = 0,
             _ => state.selected_service = 0,
         },
         KeyCode::Char('G') => match state.view {
@@ -150,6 +168,14 @@ pub async fn handle_normal_key(
                 // Snap to last line; render clamps to the visible window.
                 let total = super::ui::networks::rendered_line_count(state);
                 state.network_scroll = total.saturating_sub(1);
+            }
+            View::Alerts => {
+                if !state.alerts.is_empty() {
+                    state.selected_alert = state.alerts.len() - 1;
+                }
+            }
+            View::AlertDetail { .. } => {
+                state.alert_detail_scroll = state.alert_detail_scroll.saturating_add(100);
             }
             _ => {
                 let len = state.filtered_services().len();
@@ -192,6 +218,9 @@ pub async fn handle_normal_key(
                     super::refresh_secrets_usage(client, state).await
                 }
                 View::Networks => super::refresh_networks(client, state).await,
+                View::Alerts | View::AlertDetail { .. } => {
+                    super::refresh_alerts(client, state).await;
+                }
                 _ => {}
             }
             *last_refresh = tokio::time::Instant::now();
@@ -235,6 +264,49 @@ pub async fn handle_normal_key(
             state.push_view(View::Networks);
         }
         KeyCode::Char('6') => {}
+        KeyCode::Char('7') if !matches!(state.view, View::Alerts) => {
+            super::refresh_alerts(client, state).await;
+            state.selected_alert = 0;
+            state.push_view(View::Alerts);
+        }
+        KeyCode::Char('7') => {}
+        // Toggle active vs all in the Alerts view. The `a` key is already
+        // used by Webhooks for "add"; the matches!() guard keeps them apart.
+        KeyCode::Char('a') if matches!(state.view, View::Alerts) => {
+            state.alerts_show_all = !state.alerts_show_all;
+            super::refresh_alerts(client, state).await;
+            state.selected_alert = 0;
+        }
+        // Dismiss the selected alert (list) or the current one (detail).
+        // Lowercase `d` to match conventions; `R` (capital) resolves.
+        KeyCode::Char('d')
+            if matches!(state.view, View::Alerts | View::AlertDetail { .. })
+                && crate::ui::alerts::current_alert_id(state).is_some() =>
+        {
+            if let Some(id) = crate::ui::alerts::current_alert_id(state) {
+                match client.alerts_dismiss(&id).await {
+                    Ok(_) => {
+                        state.flash("Dismissed.".into());
+                        super::refresh_alerts(client, state).await;
+                    }
+                    Err(e) => state.error = Some(format!("Dismiss failed: {e}")),
+                }
+            }
+        }
+        KeyCode::Char('R')
+            if matches!(state.view, View::Alerts | View::AlertDetail { .. })
+                && crate::ui::alerts::current_alert_id(state).is_some() =>
+        {
+            if let Some(id) = crate::ui::alerts::current_alert_id(state) {
+                match client.alerts_resolve(&id).await {
+                    Ok(_) => {
+                        state.flash("Resolved.".into());
+                        super::refresh_alerts(client, state).await;
+                    }
+                    Err(e) => state.error = Some(format!("Resolve failed: {e}")),
+                }
+            }
+        }
         // `a` adds a webhook (claimed only in the Webhooks view to avoid
         // colliding with future global shortcuts).
         KeyCode::Char('a') if matches!(state.view, View::Webhooks) => {
@@ -385,6 +457,13 @@ async fn handle_enter(state: &mut AppState, client: &ApiClient) {
             if let Some(u) = crate::ui::secrets::selected_key(state) {
                 let key = u.key.clone();
                 state.push_view(View::SecretRefs { key });
+            }
+        }
+        View::Alerts => {
+            if let Some(a) = state.alerts.get(state.selected_alert) {
+                let id = a.id.to_string();
+                state.alert_detail_scroll = 0;
+                state.push_view(View::AlertDetail { id });
             }
         }
         _ => {}

--- a/crates/orca-tui/src/keys.rs
+++ b/crates/orca-tui/src/keys.rs
@@ -277,35 +277,24 @@ pub async fn handle_normal_key(
             super::refresh_alerts(client, state).await;
             state.selected_alert = 0;
         }
-        // Dismiss the selected alert (list) or the current one (detail).
-        // Lowercase `d` to match conventions; `R` (capital) resolves.
-        KeyCode::Char('d')
-            if matches!(state.view, View::Alerts | View::AlertDetail { .. })
-                && crate::ui::alerts::current_alert_id(state).is_some() =>
-        {
-            if let Some(id) = crate::ui::alerts::current_alert_id(state) {
-                match client.alerts_dismiss(&id).await {
-                    Ok(_) => {
-                        state.flash("Dismissed.".into());
-                        super::refresh_alerts(client, state).await;
-                    }
-                    Err(e) => state.error = Some(format!("Dismiss failed: {e}")),
-                }
-            }
+        // Dismiss / resolve the currently-targeted alert (selected row in
+        // list, or the conversation in detail). Lowercase `d` for dismiss,
+        // capital `R` for resolve — same convention as everywhere else.
+        KeyCode::Char('d') if matches!(state.view, View::Alerts | View::AlertDetail { .. }) => {
+            crate::chat_dispatch::alert_action(
+                state,
+                client,
+                crate::chat_dispatch::AlertAction::Dismiss,
+            )
+            .await;
         }
-        KeyCode::Char('R')
-            if matches!(state.view, View::Alerts | View::AlertDetail { .. })
-                && crate::ui::alerts::current_alert_id(state).is_some() =>
-        {
-            if let Some(id) = crate::ui::alerts::current_alert_id(state) {
-                match client.alerts_resolve(&id).await {
-                    Ok(_) => {
-                        state.flash("Resolved.".into());
-                        super::refresh_alerts(client, state).await;
-                    }
-                    Err(e) => state.error = Some(format!("Resolve failed: {e}")),
-                }
-            }
+        KeyCode::Char('R') if matches!(state.view, View::Alerts | View::AlertDetail { .. }) => {
+            crate::chat_dispatch::alert_action(
+                state,
+                client,
+                crate::chat_dispatch::AlertAction::Resolve,
+            )
+            .await;
         }
         // `a` adds a webhook (claimed only in the Webhooks view to avoid
         // colliding with future global shortcuts).

--- a/crates/orca-tui/src/lib.rs
+++ b/crates/orca-tui/src/lib.rs
@@ -282,6 +282,26 @@ async fn refresh_networks(client: &ApiClient, state: &mut AppState) {
     }
 }
 
+/// Fetch alerts via the control plane. 503 (no `[ai]` configured) sets the
+/// `alerts_unavailable` flag so the view shows a friendly message. Selection
+/// is clamped to the new list size.
+pub(crate) async fn refresh_alerts(client: &ApiClient, state: &mut AppState) {
+    match client.alerts_list(state.alerts_show_all).await {
+        Ok(Some(alerts)) => {
+            state.alerts = alerts;
+            state.alerts_unavailable = false;
+            if state.selected_alert >= state.alerts.len() {
+                state.selected_alert = state.alerts.len().saturating_sub(1);
+            }
+        }
+        Ok(None) => {
+            state.alerts = Vec::new();
+            state.alerts_unavailable = true;
+        }
+        Err(e) => state.error = Some(format!("Alerts fetch failed: {e}")),
+    }
+}
+
 /// Fetch the secrets organizer view (key → referencing-services index).
 /// Refreshed on entry and on `r`; never polled. Also called after
 /// `:set`/`:rm` flows that may change the visible counts.

--- a/crates/orca-tui/src/state.rs
+++ b/crates/orca-tui/src/state.rs
@@ -44,6 +44,13 @@ pub enum View {
         key: String,
     },
     Networks,
+    /// AI alert conversations (`/api/v1/alerts`). Acts as a list view; press
+    /// Enter on a row to drill down to [`View::AlertDetail`].
+    Alerts,
+    /// Drill-down: the full transcript for one alert conversation.
+    AlertDetail {
+        id: String,
+    },
 }
 
 /// Input mode for the TUI.
@@ -146,6 +153,19 @@ pub struct AppState {
     /// a tokio task so the event loop stays responsive while the LLM is
     /// thinking. `None` between requests.
     pub chat_result_rx: Option<tokio::sync::mpsc::UnboundedReceiver<ChatTaskResult>>,
+    /// Cached alert conversations from `GET /api/v1/alerts`. Polled on the
+    /// regular status tick when the view is open; otherwise stale.
+    pub alerts: Vec<crate::api::AlertConversation>,
+    /// Selected row in the Alerts list.
+    pub selected_alert: usize,
+    /// Scroll offset for the AlertDetail conversation view.
+    pub alert_detail_scroll: usize,
+    /// Whether the Alerts list includes resolved/dismissed/remediated rows
+    /// (toggled with `a` for "show all").
+    pub alerts_show_all: bool,
+    /// True when the alerts API returned 503 (no `[ai]` configured). Lets
+    /// the view show a friendly message instead of an empty table.
+    pub alerts_unavailable: bool,
 }
 
 /// Result of a background chat dispatch — handed back to the event loop
@@ -226,6 +246,11 @@ impl AppState {
             chat_pending: false,
             chat_unavailable: false,
             chat_result_rx: None,
+            alerts: Vec::new(),
+            selected_alert: 0,
+            alert_detail_scroll: 0,
+            alerts_show_all: false,
+            alerts_unavailable: false,
         }
     }
 
@@ -420,6 +445,8 @@ impl AppState {
             View::WebhookInvocations { .. } => "Invocations",
             View::SecretRefs { .. } => "Secret Refs",
             View::Networks => "Networks",
+            View::Alerts => "Alerts",
+            View::AlertDetail { .. } => "Alert Detail",
         }
     }
 }

--- a/crates/orca-tui/src/ui.rs
+++ b/crates/orca-tui/src/ui.rs
@@ -1,5 +1,6 @@
 //! TUI rendering — k9s-style full-screen views with header/footer chrome.
 
+pub mod alerts;
 pub mod backup_snapshots;
 pub mod backups;
 pub mod chat;
@@ -78,6 +79,8 @@ fn draw_content(f: &mut Frame, area: Rect, state: &AppState) {
         View::SecretRefs { key } => secret_refs::draw_secret_refs(f, area, state, key),
         View::Networks => networks::draw_networks(f, area, state),
         View::Chat => chat::draw_chat(f, area, state),
+        View::Alerts => alerts::draw_alerts(f, area, state),
+        View::AlertDetail { id } => alerts::draw_alert_detail(f, area, state, id),
     }
 }
 
@@ -187,6 +190,8 @@ fn draw_breadcrumb(f: &mut Frame, area: Rect, state: &AppState) {
         View::SecretRefs { key } => format!("Secrets > {key} > Refs"),
         View::Networks => "Networks".to_string(),
         View::Chat => "Chat".to_string(),
+        View::Alerts => "Alerts".to_string(),
+        View::AlertDetail { id } => format!("Alerts > {}", &id[..8.min(id.len())]),
     };
     let line = Line::from(vec![
         Span::styled(" ", Style::default()),
@@ -290,6 +295,8 @@ fn draw_footer(f: &mut Frame, area: Rect, state: &AppState) {
         }
         View::WebhookInvocations { .. } => "Esc:back r:refresh ?:help",
         View::Chat => "type:ask Enter:send PgUp/PgDn:scroll /cmd:jump 0-6:views Esc:clear ?:help",
+        View::Alerts => "Esc:back j/k:select ↵:detail a:all r:refresh d:dismiss R:resolve ?:help",
+        View::AlertDetail { .. } => "Esc:back j/k:scroll d:dismiss R:resolve :reply ?:help",
     };
     spans.push(Span::styled(keys, dim));
 

--- a/crates/orca-tui/src/ui/alerts.rs
+++ b/crates/orca-tui/src/ui/alerts.rs
@@ -1,0 +1,275 @@
+//! Alerts view — list + drill-down for AI alert conversations.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Row, Table, Wrap};
+
+use crate::api::{AlertSender, AlertSeverity, AlertState};
+use crate::state::AppState;
+
+/// Top-level alerts table.
+pub fn draw_alerts(f: &mut Frame, area: Rect, state: &AppState) {
+    if state.alerts_unavailable {
+        let block = Block::default()
+            .title(" Alerts (unavailable) ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Yellow));
+        let text = "  AI alerts are not configured.\n\n  Add an [ai] block + [ai.alerts.channels.*] to cluster.toml, then restart the server.";
+        f.render_widget(Paragraph::new(text).block(block), area);
+        return;
+    }
+    if state.alerts.is_empty() {
+        let scope = if state.alerts_show_all {
+            "all"
+        } else {
+            "active"
+        };
+        let block = Block::default()
+            .title(format!(" Alerts ({scope}: 0) "))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan));
+        let text = "  No conversations.\n\n  Press 'a' to toggle showing dismissed/resolved.";
+        f.render_widget(Paragraph::new(text).block(block), area);
+        return;
+    }
+
+    let header = Row::new(vec![
+        "SEVERITY", "SERVICE", "STATE", "AGE", "TURNS", "LATEST",
+    ])
+    .style(Style::default().add_modifier(Modifier::BOLD));
+
+    let rows: Vec<Row> = state
+        .alerts
+        .iter()
+        .enumerate()
+        .map(|(i, a)| {
+            let selected = i == state.selected_alert;
+            let base = if selected {
+                Style::default()
+                    .bg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            let sev = severity_label(a.severity);
+            let sev_style = base.fg(severity_color(a.severity));
+            let state_style = base.fg(state_color(a.state));
+            let latest = a
+                .messages
+                .last()
+                .map(|m| truncate(&m.content.replace('\n', " "), 60))
+                .unwrap_or_default();
+            let age = format_age(a.started_at);
+            Row::new(vec![
+                Span::styled(sev.to_string(), sev_style),
+                Span::styled(a.service.clone(), base),
+                Span::styled(format!("{:?}", a.state).to_lowercase(), state_style),
+                Span::styled(age, base),
+                Span::styled(a.messages.len().to_string(), base),
+                Span::styled(latest, base),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(10),
+        Constraint::Min(14),
+        Constraint::Length(15),
+        Constraint::Length(8),
+        Constraint::Length(6),
+        Constraint::Min(30),
+    ];
+
+    let scope = if state.alerts_show_all {
+        "all"
+    } else {
+        "active"
+    };
+    let critical = state
+        .alerts
+        .iter()
+        .filter(|a| a.severity == AlertSeverity::Critical)
+        .count();
+    let title = if critical > 0 {
+        format!(
+            " Alerts ({scope}: {}, {critical} critical) ",
+            state.alerts.len()
+        )
+    } else {
+        format!(" Alerts ({scope}: {}) ", state.alerts.len())
+    };
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let table = Table::new(rows, widths).header(header).block(block);
+    f.render_widget(table, area);
+}
+
+/// Drill-down view for one conversation.
+pub fn draw_alert_detail(f: &mut Frame, area: Rect, state: &AppState, id: &str) {
+    let Some(conv) = state.alerts.iter().find(|a| a.id.to_string() == id) else {
+        let block = Block::default()
+            .title(" Alert Detail (not found) ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Yellow));
+        f.render_widget(
+            Paragraph::new("  Alert not in the current list. Press Esc to go back.").block(block),
+            area,
+        );
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(vec![
+        Span::styled("Service: ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(conv.service.clone()),
+        Span::raw("  "),
+        Span::styled("Severity: ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::styled(
+            severity_label(conv.severity),
+            Style::default().fg(severity_color(conv.severity)),
+        ),
+        Span::raw("  "),
+        Span::styled("State: ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::styled(
+            format!("{:?}", conv.state).to_lowercase(),
+            Style::default().fg(state_color(conv.state)),
+        ),
+    ]));
+    lines.push(Line::from(format!(
+        "Started: {}   ID: {}",
+        conv.started_at.to_rfc3339(),
+        conv.id
+    )));
+    lines.push(Line::from(""));
+
+    for msg in &conv.messages {
+        let (label, color) = match msg.sender {
+            AlertSender::Orca => ("orca", Color::Cyan),
+            AlertSender::Operator => ("you", Color::Green),
+            AlertSender::System => ("system", Color::DarkGray),
+        };
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("[{}] ", msg.timestamp.format("%H:%M:%S")),
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::styled(
+                format!("{label}: "),
+                Style::default().fg(color).add_modifier(Modifier::BOLD),
+            ),
+        ]));
+        for content_line in msg.content.lines() {
+            lines.push(Line::from(format!("  {content_line}")));
+        }
+        if let Some(cmd) = &msg.suggested_command {
+            lines.push(Line::from(vec![
+                Span::styled("    fix: ", Style::default().fg(Color::Yellow)),
+                Span::styled(cmd.clone(), Style::default().fg(Color::Yellow)),
+            ]));
+        }
+        lines.push(Line::from(""));
+    }
+
+    let total = lines.len();
+    let block = Block::default()
+        .title(format!(
+            " Alert: {} — {} [{}/{}] ",
+            conv.service,
+            severity_label(conv.severity),
+            state.alert_detail_scroll + 1,
+            total.max(1)
+        ))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let para = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false })
+        .scroll((state.alert_detail_scroll as u16, 0));
+    f.render_widget(para, area);
+}
+
+fn severity_label(s: AlertSeverity) -> &'static str {
+    match s {
+        AlertSeverity::Critical => "CRITICAL",
+        AlertSeverity::Warning => "WARNING",
+        AlertSeverity::Info => "INFO",
+    }
+}
+
+fn severity_color(s: AlertSeverity) -> Color {
+    match s {
+        AlertSeverity::Critical => Color::Red,
+        AlertSeverity::Warning => Color::Yellow,
+        AlertSeverity::Info => Color::Cyan,
+    }
+}
+
+fn state_color(s: AlertState) -> Color {
+    match s {
+        AlertState::Investigating => Color::Yellow,
+        AlertState::AwaitingAction => Color::Magenta,
+        AlertState::Acknowledged => Color::Cyan,
+        AlertState::Remediated | AlertState::Resolved => Color::Green,
+        AlertState::Dismissed => Color::DarkGray,
+    }
+}
+
+fn format_age(started: chrono::DateTime<chrono::Utc>) -> String {
+    let secs = (chrono::Utc::now() - started).num_seconds().max(0);
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else if secs < 86_400 {
+        format!("{}h", secs / 3600)
+    } else {
+        format!("{}d", secs / 86_400)
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    }
+}
+
+/// Resolve the alert ID the current view targets: drill-down uses its path
+/// id; list view uses the selected row. `None` outside those views or when
+/// the list is empty. Used by both keymap (d / R / Enter) and command-mode
+/// handlers (`:reply`, `:dismiss`, `:resolve`).
+pub fn current_alert_id(state: &AppState) -> Option<String> {
+    use crate::state::View;
+    match &state.view {
+        View::AlertDetail { id } => Some(id.clone()),
+        View::Alerts => state
+            .alerts
+            .get(state.selected_alert)
+            .map(|a| a.id.to_string()),
+        _ => None,
+    }
+}
+
+/// Count of critical alerts currently active — used by the header badge.
+pub fn critical_count(state: &AppState) -> usize {
+    state
+        .alerts
+        .iter()
+        .filter(|a| {
+            a.severity == AlertSeverity::Critical
+                && !matches!(
+                    a.state,
+                    AlertState::Resolved | AlertState::Dismissed | AlertState::Remediated
+                )
+        })
+        .count()
+}


### PR DESCRIPTION
Closes #39. Wires the `/api/v1/alerts/*` surface from #53 into the dashboard.

## What lands

**New views**
- `View::Alerts` (tab `7` or `:alerts`) — table of conversations: severity / service / state / age / turn count / latest message. Severity- and state-coloured. Title shows critical count as a badge.
- `View::AlertDetail` (Enter from the list) — full transcript with timestamps, sender labels (orca / you / system), and suggested-fix lines highlighted yellow. j/k/g/G scrolls; position shown as `[N/total]`.

**Keymap**
- `7` opens the list; `Enter` drills in; `Esc` pops back.
- `a` toggles active vs all conversations.
- `d` dismisses, `R` (capital) resolves — works from list or detail.
- `r` (refresh) now re-fetches alerts when the view is open (was silently a no-op).
- `j/k/g/G` navigation in both views.

**Command mode**
- `:alerts` to open from anywhere.
- `:reply <message...>` sends an operator turn; AI's response appears on next refresh. Was advertised in the footer but never wired — fixed.
- `:dismiss` / `:resolve` as command-mode aliases.

**State + API**
- `ApiClient` gets `alerts_list` (returns `Option` to expose the 503 "no `[ai]`" case cleanly), `alerts_reply`, `alerts_dismiss`, `alerts_resolve`.
- `AppState` gets `alerts`, `selected_alert`, `alert_detail_scroll`, `alerts_show_all`, `alerts_unavailable`.
- "AI alerts are not configured" placeholder when the server returns 503.

## Manual smoke verified

Against the local LiteLLM + mailpit smoke cluster:
- list shows alerts opened by the AI monitor (smoke-dead, smoke-crash)
- drill-down renders the full LLM diagnosis cleanly
- `:reply what about memory limits` round-trips through the engine; AI's follow-up appears on the next refresh
- `d` / `R` transitions persist via the API

## Test plan
- [ ] CI green
- [ ] After merge, optional follow-up: move the global 2s refresh off the event-loop hot path so heavy clusters don't briefly stutter the UI (called out by user during smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)