### PR TITLE
chore(release): v0.2.9 (stable)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mallorca"
-version = "0.2.9-rc.3"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2554,7 +2554,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orca-agent"
-version = "0.2.9-rc.3"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "orca-ai"
-version = "0.2.9-rc.3"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "orca-control"
-version = "0.2.9-rc.3"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "orca-core"
-version = "0.2.9-rc.3"
+version = "0.2.9"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "orca-proxy"
-version = "0.2.9-rc.3"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "orca-tui"
-version = "0.2.9-rc.3"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "orca-web"
-version = "0.2.9-rc.3"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/wasm-hello"]
 
 [workspace.package]
-version = "0.2.9-rc.3"
+version = "0.2.9"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mighty840/orca"
@@ -24,9 +24,9 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Shared across crates
-orca-core = { path = "crates/orca-core", version = "0.2.9-rc.3" }
-orca-ai = { path = "crates/orca-ai", version = "0.2.9-rc.3" }
-orca-proxy = { path = "crates/orca-proxy", version = "0.2.9-rc.3" }
+orca-core = { path = "crates/orca-core", version = "0.2.9" }
+orca-ai = { path = "crates/orca-ai", version = "0.2.9" }
+orca-proxy = { path = "crates/orca-proxy", version = "0.2.9" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/orca-cli/Cargo.toml
+++ b/crates/orca-cli/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/main.rs"
 [dependencies]
 orca-core = { workspace = true }
 orca-ai = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.9-rc.3" }
-orca-control = { path = "../orca-control", version = "0.2.9-rc.3" }
+orca-agent = { path = "../orca-agent", version = "0.2.9" }
+orca-control = { path = "../orca-control", version = "0.2.9" }
 orca-proxy = { workspace = true }
-orca-tui = { path = "../orca-tui", version = "0.2.9-rc.3" }
+orca-tui = { path = "../orca-tui", version = "0.2.9" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 
 [dependencies]
 orca-core = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.9-rc.3" }
+orca-agent = { path = "../orca-agent", version = "0.2.9" }
 orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary

Promotes v0.2.9-rc.3 → **v0.2.9 stable**. Prod has been running rc.3 for 24+ hours with zero TLS handshake stalls and no other regressions.

## Highlights since v0.2.8

### AI Ops finale (rc.1)
- #24 alert delivery channels (Slack/webhook/email + monitor + API + CLI)
- #38 TUI AI chat as landing page
- #39 TUI alerts view (list/drill-down/reply/dismiss/resolve)
- #17 networks polish (A-records, missing-alias detection, per-node edge routes)

### Production hotfixes (rc.2/rc.3)
- #61 master skips ACME for agent-placed domains + per-cert timeout
- #62 refuse to start on malformed cluster.toml (no more silent fallback)
- #63 stream upstream response bodies (registry blob pulls)
- #65 release route_table read lock before awaits (fixes 17-20s TLS handshake stalls under sustained master load)

### Carried over to v0.2.10
- Project-scoped secrets (`project.KEY` prefix scheme)
- #37 inline a/e/x in TUI secrets organizer
- TUI networks: A-records for agent-served domains (master-only today)
- Networks ASCII art
- Request-body streaming (registry blob pushes)

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --all && cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` — all green
- [x] Prod (zeroclaw) on v0.2.9-rc.3 for 24h with zero stalls
- [ ] Tag v0.2.9 after merge, watch crates.io publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)