### PR TITLE
fix: node-sync orphaning, single-target request streaming, bind-mount backup warning

### DIFF
--- a/crates/orca-cli/src/handlers/volume_backup/bind_mounts.rs
+++ b/crates/orca-cli/src/handlers/volume_backup/bind_mounts.rs
@@ -1,0 +1,188 @@
+//! Detection and reporting of host bind mounts that the volume backup does
+//! not capture (issue #83).
+//!
+//! `orca backup all` tars named Docker volumes, but host bind mounts declared
+//! via `mounts = ["/host/path:/container/path"]` point at paths on the host
+//! filesystem that live outside any backup. If the node is lost, that data is
+//! gone — and previously there was no signal at backup time (not even when a
+//! service had bind mounts and *no* named volume, so the volume backup said
+//! "nothing to do" and exited clean). We inspect the running orca service
+//! containers — Docker is the source of truth for what is actually mounted —
+//! and surface every bind mount as a warning.
+
+use std::collections::BTreeMap;
+
+use bollard::Docker;
+use bollard::container::ListContainersOptions;
+use bollard::models::MountPointTypeEnum;
+
+/// A host bind mount on an orca service container that the backup does not
+/// cover.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UnbackedMount {
+    pub service: String,
+    pub host_path: String,
+    pub container_path: String,
+}
+
+/// Inspect all orca service containers for host bind mounts. Named volumes
+/// (`Type: volume`) are captured by the volume backup; only bind mounts
+/// (`Type: bind`) are returned here. Best-effort: a Docker error logs and
+/// yields an empty list rather than failing the backup.
+pub(crate) async fn list_unbacked_bind_mounts(docker: &Docker) -> Vec<UnbackedMount> {
+    let opts = ListContainersOptions::<String> {
+        all: true,
+        ..Default::default()
+    };
+    let containers = match docker.list_containers(Some(opts)).await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("Failed to list containers for bind-mount check: {e}");
+            return Vec::new();
+        }
+    };
+
+    let mut out = Vec::new();
+    for c in containers {
+        let Some(service) = service_from_names(c.names.as_deref()) else {
+            continue;
+        };
+        for m in c.mounts.unwrap_or_default() {
+            if m.typ == Some(MountPointTypeEnum::BIND) {
+                out.push(UnbackedMount {
+                    service: service.clone(),
+                    host_path: m.source.unwrap_or_default(),
+                    container_path: m.destination.unwrap_or_default(),
+                });
+            }
+        }
+    }
+    out
+}
+
+/// Derive the orca service name from a container's Docker names. Containers
+/// are named `orca-{service}` (with a leading `/` in the API). Returns `None`
+/// for non-orca containers and the transient `orca-backup-*` helpers we spawn
+/// during the backup itself.
+fn service_from_names(names: Option<&[String]>) -> Option<String> {
+    let raw = names?.first()?;
+    let name = raw.trim_start_matches('/');
+    if !name.starts_with("orca-") || name.starts_with("orca-backup-") {
+        return None;
+    }
+    Some(name.strip_prefix("orca-").unwrap_or(name).to_string())
+}
+
+/// Emit a warning for each service with unbacked bind mounts. Prints to stdout
+/// (seen by a manual `orca backup all`) and via `tracing::warn!` (captured by
+/// scheduled and agent-dispatched runs). No-op when there are no bind mounts.
+pub(crate) async fn warn_unbacked_bind_mounts(docker: &Docker) {
+    report_unbacked_bind_mounts(list_unbacked_bind_mounts(docker).await);
+}
+
+/// Pure formatting/reporting half of [`warn_unbacked_bind_mounts`], split out
+/// so it is unit-testable without a live Docker daemon. The summary line is
+/// printed last so it becomes the dashboard's last-backup message for
+/// scheduled/agent runs (which relay the subprocess's final stdout line).
+fn report_unbacked_bind_mounts(mounts: Vec<UnbackedMount>) {
+    if mounts.is_empty() {
+        return;
+    }
+    let grouped = group_by_service(&mounts);
+    let svc_count = grouped.len();
+    let mount_count = mounts.len();
+
+    println!(
+        "WARNING: {mount_count} host bind mount(s) on {svc_count} service(s) are NOT backed up \
+         (only named volumes are captured):"
+    );
+    for (svc, paths) in &grouped {
+        for p in paths {
+            println!("  {svc}: {p}");
+        }
+        tracing::warn!(
+            service = %svc,
+            mounts = %paths.join(", "),
+            "service has host bind mounts excluded from backup"
+        );
+    }
+    println!(
+        "Backup summary: {mount_count} unbacked bind mount(s) on {svc_count} service(s) — \
+         data behind these host paths is NOT in the backup."
+    );
+}
+
+/// Group bind mounts by service into `host -> container` display strings,
+/// ordered (BTreeMap) for stable output.
+fn group_by_service(mounts: &[UnbackedMount]) -> BTreeMap<String, Vec<String>> {
+    let mut grouped: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for m in mounts {
+        grouped
+            .entry(m.service.clone())
+            .or_default()
+            .push(format!("{} -> {}", m.host_path, m.container_path));
+    }
+    grouped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mount(service: &str, host: &str, ctr: &str) -> UnbackedMount {
+        UnbackedMount {
+            service: service.into(),
+            host_path: host.into(),
+            container_path: ctr.into(),
+        }
+    }
+
+    #[test]
+    fn service_from_names_strips_prefix_and_slash() {
+        assert_eq!(
+            service_from_names(Some(&["/orca-freqtrade".to_string()])),
+            Some("freqtrade".to_string())
+        );
+    }
+
+    #[test]
+    fn service_from_names_ignores_non_orca() {
+        assert_eq!(service_from_names(Some(&["/postgres".to_string()])), None);
+    }
+
+    #[test]
+    fn service_from_names_ignores_transient_backup_helpers() {
+        // The busybox tar containers we spawn are named orca-backup-* and must
+        // not be reported as services with unbacked mounts.
+        assert_eq!(
+            service_from_names(Some(&["/orca-backup-12345".to_string()])),
+            None
+        );
+    }
+
+    #[test]
+    fn service_from_names_handles_missing() {
+        assert_eq!(service_from_names(None), None);
+        assert_eq!(service_from_names(Some(&[])), None);
+    }
+
+    #[test]
+    fn group_by_service_groups_and_orders() {
+        let mounts = vec![
+            mount("freqtrade", "/home/u/data", "/freqtrade/user_data"),
+            mount("freqtrade", "/home/u/logs", "/freqtrade/logs"),
+            mount("api", "/etc/api", "/etc/api"),
+        ];
+        let grouped = group_by_service(&mounts);
+        let keys: Vec<_> = grouped.keys().cloned().collect();
+        assert_eq!(keys, vec!["api".to_string(), "freqtrade".to_string()]);
+        assert_eq!(grouped["freqtrade"].len(), 2);
+        assert_eq!(grouped["api"], vec!["/etc/api -> /etc/api".to_string()]);
+    }
+
+    #[test]
+    fn report_empty_is_noop() {
+        // The no-bind-mounts path must not panic or print.
+        report_unbacked_bind_mounts(Vec::new());
+    }
+}

