### PR TITLE
chore(release): bump workspace to v0.2.9-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mallorca"
-version = "0.2.9-rc.2"
+version = "0.2.9-rc.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2554,7 +2554,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orca-agent"
-version = "0.2.9-rc.2"
+version = "0.2.9-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "orca-ai"
-version = "0.2.9-rc.2"
+version = "0.2.9-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "orca-control"
-version = "0.2.9-rc.2"
+version = "0.2.9-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "orca-core"
-version = "0.2.9-rc.2"
+version = "0.2.9-rc.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "orca-proxy"
-version = "0.2.9-rc.2"
+version = "0.2.9-rc.3"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "orca-tui"
-version = "0.2.9-rc.2"
+version = "0.2.9-rc.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "orca-web"
-version = "0.2.9-rc.2"
+version = "0.2.9-rc.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/wasm-hello"]
 
 [workspace.package]
-version = "0.2.9-rc.2"
+version = "0.2.9-rc.3"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mighty840/orca"
@@ -24,9 +24,9 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Shared across crates
-orca-core = { path = "crates/orca-core", version = "0.2.9-rc.2" }
-orca-ai = { path = "crates/orca-ai", version = "0.2.9-rc.2" }
-orca-proxy = { path = "crates/orca-proxy", version = "0.2.9-rc.2" }
+orca-core = { path = "crates/orca-core", version = "0.2.9-rc.3" }
+orca-ai = { path = "crates/orca-ai", version = "0.2.9-rc.3" }
+orca-proxy = { path = "crates/orca-proxy", version = "0.2.9-rc.3" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/orca-cli/Cargo.toml
+++ b/crates/orca-cli/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/main.rs"
 [dependencies]
 orca-core = { workspace = true }
 orca-ai = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.9-rc.2" }
-orca-control = { path = "../orca-control", version = "0.2.9-rc.2" }
+orca-agent = { path = "../orca-agent", version = "0.2.9-rc.3" }
+orca-control = { path = "../orca-control", version = "0.2.9-rc.3" }
 orca-proxy = { workspace = true }
-orca-tui = { path = "../orca-tui", version = "0.2.9-rc.2" }
+orca-tui = { path = "../orca-tui", version = "0.2.9-rc.3" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 
 [dependencies]
 orca-core = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.9-rc.2" }
+orca-agent = { path = "../orca-agent", version = "0.2.9-rc.3" }
 orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary

Bumps workspace version 0.2.9-rc.2 → 0.2.9-rc.3 ahead of tagging. One prod-found fix lands in this rc:

- #65 — release `route_table` read lock before awaits to unblock TLS handshakes (kills the 17-20s stalls under sustained master load)

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --all && cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` — all green
- [ ] Tag v0.2.9-rc.3 after merge, watch crates.io publish workflow.
- [ ] On zeroclaw: `cargo install mallorca --version 0.2.9-rc.3 --force` + restart, confirm 20-curl loop has zero stalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)