### PR TITLE
fix(proxy): release route_table read lock before awaits to unblock TLS handshakes

### DIFF
--- a/crates/orca-control/src/api/handlers/ops/networks.rs
+++ b/crates/orca-control/src/api/handlers/ops/networks.rs
@@ -58,18 +58,47 @@ pub(crate) async fn cluster_networks(State(state): State<Arc<AppState>>) -> impl
 /// the master). Routes whose service isn't in the services map (e.g. stale
 /// route after a service was removed) fall under `None` defensively.
 async fn group_routes_by_placement(state: &AppState) -> HashMap<Option<String>, Vec<DomainRoute>> {
-    let services = state.services.read().await;
-    let routes = state.route_table.read().await;
+    // Snapshot the data we need under tight, scoped reads, then drop both
+    // guards before any further work. Holding `state.route_table.read()`
+    // across iteration was the primary lock-contention source that stalled
+    // proxy TLS handshakes by up to 20 seconds — tokio::sync::RwLock uses
+    // write-priority, so once *any* writer (update_container_routes from
+    // the reconciler/watchdog) queues behind this long-running reader, all
+    // subsequent readers (including the serve-loop check that happens
+    // between peek_sni and acceptor.accept) queue behind the writer too.
+    // See project_v0_2_9_rc2_proxy_lock_contention for the diagnosis.
+    let service_placements: HashMap<String, Option<String>> = {
+        let services = state.services.read().await;
+        services
+            .values()
+            .map(|s| {
+                (
+                    s.config.name.clone(),
+                    s.config.placement.as_ref().and_then(|p| p.node.clone()),
+                )
+            })
+            .collect()
+    };
+    let route_snapshot: Vec<(String, Vec<String>)> = {
+        let routes = state.route_table.read().await;
+        routes
+            .iter()
+            .map(|(domain, targets)| {
+                (
+                    domain.clone(),
+                    targets.iter().map(|t| t.service_name.clone()).collect(),
+                )
+            })
+            .collect()
+    };
+
     let mut out: HashMap<Option<String>, Vec<DomainRoute>> = HashMap::new();
-    for (domain, targets) in routes.iter() {
-        for t in targets {
-            let node = services
-                .get(&t.service_name)
-                .and_then(|s| s.config.placement.as_ref())
-                .and_then(|p| p.node.clone());
+    for (domain, service_names) in &route_snapshot {
+        for service_name in service_names {
+            let node = service_placements.get(service_name).cloned().flatten();
             out.entry(node).or_default().push(DomainRoute {
                 domain: domain.clone(),
-                service: t.service_name.clone(),
+                service: service_name.clone(),
                 resolved_ip: None,
             });
         }

--- a/crates/orca-proxy/src/handler.rs
+++ b/crates/orca-proxy/src/handler.rs
@@ -154,11 +154,15 @@ pub(crate) async fn handle_request(
         ));
     };
 
-    // HTTP -> HTTPS redirect: if not TLS and host has routes, redirect
+    // HTTP -> HTTPS redirect: if not TLS and host has routes, redirect.
+    // Take the read in a tight scope so the lock releases before further
+    // awaits — see comment below.
     if !is_tls {
-        let routes = route_table.read().await;
-        if routes.contains_key(&host) {
-            drop(routes);
+        let known = {
+            let routes = route_table.read().await;
+            routes.contains_key(&host)
+        };
+        if known {
             return Ok(redirect_to_https(&host, &path));
         }
     }
@@ -169,33 +173,32 @@ pub(crate) async fn handle_request(
     // vec pointing at the fallback so the existing forward path handles it
     // uniformly. This is what makes orca able to coexist with another
     // reverse proxy on the same edge.
-    let routes = route_table.read().await;
-    let matched: Vec<RouteTarget> = match routes.get(&host) {
-        Some(targets) if targets.is_empty() => {
-            drop(routes);
+    //
+    // Lock discipline: take a snapshot of the matched targets inside a
+    // tight scope and release the read guard BEFORE any further await (body
+    // collect / forward / websocket upgrade). Holding the guard across
+    // those awaits lets a long-lived request (Matrix `/sync`'s 30s long-
+    // poll, gitea CI runner long-polls) keep the lock for tens of seconds.
+    // Once a writer queues behind that reader, tokio::sync::RwLock's
+    // write-priority semantics make every new reader wait too — which on
+    // a busy master manifests as 17-20-second stalls on the TLS handshake
+    // path (the serve-loop also reads route_table before acceptor.accept).
+    let lookup: Option<Vec<RouteTarget>> = {
+        let routes = route_table.read().await;
+        match routes.get(&host) {
+            Some(targets) if targets.is_empty() => None, // explicit-empty sentinel
+            Some(targets) => Some(select_path_targets(targets, &path)),
+            None => Some(Vec::new()), // host unknown — try fallback
+        }
+    };
+    let matched: Vec<RouteTarget> = match lookup {
+        None => {
             return Ok(error_response(
                 StatusCode::SERVICE_UNAVAILABLE,
                 &format!("no backends for host: {host}"),
             ));
         }
-        Some(targets) => {
-            let sel = select_path_targets(targets, &path);
-            if sel.is_empty() {
-                drop(routes);
-                if let Some(target) = fallback_target(fallback) {
-                    vec![target]
-                } else {
-                    return Ok(error_response(
-                        StatusCode::NOT_FOUND,
-                        &format!("no backend for path: {path} on host: {host}"),
-                    ));
-                }
-            } else {
-                sel
-            }
-        }
-        None => {
-            drop(routes);
+        Some(sel) if sel.is_empty() => {
             if let Some(target) = fallback_target(fallback) {
                 vec![target]
             } else {
@@ -205,9 +208,9 @@ pub(crate) async fn handle_request(
                 ));
             }
         }
+        Some(sel) => sel,
     };
     let base_idx = counter.fetch_add(1, Ordering::Relaxed);
-    // `routes` was dropped in each branch above; nothing more to release.
 
     // WebSocket upgrade: tunnel via raw TCP instead of HTTP proxying
     if crate::websocket::is_websocket_upgrade(&req) {


### PR DESCRIPTION
## Summary

On a busy master, 15-20% of cold TLS handshakes were stalling **17-20 seconds** before completing, while the proxy itself appeared idle (workers parked, no CPU, no network loss). Diagnosed via per-phase tracing: the wall lives in the `route_table.read().await` between `peek_sni` and `acceptor.accept`, waiting on a queued writer that was itself blocked behind a long-running reader.

Two readers held `state.route_table.read()` across awaits long enough to let writers (`update_container_routes` from reconciler/watchdog) queue. Once a writer queues, **`tokio::sync::RwLock`'s write-priority semantics make every new reader wait too** — so the serve-loop's brief SNI passthrough check stalled for the full duration of the original long-running reader, batching all queued handshakes to complete simultaneously at the writer's release.

## Fixes

- **`crates/orca-control/src/api/handlers/ops/networks.rs`**: `group_routes_by_placement` was holding `state.services.read()` AND `state.route_table.read()` across the entire result-building iteration. Now snapshots the data into local maps in two tight scopes that drop the guards immediately, then builds the result.

- **`crates/orca-proxy/src/handler.rs`**: route lookup in `handle_request` relied on NLL to drop the read guard before `forward_with_retry`'s await. In one match arm (non-empty `select_path_targets`) the guard might have lingered. Reworked to clone the matched targets inside a tight scope and release the guard explicitly before any further await. Same tightening on the HTTP→HTTPS redirect-check read.

## Verification

On prod (zeroclaw) before fix:
- 3-5 of 20 cold TLS handshakes to master sat at 17-20s
- Batches of handshakes completed simultaneously every 30s (watchdog interval)
- All 12 tokio workers parked during the stall (no work, just queued behind RwLock)

After this patch:
- 20/20 sub-100ms
- No batching pattern
- Browser apps that felt hung respond instantly

## Test plan

- [x] `cargo fmt --all && cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test -p orca-proxy --lib` 50/50 pass
- [x] Reproduced and confirmed fixed on prod via 20-curl loop against `registry.meghsakha.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)