--- a/crates/orca-cli/src/handlers/volume_backup/mod.rs
+++ b/crates/orca-cli/src/handlers/volume_backup/mod.rs
@@ -1,7 +1,9 @@
 //! Docker volume backup and restore using bollard.
 
+mod bind_mounts;
 mod helpers;
 
+use bind_mounts::warn_unbacked_bind_mounts;
 use bollard::Docker;
 use helpers::{
     create_backup_dir, find_latest_backup_dir, list_orca_volumes, prune_old_backup_dirs,
@@ -40,37 +42,42 @@ async fn attempt_backup(backup_cfg: &orca_core::backup::BackupConfig) {
 
     if volumes.is_empty() {
         println!("No orca volumes found.");
-        return;
-    }
+    } else {
+        let hooks = load_service_hooks();
 
-    let hooks = load_service_hooks();
+        println!("Backing up {} volume(s) to {}", volumes.len(), backup_dir);
+        let mut count = 0u32;
 
-    println!("Backing up {} volume(s) to {}", volumes.len(), backup_dir);
-    let mut count = 0u32;
-
-    for vol in &volumes {
-        print!("  {vol} ... ");
-        // Volume name is "orca-{service_name}" — derive service name for hook lookup.
-        let service_name = vol.strip_prefix("orca-").unwrap_or(vol.as_str());
-        if let Some(hook) = hooks.get(service_name) {
-            let container = format!("orca-{service_name}");
-            if let Err(e) = run_pre_hook(&docker, &container, hook).await {
-                println!("FAILED (pre-hook): {e}");
-                continue;
+        for vol in &volumes {
+            print!("  {vol} ... ");
+            // Volume name is "orca-{service_name}" — derive service name for hook lookup.
+            let service_name = vol.strip_prefix("orca-").unwrap_or(vol.as_str());
+            if let Some(hook) = hooks.get(service_name) {
+                let container = format!("orca-{service_name}");
+                if let Err(e) = run_pre_hook(&docker, &container, hook).await {
+                    println!("FAILED (pre-hook): {e}");
+                    continue;
+                }
+            }
+            match run_backup_container(&docker, vol, &backup_dir).await {
+                Ok(()) => {
+                    println!("done");
+                    count += 1;
+                }
+                Err(e) => println!("FAILED: {e}"),
             }
         }
-        match run_backup_container(&docker, vol, &backup_dir).await {
-            Ok(()) => {
-                println!("done");
-                count += 1;
-            }
-            Err(e) => println!("FAILED: {e}"),
-        }
+
+        println!("Volume backup complete: {count}/{} volumes.", volumes.len());
+
+        upload_volumes_to_s3(backup_cfg, &volumes, &backup_dir);
     }
 
-    println!("Volume backup complete: {count}/{} volumes.", volumes.len());
-
-    upload_volumes_to_s3(backup_cfg, &volumes, &backup_dir);
+    // Warn about host bind mounts, which the volume backup above does not
+    // capture (#83). Run this even when there are no named volumes — a service
+    // can have bind mounts and no volume, exactly the case that previously
+    // exited silently with "No orca volumes found."
+    warn_unbacked_bind_mounts(&docker).await;
 }
 
 /// Upload each volume tarball from a completed local backup to all S3 targets.

--- a/crates/orca-control/src/lib.rs
+++ b/crates/orca-control/src/lib.rs
@@ -317,15 +317,41 @@ async fn register_master_node(state: &state::AppState, api_port: u16) {
     info!(node_id, "Master node self-registered");
 }
 
+/// How long a node may go without a heartbeat before it is eligible for
+/// pruning — but only if it also has no live WS connection (see
+/// [`should_keep_node`]).
+const STALE_AFTER: chrono::Duration = chrono::Duration::seconds(60);
+
+/// Decide whether a node should remain in the cluster node map.
+///
+/// The master is always kept. A node with a live WS control channel
+/// (`connected`) is always kept, regardless of heartbeat age: an open
+/// connection means the agent is alive, and a single late heartbeat (lock
+/// contention, load spike, jitter) must not orphan it — pruning a connected
+/// node leaves the master and agent permanently desynced because the agent's
+/// WS never drops and so never re-registers. Only a node that is both stale
+/// *and* has no live connection is dropped.
+fn should_keep_node(
+    id: u64,
+    master_id: u64,
+    connected: &std::collections::HashSet<u64>,
+    last_heartbeat: chrono::DateTime<chrono::Utc>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    if id == master_id || connected.contains(&id) {
+        return true;
+    }
+    now - last_heartbeat < STALE_AFTER
+}
+
 /// Spawn a periodic task that samples host stats and writes them onto the
 /// master node's entry in the cluster node map. Joined nodes push their own
 /// stats via the heartbeat; the master has no heartbeat to piggyback on so
 /// it does this in-process instead. The same loop also prunes zombie
-/// nodes — entries whose last heartbeat is older than 60s — which keeps
-/// the cluster/info endpoint clean after a joined node is restarted with
-/// a fresh id (until node.id persistence lands on every joined box).
+/// nodes — entries that are both stale (no heartbeat for >60s) and have no
+/// live WS connection — which keeps the cluster/info endpoint clean after a
+/// joined node disconnects for good.
 fn spawn_master_heartbeat(state: Arc<state::AppState>) {
-    const STALE_AFTER: chrono::Duration = chrono::Duration::seconds(60);
     let node_id = master_node_id();
     let collector = Arc::new(orca_agent::host_stats::HostStatsCollector::new());
     tokio::spawn(async move {
@@ -333,6 +359,17 @@ fn spawn_master_heartbeat(state: Arc<state::AppState>) {
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
             let sample = collector.sample();
             let now = chrono::Utc::now();
+
+            // Snapshot the nodes that still hold a live WS control channel. A node
+            // with an open connection is alive even if a single heartbeat was merely
+            // delayed (lock contention, load spike, or network jitter that stalls but
+            // does not drop the socket). Pruning such a node orphans the agent: its WS
+            // stays up so it never re-registers, and the only recovery is a full
+            // restart of every node. Read this lock first and drop it before taking
+            // the registered_nodes write lock to avoid holding both at once.
+            let connected: std::collections::HashSet<u64> =
+                state.ws_agents.read().await.keys().copied().collect();
+
             let mut nodes = state.registered_nodes.write().await;
             if let Some(node) = nodes.get_mut(&node_id) {
                 node.last_heartbeat = now;
@@ -345,11 +382,15 @@ fn spawn_master_heartbeat(state: Arc<state::AppState>) {
                 node.net_tx = sample.net_tx;
             }
             nodes.retain(|id, node| {
-                if *id == node_id {
-                    return true;
+                let keep = should_keep_node(*id, node_id, &connected, node.last_heartbeat, now);
+                if !keep {
+                    tracing::warn!(
+                        node_id = *id,
+                        age_secs = (now - node.last_heartbeat).num_seconds(),
+                        "Pruning stale node: no heartbeat for >60s and no live WS connection"
+                    );
                 }
-                let age = now - node.last_heartbeat;
-                age < STALE_AFTER
+                keep
             });
         }
     });
@@ -360,4 +401,72 @@ async fn shutdown_signal() {
         .await
         .expect("failed to install ctrl+c handler");
     info!("Shutdown signal received");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    const MASTER: u64 = 1;
+    const AGENT: u64 = 2;
+
+    fn ago(now: chrono::DateTime<chrono::Utc>, secs: i64) -> chrono::DateTime<chrono::Utc> {
+        now - chrono::Duration::seconds(secs)
+    }
+
+    #[test]
+    fn master_is_never_pruned_even_when_stale() {
+        let now = chrono::Utc::now();
+        let connected = HashSet::new();
+        assert!(should_keep_node(
+            MASTER,
+            MASTER,
+            &connected,
+            ago(now, 600),
+            now
+        ));
+    }
+
+    #[test]
+    fn fresh_agent_is_kept() {
+        let now = chrono::Utc::now();
+        let connected = HashSet::new();
+        assert!(should_keep_node(
+            AGENT,
+            MASTER,
+            &connected,
+            ago(now, 5),
+            now
+        ));
+    }
+
+    #[test]
+    fn stale_agent_without_connection_is_pruned() {
+        let now = chrono::Utc::now();
+        let connected = HashSet::new();
+        assert!(!should_keep_node(
+            AGENT,
+            MASTER,
+            &connected,
+            ago(now, 120),
+            now
+        ));
+    }
+
+    #[test]
+    fn stale_agent_with_live_ws_is_kept() {
+        // Regression: a delayed heartbeat on a still-connected agent must not
+        // orphan it. A connected-but-stale node was the cause of the
+        // master-forgets-agent desync that required restarting every node.
+        let now = chrono::Utc::now();
+        let connected = HashSet::from([AGENT]);
+        assert!(should_keep_node(
+            AGENT,
+            MASTER,
+            &connected,
+            ago(now, 600),
+            now
+        ));
+    }
 }

--- a/crates/orca-proxy/src/forward.rs
+++ b/crates/orca-proxy/src/forward.rs
@@ -1,5 +1,7 @@
 //! Backend forwarding with retry logic and HTTPS redirect helpers.
 
+use http_body_util::BodyDataStream;
+use hyper::body::Incoming;
 use hyper::{Response, StatusCode};
 use tracing::{debug, error};
 
@@ -36,8 +38,126 @@ pub(crate) fn weighted_index(targets: &[RouteTarget], counter: usize) -> usize {
     targets.len() - 1
 }
 
+/// Apply per-target prefix stripping so backends that expect a clean URL
+/// (e.g. `/users`) don't see the full routed path (e.g. `/admin/users`).
+/// No-op when `strip_prefix` is `None`.
+fn strip_target_prefix<'a>(
+    target: &RouteTarget,
+    path_and_query: &'a str,
+) -> std::borrow::Cow<'a, str> {
+    match &target.strip_prefix {
+        Some(prefix) if path_and_query.starts_with(prefix.as_str()) => {
+            let rest = &path_and_query[prefix.len()..];
+            if rest.is_empty() {
+                std::borrow::Cow::Borrowed("/")
+            } else if rest.starts_with('/') {
+                std::borrow::Cow::Borrowed(rest)
+            } else {
+                std::borrow::Cow::Owned(format!("/{rest}"))
+            }
+        }
+        _ => std::borrow::Cow::Borrowed(path_and_query),
+    }
+}
+
+/// Build the forwarded reqwest request for `target` — method, URI (with
+/// prefix stripping), client headers, and the X-Forwarded-* set — but WITHOUT
+/// a body attached. Shared by the buffered retry path and the single-target
+/// streaming path. Returns the builder and the resolved upstream URI (for
+/// logging). The caller attaches the body.
+#[allow(clippy::too_many_arguments)]
+fn build_forward_request(
+    client: &reqwest::Client,
+    target: &RouteTarget,
+    method: &reqwest::Method,
+    headers: &hyper::HeaderMap,
+    path_and_query: &str,
+    host: &str,
+    is_tls: bool,
+    client_ip: &str,
+) -> (reqwest::RequestBuilder, String) {
+    let forwarded_path = strip_target_prefix(target, path_and_query);
+    let uri = format!("http://{}{}", target.address, forwarded_path);
+
+    let mut forward_req = client.request(method.clone(), &uri);
+    let mut saw_xff = false;
+    let mut saw_proto = false;
+    let mut saw_fhost = false;
+    for (key, value) in headers {
+        let name = key.as_str().to_lowercase();
+        if name == "host" {
+            // Skip the original Host header — reqwest sets it from URI.
+            // We preserve the original host via X-Forwarded-Host below,
+            // but also set Host to the original so backends (litellm,
+            // keycloak) that build redirect URLs from Host see the
+            // external domain, not the internal 127.0.0.1:port.
+            continue;
+        }
+        if name == "x-forwarded-for" {
+            saw_xff = true;
+        } else if name == "x-forwarded-proto" {
+            saw_proto = true;
+        } else if name == "x-forwarded-host" {
+            saw_fhost = true;
+        }
+        forward_req = forward_req.header(key, value);
+    }
+    // Override the Host header to the original external host so backends that
+    // build redirect URLs from Host (litellm /ui, keycloak OIDC) use the
+    // correct public-facing domain.
+    forward_req = forward_req.header("Host", host);
+    // Inject X-Forwarded-* for upstream apps behind TLS termination.
+    let scheme = if is_tls { "https" } else { "http" };
+    if !saw_proto {
+        forward_req = forward_req.header("X-Forwarded-Proto", scheme);
+    }
+    if !saw_fhost {
+        forward_req = forward_req.header("X-Forwarded-Host", host);
+    }
+    if !saw_xff {
+        forward_req = forward_req.header("X-Forwarded-For", client_ip);
+    }
+    (forward_req, uri)
+}
+
+/// Convert an upstream reqwest response into the proxy's streaming response,
+/// copying backend headers (minus hop-by-hop) and streaming the body straight
+/// through instead of buffering with `resp.bytes().await`. For a Docker
+/// registry blob pull (100MB+) buffering doubles end-to-end latency AND parks
+/// ~100MB in the proxy task — when several pile up, the accept loop loses the
+/// headroom to complete new TLS handshakes (`docker login`, browser hits) and
+/// they time out. See the v0.2.9-rc.2 streaming-bodies memory.
+fn build_response(resp: reqwest::Response) -> Response<ProxyBody> {
+    let status = resp.status();
+    let backend_headers = resp.headers().clone();
+    let body = stream_body(resp.bytes_stream());
+    let mut response = Response::new(body);
+    *response.status_mut() = status;
+    // Forward backend headers (skip hop-by-hop only). content-length is
+    // preserved — clients need it.
+    for (k, v) in backend_headers.iter() {
+        let name = k.as_str().to_lowercase();
+        if !matches!(
+            name.as_str(),
+            "connection"
+                | "keep-alive"
+                | "proxy-authenticate"
+                | "proxy-authorization"
+                | "te"
+                | "trailers"
+                | "transfer-encoding"
+                | "upgrade"
+        ) {
+            response.headers_mut().append(k.clone(), v.clone());
+        }
+    }
+    response
+}
+
 /// Forward a request to a backend, retrying once on 502 with a different
-/// backend if multiple exist.
+/// backend if multiple exist. Buffers the request body (`body`) so it can be
+/// replayed on retry — used for multi-target routes. Single-target routes use
+/// [`forward_streaming`] instead, which avoids buffering entirely.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn forward_with_retry(
     client: &reqwest::Client,
@@ -61,109 +181,28 @@ pub(crate) async fn forward_with_retry(
             (weighted_index(matched, base_idx) + 1) % matched.len()
         };
         let target = &matched[idx];
-        // Apply per-target prefix stripping so backends that expect a
-        // clean URL (e.g. /users) don't see the full routed path
-        // (e.g. /admin/users). No-op when `strip_prefix` is None.
-        let forwarded_path: std::borrow::Cow<'_, str> = match &target.strip_prefix {
-            Some(prefix) if path_and_query.starts_with(prefix.as_str()) => {
-                let rest = &path_and_query[prefix.len()..];
-                if rest.is_empty() {
-                    std::borrow::Cow::Borrowed("/")
-                } else if rest.starts_with('/') {
-                    std::borrow::Cow::Borrowed(rest)
-                } else {
-                    std::borrow::Cow::Owned(format!("/{rest}"))
-                }
-            }
-            _ => std::borrow::Cow::Borrowed(path_and_query),
-        };
-        let uri = format!("http://{}{}", target.address, forwarded_path);
-
+        let (forward_req, uri) = build_forward_request(
+            client,
+            target,
+            method,
+            headers,
+            path_and_query,
+            host,
+            is_tls,
+            &client_ip,
+        );
         debug!("Proxying {host}{path_and_query} -> {uri} (attempt {attempt})");
-
-        let mut forward_req = client.request(method.clone(), &uri);
-        let mut saw_xff = false;
-        let mut saw_proto = false;
-        let mut saw_fhost = false;
-        for (key, value) in headers {
-            let name = key.as_str().to_lowercase();
-            if name == "host" {
-                // Skip the original Host header — reqwest sets it from URI.
-                // We preserve the original host via X-Forwarded-Host below,
-                // but also set Host to the original so backends (litellm,
-                // keycloak) that build redirect URLs from Host see the
-                // external domain, not the internal 127.0.0.1:port.
-                continue;
-            }
-            if name == "x-forwarded-for" {
-                saw_xff = true;
-            } else if name == "x-forwarded-proto" {
-                saw_proto = true;
-            } else if name == "x-forwarded-host" {
-                saw_fhost = true;
-            }
-            forward_req = forward_req.header(key, value);
-        }
-        // Override the Host header to the original external host so
-        // backends that build redirect URLs from Host (litellm /ui,
-        // keycloak OIDC) use the correct public-facing domain.
-        forward_req = forward_req.header("Host", host);
-        // Inject X-Forwarded-* for upstream apps behind TLS termination
-        let scheme = if is_tls { "https" } else { "http" };
-        if !saw_proto {
-            forward_req = forward_req.header("X-Forwarded-Proto", scheme);
-        }
-        if !saw_fhost {
-            forward_req = forward_req.header("X-Forwarded-Host", host);
-        }
-        if !saw_xff {
-            forward_req = forward_req.header("X-Forwarded-For", &client_ip);
-        }
-        forward_req = forward_req.body(body.clone());
+        let forward_req = forward_req.body(body.clone());
 
         match forward_req.send().await {
             Ok(resp) if resp.status() == StatusCode::BAD_GATEWAY && attempt + 1 < max_attempts => {
                 debug!("Got 502 from {}, retrying", target.address);
                 continue;
             }
-            Ok(resp) => {
-                let status = resp.status();
-                let backend_headers = resp.headers().clone();
-                // Stream the upstream body straight through instead of
-                // buffering with resp.bytes().await. For a Docker registry
-                // blob pull (100MB+) buffering doubles end-to-end latency
-                // AND parks ~100MB in the proxy task — when several streams
-                // pile up, the proxy's accept loop runs out of headroom and
-                // new TLS handshakes from concurrent clients (`docker login`,
-                // browser hits) start timing out. See PR description / the
-                // v0.2.9-rc.2 streaming-bodies memory for the full incident.
-                //
-                // 502 retry is preserved: status is checked above before we
-                // consume the body, so a 502 still falls through to the
-                // next iteration without writing anything to the client.
-                let body = stream_body(resp.bytes_stream());
-                let mut response = Response::new(body);
-                *response.status_mut() = status;
-                // Forward backend headers (skip hop-by-hop only).
-                // content-length is preserved — clients need it.
-                for (k, v) in backend_headers.iter() {
-                    let name = k.as_str().to_lowercase();
-                    if !matches!(
-                        name.as_str(),
-                        "connection"
-                            | "keep-alive"
-                            | "proxy-authenticate"
-                            | "proxy-authorization"
-                            | "te"
-                            | "trailers"
-                            | "transfer-encoding"
-                            | "upgrade"
-                    ) {
-                        response.headers_mut().append(k.clone(), v.clone());
-                    }
-                }
-                return response;
-            }
+            // 502 retry is preserved: status is checked above before we
+            // consume the body, so a 502 falls through to the next attempt
+            // without writing anything to the client.
+            Ok(resp) => return build_response(resp),
             Err(e) if attempt + 1 < max_attempts => {
                 debug!("Backend error from {}: {e}, retrying", target.address);
                 continue;
@@ -179,6 +218,52 @@ pub(crate) async fn forward_with_retry(
     }
 
     super::handler::error_response(StatusCode::BAD_GATEWAY, "all backends failed")
+}
+
+/// Forward a single-target request, streaming the request body straight to the
+/// backend with no intermediate buffer (symmetric to the response streaming in
+/// [`build_response`] / #63).
+///
+/// A single-target route has no alternate backend, so the loss of 502-retry —
+/// a streamed body is single-use — costs nothing. This covers the >90% of
+/// routes with exactly one target, notably Docker registry blob *pushes*
+/// (100MB+ layers) which previously buffered fully in the proxy task and were a
+/// contributing factor in the accept-loop starvation seen in v0.2.9-rc.2.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn forward_streaming(
+    client: &reqwest::Client,
+    target: &RouteTarget,
+    method: &reqwest::Method,
+    headers: &hyper::HeaderMap,
+    body: Incoming,
+    path_and_query: &str,
+    host: &str,
+    is_tls: bool,
+    client_ip: String,
+) -> Response<ProxyBody> {
+    let (forward_req, uri) = build_forward_request(
+        client,
+        target,
+        method,
+        headers,
+        path_and_query,
+        host,
+        is_tls,
+        &client_ip,
+    );
+    debug!("Proxying (stream) {host}{path_and_query} -> {uri}");
+
+    // Wrap the incoming hyper body as a byte stream for reqwest — data frames
+    // flow through without ever materializing the full body in memory.
+    let forward_req = forward_req.body(reqwest::Body::wrap_stream(BodyDataStream::new(body)));
+
+    match forward_req.send().await {
+        Ok(resp) => build_response(resp),
+        Err(e) => {
+            error!("Proxy error to {}: {e}", target.address);
+            super::handler::error_response(StatusCode::BAD_GATEWAY, &format!("backend error: {e}"))
+        }
+    }
 }
 
 /// Build a 301 redirect response to HTTPS.

--- a/crates/orca-proxy/src/handler.rs
+++ b/crates/orca-proxy/src/handler.rs
@@ -14,7 +14,7 @@ use tracing::{debug, error, info};
 
 use crate::acme::AcmeManager;
 use crate::body::{ProxyBody, full_body};
-use crate::forward::{forward_with_retry, redirect_to_https};
+use crate::forward::{forward_streaming, forward_with_retry, redirect_to_https};
 use crate::rate_limit::RateLimiter;
 use crate::routing::{find_matching_trigger, select_path_targets};
 use crate::{RouteTarget, SharedWasmTriggers, WasmInvoker};
@@ -220,7 +220,7 @@ pub(crate) async fn handle_request(
         return Ok(crate::websocket::handle_websocket_proxy(req, &target.address).await);
     }
 
-    // Read body once for forwarding (and potential retry)
+    // Snapshot request metadata before consuming the body below.
     let method_reqwest: reqwest::Method = req.method().clone();
     let headers = req.headers().clone();
     let pq = req
@@ -230,31 +230,49 @@ pub(crate) async fn handle_request(
         .unwrap_or("/")
         .to_string();
 
-    let body_bytes = match req.into_body().collect().await {
-        Ok(collected) => collected.to_bytes(),
-        Err(e) => {
-            error!("Failed to read request body: {e}");
-            return Ok(error_response(
-                StatusCode::BAD_GATEWAY,
-                "failed to read request body",
-            ));
-        }
+    // Single-target route: stream the request body straight through with no
+    // buffering. There's no alternate backend, so giving up 502-retry (a
+    // streamed body is single-use) costs nothing, and a 100MB+ registry blob
+    // push never has to materialize in the proxy task. Multi-target routes
+    // buffer the body so it can be replayed against a second backend on 502.
+    let resp = if matched.len() == 1 {
+        forward_streaming(
+            client,
+            &matched[0],
+            &method_reqwest,
+            &headers,
+            req.into_body(),
+            &pq,
+            &host,
+            is_tls,
+            peer.ip().to_string(),
+        )
+        .await
+    } else {
+        let body_bytes = match req.into_body().collect().await {
+            Ok(collected) => collected.to_bytes(),
+            Err(e) => {
+                error!("Failed to read request body: {e}");
+                return Ok(error_response(
+                    StatusCode::BAD_GATEWAY,
+                    "failed to read request body",
+                ));
+            }
+        };
+        forward_with_retry(
+            client,
+            &matched,
+            base_idx,
+            &method_reqwest,
+            &headers,
+            &body_bytes,
+            &pq,
+            &host,
+            is_tls,
+            peer.ip().to_string(),
+        )
+        .await
     };
-
-    // Forward with retry on 502
-    let resp = forward_with_retry(
-        client,
-        &matched,
-        base_idx,
-        &method_reqwest,
-        &headers,
-        &body_bytes,
-        &pq,
-        &host,
-        is_tls,
-        peer.ip().to_string(),
-    )
-    .await;
 
     let elapsed_ms = start.elapsed().as_millis();
     let status = resp.status().as_u16();

--- a/crates/orca-proxy/tests/request_streaming_test.rs
+++ b/crates/orca-proxy/tests/request_streaming_test.rs
@@ -1,0 +1,155 @@
+//! End-to-end test: the proxy streams large *request* bodies for
+//! single-target routes without buffering them (issue #72). This is the
+//! symmetric counterpart to the response-body streaming covered in
+//! `streaming_body_test.rs` (#63).
+//!
+//! A single-target route — here the `fallback.http` path, which resolves to
+//! exactly one target — takes `forward::forward_streaming`, which wraps the
+//! incoming hyper body as a reqwest stream instead of `collect()`-ing it into
+//! `Bytes`. The backend echoes the request body straight back, so the test
+//! asserts the round trip byte-for-byte for a payload far larger than any
+//! sane intermediate buffer. Before this change, a 100MB+ registry blob push
+//! was fully buffered in the proxy task before forwarding — a contributing
+//! factor in the accept-loop starvation seen in v0.2.9-rc.2.
+//!
+//! This asserts *correctness* of request streaming, not perf; perf is
+//! validated against a real registry push workload.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use http_body_util::{BodyExt, Full};
+use hyper::body::Incoming;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use orca_core::config::FallbackConfig;
+use orca_proxy::run_proxy_with_fallback;
+use tokio::net::TcpListener;
+use tokio::sync::RwLock;
+
+/// Spawn a backend that echoes the received request body back verbatim.
+async fn spawn_echo_backend() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            tokio::spawn(async move {
+                let svc = service_fn(|req: Request<Incoming>| async move {
+                    let body = req.into_body().collect().await.unwrap().to_bytes();
+                    Ok::<_, hyper::Error>(Response::new(Full::new(body)))
+                });
+                let _ = http1::Builder::new().serve_connection(io, svc).await;
+            });
+        }
+    });
+    addr
+}
+
+/// Start the orca proxy forwarding ALL traffic to `backend` via `fallback.http`
+/// (a single-target route, so the streaming forward path is exercised). Polls
+/// until bound so tests don't race.
+async fn spawn_proxy(backend: SocketAddr) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    let routes = Arc::new(RwLock::new(HashMap::new()));
+    let triggers = Arc::new(RwLock::new(Vec::new()));
+    let fallback = FallbackConfig {
+        http: Some(backend.to_string()),
+        tls: None,
+    };
+
+    tokio::spawn(async move {
+        let _ =
+            run_proxy_with_fallback(routes, triggers, None, port, None, None, Some(fallback)).await;
+    });
+
+    let probe = client();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    while tokio::time::Instant::now() < deadline {
+        if probe
+            .post(format!("http://127.0.0.1:{port}/_probe"))
+            .header("Host", "any.example.com")
+            .body("probe")
+            .send()
+            .await
+            .is_ok()
+        {
+            return port;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("proxy on port {port} never came up");
+}
+
+/// reqwest client with no proxy env pickup and no redirect-following (matches
+/// the response-streaming test's rationale).
+fn client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .no_proxy()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap()
+}
+
+/// Deterministic byte pattern so the round trip is asserted byte-for-byte.
+fn pattern(len: usize) -> Vec<u8> {
+    (0..len).map(|i| (i % 251) as u8).collect()
+}
+
+#[tokio::test]
+async fn proxy_streams_large_request_body_byte_for_byte() {
+    // 16 MiB request body — large enough that any buffering regression would
+    // show as a memory blip, and large enough to span many TCP segments
+    // through the streaming pipeline. Models a registry blob push.
+    const LEN: usize = 16 * 1024 * 1024;
+    let payload = pattern(LEN);
+
+    let backend = spawn_echo_backend().await;
+    let port = spawn_proxy(backend).await;
+
+    let resp = client()
+        .post(format!("http://127.0.0.1:{port}/v2/blobs/uploads/"))
+        .header("Host", "registry.example.com")
+        .body(payload.clone())
+        .send()
+        .await
+        .expect("proxy request must succeed");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let echoed = resp.bytes().await.expect("body must read cleanly");
+    assert_eq!(
+        echoed.len(),
+        LEN,
+        "streamed request body length differs from what was sent"
+    );
+    assert_eq!(
+        &echoed[..],
+        &payload[..],
+        "streamed request body bytes differ from what was sent"
+    );
+}
+
+#[tokio::test]
+async fn proxy_streams_empty_request_body() {
+    // A bodyless GET on a single-target route must still forward cleanly
+    // through the streaming path (empty stream, not a hang).
+    let backend = spawn_echo_backend().await;
+    let port = spawn_proxy(backend).await;
+
+    let resp = client()
+        .get(format!("http://127.0.0.1:{port}/"))
+        .header("Host", "registry.example.com")
+        .send()
+        .await
+        .expect("proxy request must succeed");
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(resp.bytes().await.unwrap().is_empty());
+}


### PR DESCRIPTION
Three v0.2.10 fixes: one prod-reported cluster desync bug, plus the proxy and backup milestone items.

## 1. `fix(control)`: master forgets live agents → permanent desync (Refs #84)

The master heartbeat loop pruned any non-master node stale for >60s **even with a live WebSocket**. Combined with the WS heartbeat handler only refreshing the timestamp when the node is already present (`get_mut`), and re-registration only happening on a *fresh* WS connect, a single delayed heartbeat on a still-connected agent (lock contention, load spike, or TCP jitter that stalls but doesn't drop the socket) permanently desynced master and agent — the WS stayed up so the agent never re-registered, and the only recovery was restarting the systemd service on every node.

**Fix:** a node with a live WS control channel is alive by definition — never prune it. Genuinely dead nodes are removed from `ws_agents` on disconnect, so they still get culled after 60s. Extracted the decision into a pure, testable `should_keep_node`, snapshot `ws_agents` before the `registered_nodes` write lock, and log evictions (previously silent). 4 regression tests.

> Distinct from #84, which is about culling genuinely *dead* phantom nodes + a `DELETE /nodes` API. This fixes *live* nodes being wrongly forgotten. The two pair naturally.

## 2. `perf(proxy)`: stream request bodies for single-target routes (Closes #72)

`handle_request` buffered the entire request body before forwarding, so a 100MB+ registry blob push fully materialized in the proxy task — a contributing factor in the rc.2 accept-loop starvation. Symmetric counterpart to the response-body streaming in #63.

**Fix:** single-target routes stream the body straight through (`BodyDataStream` + `reqwest::Body::wrap_stream`); they have no alternate backend, so giving up 502-retry costs nothing. Multi-target routes keep the buffer-and-clone path so the body can be replayed on 502. Extracted `build_forward_request`/`build_response` so both paths share header/response handling. New integration test streams a 16 MiB request body byte-for-byte + an empty-body case.

## 3. `fix(backup)`: warn about excluded host bind mounts (Closes #83)

`orca backup all` captured named volumes but silently skipped host bind mounts (`mounts = [...]`). A service with bind mounts and no named volume even hit the "No orca volumes found." early-return and exited clean — exactly how a freqtrade fleet's live trading state was lost in a VPS reclaim.

**Fix:** inspect running orca containers (Docker = source of truth) and warn about every bind mount, grouped by service, to stdout (manual runs) and `tracing::warn!` (scheduled/agent runs), with a final summary line that surfaces in the dashboard's last-backup message. Runs even with no named volumes. New `bind_mounts` submodule + unit tests. Opt-in *capture* and `backup list` surfacing are deferred follow-ups; warning alone closes the silent-data-loss gap.

## Verification
- `cargo fmt --all` clean
- `cargo clippy -- -D warnings` clean (the project/CI gate)
- `cargo test`: **484 passed, 0 failed**

> Note: `cargo clippy --all-targets` surfaces two pre-existing `field_reassign_with_default` lints in `orca-control` integration tests (`ws_reconcile_test.rs`, `remote_state_test.rs`) that exist on `main` and are unrelated to this branch — left untouched to keep the diff focused. CI uses `cargo clippy -- -D warnings`, which is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)