### PR TITLE
feat(tui): AI chat landing page (#38)

### DIFF
--- a/crates/orca-ai/src/ops.rs
+++ b/crates/orca-ai/src/ops.rs
@@ -105,6 +105,66 @@ pub async fn ask(
     Ok(response.content)
 }
 
+/// One turn in a chat transcript. The TUI / API caller owns the history;
+/// the backend just passes it through to the LLM.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ChatTurn {
+    /// "user" or "assistant".
+    pub role: String,
+    pub content: String,
+}
+
+/// Multi-turn chat with cluster context as the system prompt.
+///
+/// `history` is the prior transcript (oldest first). `question` is the new
+/// user message. Cluster status/logs are merged into the system prompt
+/// so the LLM grounds answers in real state.
+pub async fn chat(
+    config: &AiConfig,
+    history: &[ChatTurn],
+    question: &str,
+    status_text: &str,
+    logs_text: &str,
+) -> anyhow::Result<String> {
+    let backend = build_backend(config)?;
+
+    let system = format!(
+        "{ASK_SYSTEM_PROMPT}\n\n## Current cluster status\n{status}\n\n## Recent logs\n{logs}",
+        status = if status_text.is_empty() {
+            "(no status available)"
+        } else {
+            status_text
+        },
+        logs = if logs_text.is_empty() {
+            "(no recent logs)"
+        } else {
+            logs_text
+        },
+    );
+
+    let mut messages = vec![ChatMessage {
+        role: Role::System,
+        content: system,
+    }];
+    for turn in history {
+        let role = match turn.role.as_str() {
+            "assistant" => Role::Assistant,
+            _ => Role::User,
+        };
+        messages.push(ChatMessage {
+            role,
+            content: turn.content.clone(),
+        });
+    }
+    messages.push(ChatMessage {
+        role: Role::User,
+        content: question.to_string(),
+    });
+
+    let response = backend.chat(&messages).await?;
+    Ok(response.content)
+}
+
 /// Generate a service.toml configuration from a natural language description.
 pub async fn generate(config: &AiConfig, description: &str) -> anyhow::Result<String> {
     let backend = build_backend(config)?;
@@ -188,5 +248,33 @@ mod tests {
         let input = "[[service]]\nname = \"pg\"";
         let result = extract_toml_block(input);
         assert_eq!(result, input);
+    }
+
+    #[test]
+    fn chat_turn_serde_round_trip() {
+        // Pin the wire format the TUI's `/api/v1/ask` client speaks: a
+        // lowercase string `role` and a `content` string. The same shape is
+        // accepted server-side and forwarded into the LLM messages list.
+        let turn = ChatTurn {
+            role: "user".into(),
+            content: "why is api down?".into(),
+        };
+        let json = serde_json::to_string(&turn).unwrap();
+        assert_eq!(json, r#"{"role":"user","content":"why is api down?"}"#);
+        let back: ChatTurn = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.role, "user");
+        assert_eq!(back.content, "why is api down?");
+    }
+
+    #[test]
+    fn chat_turn_unknown_role_is_treated_as_user() {
+        // Defensive: if a caller stuffs a typo into `role`, we shouldn't
+        // panic — `chat()` maps anything that isn't "assistant" to
+        // `Role::User`, so the LLM still gets a coherent transcript.
+        // (Verified at the mapping site; this test pins the parse step.)
+        let json = r#"{"role":"orca","content":"hi"}"#;
+        let parsed: ChatTurn = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.role, "orca"); // pass-through, mapping happens later
+        assert_eq!(parsed.content, "hi");
     }
 }

