### PR TITLE
chore(release): bump workspace to v0.2.9-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mallorca"
-version = "0.2.8"
+version = "0.2.9-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2553,7 +2553,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orca-agent"
-version = "0.2.8"
+version = "0.2.9-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "orca-ai"
-version = "0.2.8"
+version = "0.2.9-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "orca-control"
-version = "0.2.8"
+version = "0.2.9-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "orca-core"
-version = "0.2.8"
+version = "0.2.9-rc.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "orca-proxy"
-version = "0.2.8"
+version = "0.2.9-rc.1"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "orca-tui"
-version = "0.2.8"
+version = "0.2.9-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "orca-web"
-version = "0.2.8"
+version = "0.2.9-rc.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/wasm-hello"]
 
 [workspace.package]
-version = "0.2.8"
+version = "0.2.9-rc.1"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mighty840/orca"
@@ -24,9 +24,9 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Shared across crates
-orca-core = { path = "crates/orca-core", version = "0.2.8" }
-orca-ai = { path = "crates/orca-ai", version = "0.2.8" }
-orca-proxy = { path = "crates/orca-proxy", version = "0.2.8" }
+orca-core = { path = "crates/orca-core", version = "0.2.9-rc.1" }
+orca-ai = { path = "crates/orca-ai", version = "0.2.9-rc.1" }
+orca-proxy = { path = "crates/orca-proxy", version = "0.2.9-rc.1" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/orca-cli/Cargo.toml
+++ b/crates/orca-cli/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/main.rs"
 [dependencies]
 orca-core = { workspace = true }
 orca-ai = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.8" }
-orca-control = { path = "../orca-control", version = "0.2.8" }
+orca-agent = { path = "../orca-agent", version = "0.2.9-rc.1" }
+orca-control = { path = "../orca-control", version = "0.2.9-rc.1" }
 orca-proxy = { workspace = true }
-orca-tui = { path = "../orca-tui", version = "0.2.8" }
+orca-tui = { path = "../orca-tui", version = "0.2.9-rc.1" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 
 [dependencies]
 orca-core = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.8" }
+orca-agent = { path = "../orca-agent", version = "0.2.9-rc.1" }
 orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
Version bump for v0.2.9-rc.1 tag. All path-dep pins updated so cargo publish accepts the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)