### PR TITLE
fix(proxy): master skips ACME for agent-placed domains + per-cert timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,6 +2288,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite 0.29.0",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "urlencoding",

--- a/crates/orca-cli/Cargo.toml
+++ b/crates/orca-cli/Cargo.toml
@@ -42,3 +42,4 @@ base64 = "0.22.1"
 
 [dev-dependencies]
 tempfile = "3"
+toml = { workspace = true }

--- a/crates/orca-cli/src/handlers/server.rs
+++ b/crates/orca-cli/src/handlers/server.rs
@@ -70,33 +70,39 @@ pub async fn handle_server(config: &str, proxy_port: u16) -> anyhow::Result<()> 
     let wasm_as_trait: Option<Arc<dyn orca_core::runtime::Runtime>> =
         wasm_runtime.map(|wr| wr as Arc<dyn orca_core::runtime::Runtime>);
 
-    // Collect domains for ACME cert provisioning
+    // Collect domains for ACME cert provisioning. Skip domains whose service
+    // placement explicitly targets a different node — those services are
+    // edge-served by the agent, so the agent (not master) provisions and
+    // serves the cert. Master attempting ACME for them would deadlock the
+    // HTTPS startup loop on the LE HTTP-01 challenge, since DNS for those
+    // domains points elsewhere.
     let acme_email = cluster_config.cluster.acme_email.clone();
+    let master_node = master_hostname();
+    let collect_master_domains = |s: orca_core::config::ServicesConfig| -> Vec<String> {
+        s.service
+            .iter()
+            .filter(|svc| is_master_placed(svc, &master_node))
+            .filter_map(|svc| svc.domain.clone())
+            .collect()
+    };
     let services_dir = std::path::Path::new("services");
     let domains: Vec<String> = if services_dir.is_dir() {
         orca_core::config::ServicesConfig::load_dir(services_dir)
             .ok()
-            .map(|s| {
-                s.service
-                    .iter()
-                    .filter_map(|svc| svc.domain.clone())
-                    .collect()
-            })
+            .map(collect_master_domains)
             .unwrap_or_default()
     } else {
         std::path::Path::new("services.toml")
             .exists()
             .then(|| orca_core::config::ServicesConfig::load("services.toml".as_ref()).ok())
             .flatten()
-            .map(|s| {
-                s.service
-                    .iter()
-                    .filter_map(|svc| svc.domain.clone())
-                    .collect()
-            })
+            .map(collect_master_domains)
             .unwrap_or_default()
     };
-    info!("Domain detection: {} domains found", domains.len());
+    info!(
+        "Domain detection: {} master-placed domain(s) found (node={master_node})",
+        domains.len()
+    );
 
     // Start proxy and get ACME components for hot cert provisioning
     let proxy_routes = route_table.clone();