--- a/crates/orca-control/src/api/handlers/ask.rs
+++ b/crates/orca-control/src/api/handlers/ask.rs
@@ -1,0 +1,103 @@
+//! `POST /api/v1/ask` — server-mediated chat with the AI.
+//!
+//! Lets the TUI's chat landing page (#38) drive an `orca ask`-style
+//! conversation without needing local access to `cluster.toml` or the
+//! secrets store. The server holds the LLM credentials and re-builds the
+//! cluster context from `AppState` on every turn so answers track live
+//! cluster state.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+
+use orca_ai::ops::{ChatTurn, chat};
+use orca_core::types::WorkloadStatus;
+
+use crate::state::AppState;
+
+#[derive(Deserialize)]
+pub(crate) struct AskRequest {
+    pub question: String,
+    #[serde(default)]
+    pub history: Vec<ChatTurn>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct AskResponse {
+    pub response: String,
+}
+
+pub(crate) async fn ask(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<AskRequest>,
+) -> impl IntoResponse {
+    let Some(ai) = state.cluster_config.ai.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "AI is not configured; add an [ai] block to cluster.toml"
+            })),
+        )
+            .into_response();
+    };
+
+    if req.question.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "question must not be empty" })),
+        )
+            .into_response();
+    }
+
+    let status_text = render_status_text(&state).await;
+    // Logs context is omitted for the chat path — the response cycle is
+    // already 2-10s, and tailing every service's logs would multiply that.
+    // Operators can ask "what's in the api logs?" → the LLM hints at
+    // `orca logs api` and the operator runs it themselves.
+    match chat(ai, &req.history, &req.question, &status_text, "").await {
+        Ok(response) => Json(AskResponse { response }).into_response(),
+        Err(e) => (
+            StatusCode::BAD_GATEWAY,
+            Json(serde_json::json!({ "error": format!("AI request failed: {e}") })),
+        )
+            .into_response(),
+    }
+}
+
+/// Render the live service + node state as a compact text block for the
+/// LLM system prompt. Keeps the prompt budget small so we don't blow past
+/// the model's context with redundant info.
+async fn render_status_text(state: &AppState) -> String {
+    let services = state.services.read().await;
+    let nodes = state.registered_nodes.read().await;
+    let mut out = String::with_capacity(1024);
+    out.push_str(&format!(
+        "Cluster: {}\nNodes: {}\n\n",
+        state.cluster_config.cluster.name,
+        nodes.len()
+    ));
+    out.push_str("Services:\n");
+    for svc in services.values() {
+        let running = svc
+            .instances
+            .iter()
+            .filter(|i| matches!(i.status, WorkloadStatus::Running))
+            .count();
+        out.push_str(&format!(
+            "- {} [{}/{}] desired={} ",
+            svc.config.name, running, svc.desired_replicas, svc.desired_replicas
+        ));
+        if let Some(img) = &svc.config.image {
+            out.push_str(&format!("image={img} "));
+        }
+        if let Some(p) = svc.config.port {
+            out.push_str(&format!("port={p}"));
+        }
+        out.push('\n');
+    }
+    out
+}

--- a/crates/orca-control/src/api/handlers/mod.rs
+++ b/crates/orca-control/src/api/handlers/mod.rs
@@ -12,6 +12,7 @@ use crate::reconciler;
 use crate::state::AppState;
 
 pub(crate) mod alerts;
+pub(crate) mod ask;
 pub(crate) mod exec;
 mod ops;
 pub(crate) mod secrets;

--- a/crates/orca-control/src/api/mod.rs
+++ b/crates/orca-control/src/api/mod.rs
@@ -41,6 +41,7 @@ pub fn router(state: Arc<AppState>) -> Router {
             post(handlers::trigger_cluster_backup),
         )
         .route("/api/v1/cluster/networks", get(handlers::cluster_networks))
+        .route("/api/v1/ask", post(handlers::ask::ask))
         .route("/api/v1/alerts", get(handlers::alerts::list))
         .route("/api/v1/alerts/{id}", get(handlers::alerts::view))
         .route("/api/v1/alerts/{id}/reply", post(handlers::alerts::reply))

--- a/crates/orca-control/tests/ask_test.rs
+++ b/crates/orca-control/tests/ask_test.rs
@@ -1,0 +1,108 @@
+//! Integration tests for `POST /api/v1/ask`.
+//!
+//! Covers the surfaces that don't need a real LLM: the 503 path when
+//! `[ai]` is unconfigured, the 400 path on empty input, and the contract
+//! between the TUI chat client and the server's response shape.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+
+use orca_control::api::router;
+use orca_control::state::AppState;
+use orca_core::config::{AiConfig, ClusterConfig, ClusterMeta};
+use orca_core::testing::MockRuntime;
+
+fn cluster_config_no_ai() -> ClusterConfig {
+    ClusterConfig {
+        cluster: ClusterMeta {
+            name: "test-cluster".to_string(),
+            api_port: 0,
+            grpc_port: 0,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn cluster_config_with_ai() -> ClusterConfig {
+    let mut cfg = cluster_config_no_ai();
+    cfg.ai = Some(AiConfig {
+        provider: "ollama".into(),
+        endpoint: Some("http://127.0.0.1:1".into()), // intentionally unreachable
+        model: Some("test-model".into()),
+        api_key: None,
+        alerts: None,
+        auto_remediate: None,
+    });
+    cfg
+}
+
+fn build_state(cfg: ClusterConfig) -> Arc<AppState> {
+    let runtime = Arc::new(MockRuntime::with_host_port(9000));
+    Arc::new(AppState::new(
+        cfg,
+        runtime,
+        None,
+        Arc::new(RwLock::new(std::collections::HashMap::new())),
+        Arc::new(RwLock::new(Vec::new())),
+    ))
+}
+
+#[tokio::test]
+async fn ask_returns_503_when_ai_is_not_configured() {
+    let app = router(build_state(cluster_config_no_ai()));
+    let req = Request::post("/api/v1/ask")
+        .header("content-type", "application/json")
+        .body(Body::from(r#"{"question":"why?"}"#))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("AI is not configured"),
+        "503 body must explain how to fix the config — got {json}"
+    );
+}
+
+#[tokio::test]
+async fn ask_returns_400_on_empty_question() {
+    let app = router(build_state(cluster_config_with_ai()));
+    let req = Request::post("/api/v1/ask")
+        .header("content-type", "application/json")
+        .body(Body::from(r#"{"question":"   "}"#))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn ask_returns_400_when_history_missing_role_field() {
+    let app = router(build_state(cluster_config_with_ai()));
+    // History entries must have role + content; bad shape fails deserialization
+    // before the handler runs, surfacing as 4xx via axum's JSON extractor.
+    let req = Request::post("/api/v1/ask")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            r#"{"question":"hi","history":[{"content":"missing role"}]}"#,
+        ))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert!(
+        resp.status().is_client_error(),
+        "malformed history should produce a 4xx, got {}",
+        resp.status()
+    );
+}

--- a/crates/orca-tui/src/api.rs
+++ b/crates/orca-tui/src/api.rs
@@ -12,6 +12,9 @@ pub use orca_core::api_types::{
 };
 
 /// Fetches cluster data from the orca API.
+/// Cheaply cloneable so background tasks (chat dispatch) can own a handle
+/// without sharing references with the event loop.
+#[derive(Clone)]
 pub struct ApiClient {
     base_url: String,
     client: reqwest::Client,
@@ -233,6 +236,36 @@ impl ApiClient {
 
     /// Fetch the cluster networks dashboard: per-node `orca-*` Docker bridge
     /// listing plus the master's public-edge route table.
+    /// POST a chat turn to `/api/v1/ask`. Returns `Ok(None)` when the server
+    /// has no `[ai]` configured (503), so the caller renders a placeholder
+    /// rather than treating it as a hard error.
+    pub async fn ask(
+        &self,
+        question: &str,
+        history: &[(String, String)],
+    ) -> anyhow::Result<Option<String>> {
+        let url = format!("{}/api/v1/ask", self.base_url);
+        let history_json: Vec<serde_json::Value> = history
+            .iter()
+            .map(|(role, content)| serde_json::json!({ "role": role, "content": content }))
+            .collect();
+        let body = serde_json::json!({
+            "question": question,
+            "history": history_json,
+        });
+        let resp = self.auth(self.client.post(&url)).json(&body).send().await?;
+        if resp.status().as_u16() == 503 {
+            return Ok(None);
+        }
+        let resp = resp.error_for_status()?;
+        #[derive(Deserialize)]
+        struct AskResp {
+            response: String,
+        }
+        let body: AskResp = resp.json().await?;
+        Ok(Some(body.response))
+    }
+
     pub async fn cluster_networks(&self) -> anyhow::Result<ClusterNetworksResponse> {
         let resp = self
             .auth(

--- a/crates/orca-tui/src/chat_dispatch.rs
+++ b/crates/orca-tui/src/chat_dispatch.rs
@@ -1,0 +1,89 @@
+//! Background dispatch + completion polling for the chat view.
+//!
+//! Pulled out of `lib.rs` so the chat lifecycle (send → spawn → drain) is
+//! one focused thing to read and `lib.rs` stays under the file-size
+//! ceiling.
+
+use crate::api::ApiClient;
+use crate::state::{AppState, ChatRole, ChatTaskResult, ChatTurn};
+
+/// Send a chat turn to `/api/v1/ask`. Appends the user turn immediately,
+/// then dispatches the LLM call as a background tokio task. The result
+/// lands on `state.chat_result_rx`; [`drain_chat_result`] picks it up on
+/// the next event-loop tick — so the TUI stays responsive while the AI
+/// is thinking.
+pub(crate) fn send_chat_message(state: &mut AppState, client: &ApiClient, question: String) {
+    let history: Vec<(String, String)> = state
+        .chat
+        .iter()
+        .map(|t| {
+            let role = match t.role {
+                ChatRole::User => "user",
+                ChatRole::Assistant => "assistant",
+            };
+            (role.to_string(), t.content.clone())
+        })
+        .collect();
+    state.chat.push(ChatTurn {
+        role: ChatRole::User,
+        content: question.clone(),
+    });
+    // Sending pins the view to the latest exchange — every chat client
+    // works this way. Manual scrolling resumes after the reply lands.
+    state.chat_scroll = 0;
+    state.chat_pending = true;
+
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    state.chat_result_rx = Some(rx);
+    let client = client.clone();
+    tokio::spawn(async move {
+        let result = match client.ask(&question, &history).await {
+            Ok(Some(reply)) => ChatTaskResult::Reply(reply),
+            Ok(None) => ChatTaskResult::Unavailable,
+            Err(e) => ChatTaskResult::Error(format!("{e}")),
+        };
+        // Receiver may have been dropped if the user quit; ignore.
+        let _ = tx.send(result);
+    });
+}
+
+/// Poll the background chat task — called every event-loop tick. Cheap
+/// when nothing is pending. On completion, appends the assistant turn
+/// (or an error turn) and clears the spinner state.
+pub(crate) fn drain_chat_result(state: &mut AppState) {
+    let Some(rx) = state.chat_result_rx.as_mut() else {
+        return;
+    };
+    match rx.try_recv() {
+        Ok(result) => {
+            state.chat_result_rx = None;
+            state.chat_pending = false;
+            let turn = match result {
+                ChatTaskResult::Reply(r) => {
+                    state.chat_unavailable = false;
+                    ChatTurn {
+                        role: ChatRole::Assistant,
+                        content: r,
+                    }
+                }
+                ChatTaskResult::Unavailable => {
+                    state.chat_unavailable = true;
+                    ChatTurn {
+                        role: ChatRole::Assistant,
+                        content: "AI is not configured on this server (HTTP 503). Add an [ai] block to cluster.toml and restart.".into(),
+                    }
+                }
+                ChatTaskResult::Error(e) => ChatTurn {
+                    role: ChatRole::Assistant,
+                    content: format!("(error: {e})"),
+                },
+            };
+            state.chat.push(turn);
+        }
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {}
+        Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+            state.chat_result_rx = None;
+            state.chat_pending = false;
+        }
+    }
+}

--- a/crates/orca-tui/src/chat_input.rs
+++ b/crates/orca-tui/src/chat_input.rs
@@ -1,0 +1,220 @@
+//! Chat-view input handling — `handle_chat_key` + slash-command dispatcher.
+//!
+//! Kept in its own module so `keys.rs` stays under the 500-line file ceiling
+//! and the chat-specific keymap is one focused thing to read.
+
+use crossterm::event::KeyCode;
+
+use crate::api::ApiClient;
+use crate::state::{AppState, InputMode, View};
+
+/// Handle a single key event while the user is on `View::Chat`.
+///
+/// Typing fills `chat_input`; Enter sends; Esc clears. Digit / `:` / `?` /
+/// `q` shortcuts only fire when the buffer is empty so they don't fight
+/// a mid-word draft.
+pub(crate) async fn handle_chat_key(state: &mut AppState, client: &ApiClient, code: KeyCode) {
+    if state.chat_pending {
+        if matches!(code, KeyCode::Esc) {
+            state.chat_input.clear();
+        }
+        return;
+    }
+    match code {
+        // Transcript scrolling. `chat_scroll` is "lines back from latest"
+        // — 0 means pinned to the bottom, increases as you scroll up.
+        KeyCode::PageUp => {
+            state.chat_scroll = state.chat_scroll.saturating_add(10);
+        }
+        KeyCode::PageDown => {
+            state.chat_scroll = state.chat_scroll.saturating_sub(10);
+        }
+        KeyCode::Up => {
+            state.chat_scroll = state.chat_scroll.saturating_add(1);
+        }
+        KeyCode::Down => {
+            state.chat_scroll = state.chat_scroll.saturating_sub(1);
+        }
+        KeyCode::Esc => state.chat_input.clear(),
+        KeyCode::Backspace => {
+            state.chat_input.pop();
+        }
+        KeyCode::Enter => send_chat(state, client).await,
+        KeyCode::Char('q') if state.chat_input.is_empty() => state.should_quit = true,
+        KeyCode::Char(':') if state.chat_input.is_empty() => {
+            state.input_mode = InputMode::Command;
+            state.command_input.clear();
+        }
+        KeyCode::Char('?') if state.chat_input.is_empty() => state.push_view(View::Help),
+        KeyCode::Char('1') if state.chat_input.is_empty() => {
+            state.view_stack.clear();
+            state.view = View::Services;
+        }
+        KeyCode::Char('2') if state.chat_input.is_empty() => state.push_view(View::Nodes),
+        KeyCode::Char('3') if state.chat_input.is_empty() => {
+            crate::refresh_secrets_usage(client, state).await;
+            state.selected_secret = 0;
+            state.push_view(View::Secrets);
+        }
+        KeyCode::Char('4') if state.chat_input.is_empty() => {
+            crate::refresh_backups(client, state).await;
+            state.selected_backup_node = 0;
+            state.push_view(View::Backups);
+        }
+        KeyCode::Char('5') if state.chat_input.is_empty() => {
+            crate::refresh_webhooks(client, state).await;
+            state.selected_webhook = 0;
+            state.push_view(View::Webhooks);
+        }
+        KeyCode::Char('6') if state.chat_input.is_empty() => {
+            crate::refresh_networks(client, state).await;
+            state.network_scroll = 0;
+            state.push_view(View::Networks);
+        }
+        KeyCode::Char(c) => state.chat_input.push(c),
+        _ => {}
+    }
+}
+
+/// Parse a `/cmd` line into a `SlashAction`. Pure function so we can pin
+/// the routing in unit tests without standing up the whole TUI state.
+pub(crate) fn parse_slash(raw: &str) -> Option<SlashAction> {
+    let rest = raw.strip_prefix('/')?;
+    let mut parts = rest.split_whitespace();
+    let verb = parts.next()?;
+    Some(match verb {
+        "services" | "svc" => SlashAction::Goto(View::Services),
+        "nodes" => SlashAction::Goto(View::Nodes),
+        "secrets" => SlashAction::Goto(View::Secrets),
+        "backups" => SlashAction::Goto(View::Backups),
+        "webhooks" => SlashAction::Goto(View::Webhooks),
+        "networks" => SlashAction::Goto(View::Networks),
+        "logs" => match parts.next() {
+            Some(svc) => SlashAction::Logs(svc.to_string()),
+            None => SlashAction::Usage("Usage: /logs <service>".to_string()),
+        },
+        "clear" | "reset" => SlashAction::Clear,
+        "help" | "?" => SlashAction::Goto(View::Help),
+        other => SlashAction::Unknown(other.to_string()),
+    })
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum SlashAction {
+    Goto(View),
+    Logs(String),
+    Clear,
+    Usage(String),
+    Unknown(String),
+}
+
+/// Submit the current chat input. Empty input is a no-op. Lines starting
+/// with `/` are slash commands; anything else hits `/api/v1/ask`.
+async fn send_chat(state: &mut AppState, client: &ApiClient) {
+    let raw = state.chat_input.trim().to_string();
+    state.chat_input.clear();
+    if raw.is_empty() {
+        return;
+    }
+    if let Some(action) = parse_slash(&raw) {
+        match action {
+            SlashAction::Goto(view) => match view {
+                View::Services => {
+                    state.view_stack.clear();
+                    state.view = View::Services;
+                }
+                View::Secrets => {
+                    crate::refresh_secrets_usage(client, state).await;
+                    state.selected_secret = 0;
+                    state.push_view(View::Secrets);
+                }
+                View::Backups => {
+                    crate::refresh_backups(client, state).await;
+                    state.push_view(View::Backups);
+                }
+                View::Webhooks => {
+                    crate::refresh_webhooks(client, state).await;
+                    state.push_view(View::Webhooks);
+                }
+                View::Networks => {
+                    crate::refresh_networks(client, state).await;
+                    state.push_view(View::Networks);
+                }
+                other => state.push_view(other),
+            },
+            SlashAction::Logs(svc) => {
+                crate::refresh_logs_named(client, state, &svc).await;
+                state.push_view(View::Logs { service: svc });
+            }
+            SlashAction::Clear => state.chat.clear(),
+            SlashAction::Usage(msg) => state.flash(msg),
+            SlashAction::Unknown(verb) => state.flash(format!("Unknown slash: /{verb}")),
+        }
+        return;
+    }
+    crate::send_chat_message(state, client, raw);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slash_routes_named_views() {
+        assert_eq!(
+            parse_slash("/services"),
+            Some(SlashAction::Goto(View::Services))
+        );
+        assert_eq!(parse_slash("/svc"), Some(SlashAction::Goto(View::Services)));
+        assert_eq!(parse_slash("/nodes"), Some(SlashAction::Goto(View::Nodes)));
+        assert_eq!(
+            parse_slash("/secrets"),
+            Some(SlashAction::Goto(View::Secrets))
+        );
+        assert_eq!(
+            parse_slash("/backups"),
+            Some(SlashAction::Goto(View::Backups))
+        );
+        assert_eq!(
+            parse_slash("/webhooks"),
+            Some(SlashAction::Goto(View::Webhooks))
+        );
+        assert_eq!(
+            parse_slash("/networks"),
+            Some(SlashAction::Goto(View::Networks))
+        );
+        assert_eq!(parse_slash("/help"), Some(SlashAction::Goto(View::Help)));
+        assert_eq!(parse_slash("/?"), Some(SlashAction::Goto(View::Help)));
+    }
+
+    #[test]
+    fn slash_logs_with_and_without_arg() {
+        assert_eq!(
+            parse_slash("/logs api"),
+            Some(SlashAction::Logs("api".to_string()))
+        );
+        assert!(matches!(parse_slash("/logs"), Some(SlashAction::Usage(_))));
+    }
+
+    #[test]
+    fn slash_clear_alias() {
+        assert_eq!(parse_slash("/clear"), Some(SlashAction::Clear));
+        assert_eq!(parse_slash("/reset"), Some(SlashAction::Clear));
+    }
+
+    #[test]
+    fn slash_unknown_verb_reports() {
+        assert_eq!(
+            parse_slash("/foo bar"),
+            Some(SlashAction::Unknown("foo".to_string()))
+        );
+    }
+
+    #[test]
+    fn non_slash_input_returns_none() {
+        // Anything that doesn't start with `/` is a regular chat message,
+        // not a slash. Caller hands it to `send_chat_message`.
+        assert!(parse_slash("hello world").is_none());
+        assert!(parse_slash("").is_none());
+    }
+}

--- a/crates/orca-tui/src/commands.rs
+++ b/crates/orca-tui/src/commands.rs
@@ -7,6 +7,10 @@ pub async fn execute_command(state: &mut AppState, client: &ApiClient, cmd: &str
     let parts: Vec<&str> = cmd.split_whitespace().collect();
     match parts.first().copied() {
         Some("q" | "quit") => state.should_quit = true,
+        Some("chat") => {
+            state.view_stack.clear();
+            state.view = View::Chat;
+        }
         Some("services" | "svc") => {
             state.view_stack.clear();
             state.view = View::Services;

--- a/crates/orca-tui/src/keys.rs
+++ b/crates/orca-tui/src/keys.rs
@@ -58,6 +58,10 @@ pub async fn handle_normal_key(
     code: KeyCode,
     last_refresh: &mut tokio::time::Instant,
 ) {
+    if matches!(state.view, View::Chat) {
+        crate::chat_input::handle_chat_key(state, client, code).await;
+        return;
+    }
     match code {
         KeyCode::Char('q') => state.should_quit = true,
         KeyCode::Char(':') => {
@@ -195,6 +199,10 @@ pub async fn handle_normal_key(
         }
 
         // View shortcuts
+        KeyCode::Char('0') => {
+            state.view_stack.clear();
+            state.view = View::Chat;
+        }
         KeyCode::Char('1') => {
             state.view_stack.clear();
             state.view = View::Services;

--- a/crates/orca-tui/src/lib.rs
+++ b/crates/orca-tui/src/lib.rs
@@ -1,5 +1,9 @@
 pub mod api;
+mod chat_dispatch;
+mod chat_input;
 mod commands;
+
+pub(crate) use chat_dispatch::{drain_chat_result, send_chat_message};
 mod keys;
 mod metrics;
 mod persist;
@@ -87,6 +91,9 @@ async fn event_loop(
 
         state.tick = state.tick.wrapping_add(1);
         state.maybe_clear_flash();
+        // Pick up any completed background chat request before we render
+        // — so the assistant's reply shows up the same tick it lands.
+        drain_chat_result(state);
 
         terminal.draw(|f| ui::draw(f, state))?;
 

--- a/crates/orca-tui/src/state.rs
+++ b/crates/orca-tui/src/state.rs
@@ -12,6 +12,9 @@ pub use crate::metrics::{MetricHistory, parse_human_bytes};
 /// Full-screen views (k9s style — each replaces the entire screen).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum View {
+    /// Default landing page — `orca ask`-style chat with the cluster AI.
+    /// Conversation lives only for the session; quitting wipes it.
+    Chat,
     Services,
     Nodes,
     Logs {
@@ -129,6 +132,43 @@ pub struct AppState {
     /// Scroll offset (in rendered lines) for the Networks view. The view has
     /// no selection cursor — j/k just shift the viewport.
     pub network_scroll: usize,
+    /// Session chat transcript for `View::Chat`. Cleared on quit.
+    pub chat: Vec<ChatTurn>,
+    /// Composition buffer for the next chat message. Single-line in v1.
+    pub chat_input: String,
+    /// Scroll offset (lines from top) for the chat transcript pane.
+    pub chat_scroll: usize,
+    /// True while a `/api/v1/ask` request is in flight.
+    pub chat_pending: bool,
+    /// True when the ask API returned 503 (no `[ai]` configured).
+    pub chat_unavailable: bool,
+    /// Receiver for the result of an in-flight chat request, dispatched as
+    /// a tokio task so the event loop stays responsive while the LLM is
+    /// thinking. `None` between requests.
+    pub chat_result_rx: Option<tokio::sync::mpsc::UnboundedReceiver<ChatTaskResult>>,
+}
+
+/// Result of a background chat dispatch — handed back to the event loop
+/// via `chat_result_rx` so the main loop can mutate state on completion.
+#[derive(Debug)]
+pub enum ChatTaskResult {
+    Reply(String),
+    Unavailable,
+    Error(String),
+}
+
+/// One turn in the chat transcript. The API mirror in `orca_ai::ops::ChatTurn`
+/// uses string roles; we keep an enum here so renderer / handlers can match.
+#[derive(Debug, Clone)]
+pub struct ChatTurn {
+    pub role: ChatRole,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChatRole {
+    User,
+    Assistant,
 }
 
 impl Default for AppState {
@@ -140,7 +180,7 @@ impl Default for AppState {
 impl AppState {
     pub fn new() -> Self {
         Self {
-            view: View::Services,
+            view: View::Chat,
             view_stack: Vec::new(),
             cluster_name: "connecting...".into(),
             services: Vec::new(),
@@ -180,6 +220,12 @@ impl AppState {
             secrets_usage: Vec::new(),
             networks: None,
             network_scroll: 0,
+            chat: Vec::new(),
+            chat_input: String::new(),
+            chat_scroll: 0,
+            chat_pending: false,
+            chat_unavailable: false,
+            chat_result_rx: None,
         }
     }
 
@@ -361,6 +407,7 @@ impl AppState {
     /// View name for display in status bar.
     pub fn view_name(&self) -> &str {
         match &self.view {
+            View::Chat => "Chat",
             View::Services => "Services",
             View::Nodes => "Nodes",
             View::Logs { .. } => "Logs",

--- a/crates/orca-tui/src/ui.rs
+++ b/crates/orca-tui/src/ui.rs
@@ -2,6 +2,7 @@
 
 pub mod backup_snapshots;
 pub mod backups;
+pub mod chat;
 pub mod detail;
 pub mod help;
 pub mod logs;
@@ -76,6 +77,7 @@ fn draw_content(f: &mut Frame, area: Rect, state: &AppState) {
         }
         View::SecretRefs { key } => secret_refs::draw_secret_refs(f, area, state, key),
         View::Networks => networks::draw_networks(f, area, state),
+        View::Chat => chat::draw_chat(f, area, state),
     }
 }
 
@@ -184,6 +186,7 @@ fn draw_breadcrumb(f: &mut Frame, area: Rect, state: &AppState) {
         View::WebhookInvocations { service } => format!("Webhooks > {service} > Invocations"),
         View::SecretRefs { key } => format!("Secrets > {key} > Refs"),
         View::Networks => "Networks".to_string(),
+        View::Chat => "Chat".to_string(),
     };
     let line = Line::from(vec![
         Span::styled(" ", Style::default()),
@@ -286,6 +289,7 @@ fn draw_footer(f: &mut Frame, area: Rect, state: &AppState) {
             "Esc:back j/k:select ↵:invocations a:add e:edit x:delete r:refresh ?:help"
         }
         View::WebhookInvocations { .. } => "Esc:back r:refresh ?:help",
+        View::Chat => "type:ask Enter:send PgUp/PgDn:scroll /cmd:jump 0-6:views Esc:clear ?:help",
     };
     spans.push(Span::styled(keys, dim));
 

--- a/crates/orca-tui/src/ui/chat.rs
+++ b/crates/orca-tui/src/ui/chat.rs
@@ -1,0 +1,132 @@
+//! Chat landing view — `orca ask`-style conversation with the cluster AI.
+//!
+//! Transcript pane on top, single-line composition box at bottom. The user
+//! types into the box (Enter sends, Esc clears). The body of POST
+//! `/api/v1/ask` is `{question, history}`; the server gathers cluster context.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+use crate::state::{AppState, ChatRole};
+
+const HINT: &str = "Ask anything: \"why is api down?\", \"how do I scale the worker?\". Slash: /services /nodes /alerts /logs <svc>";
+
+pub fn draw_chat(f: &mut Frame, area: Rect, state: &AppState) {
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(5), Constraint::Length(3)])
+        .split(area);
+    draw_transcript(f, layout[0], state);
+    draw_input(f, layout[1], state);
+}
+
+fn draw_transcript(f: &mut Frame, area: Rect, state: &AppState) {
+    if state.chat_unavailable {
+        let block = Block::default()
+            .title(" Chat (unavailable) ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Yellow));
+        let text = "  AI is not configured.\n\n  Add an [ai] block to cluster.toml (endpoint, model, api_key) and restart the server.";
+        f.render_widget(Paragraph::new(text).block(block), area);
+        return;
+    }
+
+    let lines: Vec<Line> = if state.chat.is_empty() {
+        vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                "  Welcome — start chatting with your cluster.",
+                Style::default().fg(Color::Cyan),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                format!("  {HINT}"),
+                Style::default().fg(Color::DarkGray),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "  Tab/digit keys (1-6) jump to other views; the transcript stays put for the session.",
+                Style::default().fg(Color::DarkGray),
+            )),
+        ]
+    } else {
+        let mut out: Vec<Line> = Vec::with_capacity(state.chat.len() * 4);
+        for turn in &state.chat {
+            let (label, color) = match turn.role {
+                ChatRole::User => ("you", Color::Green),
+                ChatRole::Assistant => ("orca", Color::Cyan),
+            };
+            out.push(Line::from(Span::styled(
+                format!("{label}:"),
+                Style::default().fg(color).add_modifier(Modifier::BOLD),
+            )));
+            for content_line in turn.content.lines() {
+                out.push(Line::from(format!("  {content_line}")));
+            }
+            out.push(Line::from(""));
+        }
+        if state.chat_pending {
+            out.push(Line::from(Span::styled(
+                "orca: thinking…",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::ITALIC),
+            )));
+        }
+        out
+    };
+
+    // `chat_scroll` is "lines back from the latest" — 0 pins the view to
+    // the bottom (the latest exchange). To render with `Paragraph::scroll`
+    // (which takes an offset from the top), compute the offset such that
+    // the last visible row is `chat_scroll` lines above the actual last
+    // line. The transcript pane height excludes the top/bottom borders.
+    let visible = (area.height as usize).saturating_sub(2).max(1);
+    let total = lines.len();
+    let from_top = total
+        .saturating_sub(visible)
+        .saturating_sub(state.chat_scroll);
+    let suffix = if state.chat_scroll > 0 {
+        format!(
+            " — scrolled up {} lines (PgDn / Down to follow)",
+            state.chat_scroll
+        )
+    } else {
+        String::new()
+    };
+    let block = Block::default()
+        .title(format!(" Chat ({} turns){suffix} ", state.chat.len()))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let para = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false })
+        .scroll((from_top as u16, 0));
+    f.render_widget(para, area);
+}
+
+fn draw_input(f: &mut Frame, area: Rect, state: &AppState) {
+    let title = if state.chat_pending {
+        " ⠿ waiting for AI… "
+    } else {
+        " > type and press Enter "
+    };
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(if state.chat_pending {
+            Style::default().fg(Color::DarkGray)
+        } else {
+            Style::default().fg(Color::Green)
+        });
+    let body = if state.chat_pending && state.chat_input.is_empty() {
+        " (input disabled while AI is responding — Ctrl+C still quits)".to_string()
+    } else {
+        format!(" {}", state.chat_input)
+    };
+    f.render_widget(Paragraph::new(body).block(block), area);
+}


### PR DESCRIPTION
Closes #38. The TUI now opens directly to a chat pane backed by a new \`POST /api/v1/ask\` endpoint.

## Backend
- \`orca_ai::ops::chat\` — multi-turn chat with cluster status merged into the system prompt
- \`POST /api/v1/ask\` body \`{question, history}\` → \`{response}\`. 503 when \`[ai]\` is unconfigured, 400 on empty question

## TUI
- \`View::Chat\` is the default landing view. \`0\` / \`:chat\` returns to it from anywhere
- Transcript + input box. PgUp/PgDn/Up/Down scroll ("lines back from latest" — 0 pins to bottom). Sending re-pins.
- Digit shortcuts (1-6), \`:\`, \`?\`, \`q\` still work but gated on empty input so they don't fight mid-word drafts
- Slash commands: \`/services /nodes /secrets /backups /webhooks /networks /help /? /logs <svc> /clear /reset\`
- **Async dispatch** — the LLM call runs on a tokio task; event loop drains the result on each tick. TUI stays responsive while the AI thinks (fixes the "TUI hangs after Enter" symptom from initial smoke testing).

## Tests (10 new)
- 3 in \`crates/orca-control/tests/ask_test.rs\` (503 / 400 / malformed history)
- 2 in \`crates/orca-ai/src/ops.rs\` (ChatTurn serde + role pass-through)
- 5 in \`crates/orca-tui/src/chat_input.rs\` (slash-command parser routing)

## Test plan
- [ ] CI green
- [x] Manual smoke against LiteLLM + mailpit cluster: chat works, history is preserved, navigation while AI thinks is responsive, /slash commands route correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)