@@ -277,4 +283,94 @@ pub fn read_token(flag: Option<&str>) -> Option<String> {
         .ok()
         .map(|t| t.trim().to_string())
         .filter(|t| !t.is_empty())
+}
+
+/// Master's identity for placement matching. Mirrors the helper in
+/// `orca_control::api::handlers::ops::networks` so master and the API report
+/// the same string.
+fn master_hostname() -> String {
+    std::fs::read_to_string("/etc/hostname")
+        .map(|s| s.trim().to_string())
+        .or_else(|_| std::env::var("HOSTNAME"))
+        .unwrap_or_else(|_| "master".to_string())
+}
+
+/// True if a service should be ACME-provisioned on master.
+///
+/// Returns true when placement is unconstrained (`None`) or explicitly targets
+/// this master node. Returns false when placement targets a different node —
+/// in that case the agent serves the cert, and master would deadlock on the
+/// LE HTTP-01 challenge if it tried to provision (DNS for the domain points
+/// at the agent, not the master).
+fn is_master_placed(svc: &orca_core::config::ServiceConfig, master_hostname: &str) -> bool {
+    match svc.placement.as_ref().and_then(|p| p.node.as_deref()) {
+        Some(node) => node == master_hostname,
+        None => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orca_core::config::ServicesConfig;
+
+    fn parse_svc(toml: &str) -> orca_core::config::ServiceConfig {
+        let cfg: ServicesConfig = ::toml::from_str(toml).expect("valid toml");
+        cfg.service.into_iter().next().expect("one service")
+    }
+
+    #[test]
+    fn unconstrained_placement_is_master_placed() {
+        let svc = parse_svc(
+            r#"
+            [[service]]
+            name = "test"
+            image = "nginx:latest"
+            "#,
+        );
+        assert!(is_master_placed(&svc, "master-host"));
+    }
+
+    #[test]
+    fn matching_placement_is_master_placed() {
+        let svc = parse_svc(
+            r#"
+            [[service]]
+            name = "test"
+            image = "nginx:latest"
+            [service.placement]
+            node = "master-host"
+            "#,
+        );
+        assert!(is_master_placed(&svc, "master-host"));
+    }
+
+    #[test]
+    fn other_node_placement_is_not_master_placed() {
+        let svc = parse_svc(
+            r#"
+            [[service]]
+            name = "test"
+            image = "nginx:latest"
+            [service.placement]
+            node = "zeroclaw"
+            "#,
+        );
+        assert!(!is_master_placed(&svc, "master-host"));
+    }
+
+    #[test]
+    fn placement_with_only_labels_is_master_placed() {
+        let svc = parse_svc(
+            r#"
+            [[service]]
+            name = "test"
+            image = "nginx:latest"
+            [service.placement]
+            [service.placement.labels]
+            zone = "us-east"
+            "#,
+        );
+        assert!(is_master_placed(&svc, "master-host"));
+    }
 }

--- a/crates/orca-cli/src/handlers/volume_backup/mod.rs
+++ b/crates/orca-cli/src/handlers/volume_backup/mod.rs
@@ -298,8 +298,6 @@ mod tests {
     /// deleted before a new one exists.
     #[test]
     fn prune_does_not_remove_recent_backup_dirs() {
-        use helpers::prune_old_backup_dirs;
-
         let tmp = tempfile::tempdir().unwrap();
         let base = tmp.path().join(".orca/backups");
 

--- a/crates/orca-cli/tests/e2e/mod.rs
+++ b/crates/orca-cli/tests/e2e/mod.rs
@@ -26,6 +26,7 @@ pub const E2E_TOKEN: &str = "e2e-test-token";
 pub struct OrcaServer {
     child: Child,
     _config_path: PathBuf,
+    #[allow(dead_code)]
     pub api_port: u16,
     pub api_url: String,
 }
@@ -194,6 +195,5 @@ impl Drop for OrcaServer {
 pub fn require_e2e_env() {
     if std::env::var("ORCA_E2E").is_err() {
         eprintln!("Skipping E2E test: set ORCA_E2E=1 to run");
-        return;
     }
 }

--- a/crates/orca-control/src/api/handlers/ops/mod.rs
+++ b/crates/orca-control/src/api/handlers/ops/mod.rs
@@ -188,13 +188,12 @@ mod tests {
         let result = {
             let services = state.services.read().await;
             let svc = services.get("myapp").unwrap();
-            let remote_node_id = svc.instances.iter().find_map(|i| {
+            svc.instances.iter().find_map(|i| {
                 i.handle
                     .runtime_id
                     .strip_prefix("remote-")
                     .and_then(|s| s.parse::<u64>().ok())
-            });
-            remote_node_id
+            })
         };
         assert_eq!(result, Some(node_id));
 

--- a/crates/orca-control/tests/e2e_helpers.rs
+++ b/crates/orca-control/tests/e2e_helpers.rs
@@ -62,6 +62,7 @@ impl TestClient {
         }
     }
 
+    #[allow(dead_code)]
     pub async fn get(&self, path: &str) -> reqwest::Response {
         self.client
             .get(format!("{}{path}", self.base))

--- a/crates/orca-core/tests/project_test.rs
+++ b/crates/orca-core/tests/project_test.rs
@@ -1,7 +1,5 @@
 //! Tests for project isolation: directory-based service grouping.
 
-use std::collections::HashMap;
-
 use orca_core::config::ServicesConfig;
 
 /// load_dir should set the `project` field from the directory name.

--- a/crates/orca-proxy/src/lib.rs
+++ b/crates/orca-proxy/src/lib.rs
@@ -210,13 +210,29 @@ pub async fn run_proxy_with_acme_and_fallback(
     let https_handle = tokio::spawn(async move {
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        // Provision all initial domain certs
+        // Provision all initial domain certs. Each call gets its own 60s
+        // timeout: without it, a single domain whose LE HTTP-01 challenge
+        // hangs (DNS pointing elsewhere, port 80 firewalled, LE rate limit
+        // backoff) blocks the entire HTTPS listener startup forever. 60s is
+        // generous — a healthy LE order completes in 5-15s — so a timeout
+        // here is a real problem, but we'd rather serve the other domains
+        // than serve nothing.
+        const PER_DOMAIN_PROVISION_TIMEOUT: std::time::Duration =
+            std::time::Duration::from_secs(60);
         for domain in &domains {
-            if let Err(e) = acme_mgr
-                .ensure_cert_for_resolver(domain, &resolver_clone)
-                .await
-            {
-                error!(domain = %domain, error = %e, "Failed to provision cert");
+            let fut = acme_mgr.ensure_cert_for_resolver(domain, &resolver_clone);
+            match tokio::time::timeout(PER_DOMAIN_PROVISION_TIMEOUT, fut).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    error!(domain = %domain, error = %e, "Failed to provision cert");
+                }
+                Err(_) => {
+                    warn!(
+                        domain = %domain,
+                        timeout_secs = PER_DOMAIN_PROVISION_TIMEOUT.as_secs(),
+                        "Cert provisioning timed out — skipping (HTTPS will start without this cert; reconciler may retry on demand)"
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Two coupled prod bugs found on zeroclaw 2026-05-16 — both contributed to a silent loss of TLS on the master node:

1. **Master ACMEs every domain regardless of placement.** Agent-hosted services have DNS pointing at the agent, so LE HTTP-01 challenges initiated from master hang forever (validator queries `<domain>:80`, reaches the agent, gets no challenge token, blocks).
2. **No per-domain timeout on `ensure_cert_for_resolver`.** One hung domain blocked the entire HTTPS startup loop. Port 80 came up, port 443 never bound, no error logged.

## Changes

- `server.rs`: filter domains by placement. Drop any domain whose service has `placement.node` set to something other than the master's hostname. Keep domains with no placement or placement matching master.
- `lib.rs`: wrap each `ensure_cert_for_resolver` in `tokio::time::timeout(60s)`. On timeout, warn + continue. HTTPS still starts; reconciler can hot-add missing certs later.

Drive-by: cleaned up a few clippy warnings in test code (unused imports, dead_code, let-and-return, needless return) so a future `--all-targets` run doesn't drown in noise. CI's clippy command itself (without `--all-targets`) was already passing.

## Test plan

- [x] `cargo fmt --all && cargo clippy -- -D warnings` clean
- [x] 4 new unit tests for `is_master_placed` (unconstrained / matching / other-node / labels-only)
- [x] `cargo test -p mallorca` passes 45/45 unit + 9 ignored E2E
- [x] `cargo test -p orca-proxy` passes
- [ ] Verify on zeroclaw: restart master, watch `journalctl` for `Domain detection: N master-placed domain(s)` and `Starting HTTPS with SNI resolver` — both should appear within seconds.
- [ ] Verify hung-domain case: if a domain timeouts, look for the `timed out` warn log and confirm HTTPS still starts with the other certs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)