### PR TITLE
feat(agent): extra_ports supports specific host_ip binding

### DIFF
--- a/crates/orca-agent/src/docker/config_builder/helpers.rs
+++ b/crates/orca-agent/src/docker/config_builder/helpers.rs
@@ -11,6 +11,58 @@ use orca_core::types::WorkloadSpec;
 pub(super) type PortBindings = HashMap<String, Option<Vec<PortBinding>>>;
 pub(super) type ExposedPorts = HashMap<String, HashMap<(), ()>>;
 
+/// Parsed `extra_ports` entry: (host_ip, host_port, container_port, proto).
+pub(super) struct ExtraPort {
+    pub host_ip: String,
+    pub host_port: String,
+    pub container_port: String,
+    pub proto: String,
+}
+
+/// Parse a single `extra_ports` entry.
+///
+/// Accepted forms (matching docker-compose):
+///   - `host:container`                 → 0.0.0.0:host → container/tcp
+///   - `host:container/proto`           → 0.0.0.0:host → container/proto
+///   - `host_ip:host:container`         → host_ip:host → container/tcp
+///   - `host_ip:host:container/proto`   → host_ip:host → container/proto
+///
+/// The 3-segment form lets a service bind to a specific host address
+/// instead of the wildcard `0.0.0.0`. Needed when another listener
+/// (systemd-resolved, netbird, etc.) already holds a specific-IP bind
+/// on the same port — a wildcard bind from docker would collide.
+///
+/// Returns `None` for malformed entries so the caller can skip them.
+pub(super) fn parse_extra_port(entry: &str) -> Option<ExtraPort> {
+    let (port_spec, proto) = match entry.rsplit_once('/') {
+        Some((spec, p)) => (spec, p.to_string()),
+        None => (entry, "tcp".to_string()),
+    };
+    let parts: Vec<&str> = port_spec.split(':').collect();
+    match parts.as_slice() {
+        [host, container] if !host.is_empty() && !container.is_empty() => Some(ExtraPort {
+            host_ip: "0.0.0.0".to_string(),
+            host_port: (*host).to_string(),
+            container_port: (*container).to_string(),
+            proto,
+        }),
+        [host_ip, host, container]
+            if !host_ip.is_empty()
+                && !host.is_empty()
+                && !container.is_empty()
+                && host_ip.parse::<std::net::Ipv4Addr>().is_ok() =>
+        {
+            Some(ExtraPort {
+                host_ip: (*host_ip).to_string(),
+                host_port: (*host).to_string(),
+                container_port: (*container).to_string(),
+                proto,
+            })
+        }
+        _ => None,
+    }
+}
+
 pub(super) fn build_port_config(
     port: Option<u16>,
     host_port: Option<u16>,
@@ -348,5 +400,69 @@ mod tests {
         assert!(gpu.device_requests.is_empty());
         assert!(gpu.devices.is_empty());
         assert!(gpu.group_add.is_empty());
+    }
+
+    #[test]
+    fn extra_port_two_segment_defaults_to_wildcard_tcp() {
+        let p = parse_extra_port("3000:3000").expect("should parse");
+        assert_eq!(p.host_ip, "0.0.0.0");
+        assert_eq!(p.host_port, "3000");
+        assert_eq!(p.container_port, "3000");
+        assert_eq!(p.proto, "tcp");
+    }
+
+    #[test]
+    fn extra_port_two_segment_with_proto() {
+        let p = parse_extra_port("10000:10000/udp").expect("should parse");
+        assert_eq!(p.host_ip, "0.0.0.0");
+        assert_eq!(p.host_port, "10000");
+        assert_eq!(p.container_port, "10000");
+        assert_eq!(p.proto, "udp");
+    }
+
+    #[test]
+    fn extra_port_three_segment_binds_specific_ip() {
+        let p = parse_extra_port("46.225.100.82:53:53").expect("should parse");
+        assert_eq!(p.host_ip, "46.225.100.82");
+        assert_eq!(p.host_port, "53");
+        assert_eq!(p.container_port, "53");
+        assert_eq!(p.proto, "tcp");
+    }
+
+    #[test]
+    fn extra_port_three_segment_with_proto() {
+        let p = parse_extra_port("46.225.100.82:53:53/udp").expect("should parse");
+        assert_eq!(p.host_ip, "46.225.100.82");
+        assert_eq!(p.host_port, "53");
+        assert_eq!(p.container_port, "53");
+        assert_eq!(p.proto, "udp");
+    }
+
+    #[test]
+    fn extra_port_three_segment_rejects_non_ip_first_field() {
+        // Without a valid IPv4 in the first slot, 3-segment form is ambiguous —
+        // we refuse rather than silently misroute.
+        assert!(parse_extra_port("not-an-ip:53:53").is_none());
+    }
+
+    #[test]
+    fn extra_port_rejects_empty_parts() {
+        assert!(parse_extra_port(":53:53").is_none());
+        assert!(parse_extra_port("53:").is_none());
+        assert!(parse_extra_port(":53").is_none());
+    }
+
+    #[test]
+    fn extra_port_rejects_no_colon() {
+        assert!(parse_extra_port("3000").is_none());
+        assert!(parse_extra_port("garbage").is_none());
+    }
+
+    #[test]
+    fn extra_port_loopback_ipv4_accepted() {
+        // Common pattern: bind only to 127.0.0.1 so a port stays node-local
+        // even when the host has a public interface.
+        let p = parse_extra_port("127.0.0.1:8081:8081").expect("should parse");
+        assert_eq!(p.host_ip, "127.0.0.1");
     }
 }

--- a/crates/orca-agent/src/docker/config_builder/mod.rs
+++ b/crates/orca-agent/src/docker/config_builder/mod.rs
@@ -11,7 +11,7 @@ use orca_core::types::WorkloadSpec;
 
 use helpers::{
     build_all_binds, build_gpu_passthrough, build_labels, build_log_config, build_port_config,
-    parse_resource_limits,
+    parse_extra_port, parse_resource_limits,
 };
 
 /// Build a Docker container [`Config`] from a workload spec.
@@ -19,23 +19,21 @@ pub(crate) fn build_container_config(spec: &WorkloadSpec) -> Config<String> {
     let env: Vec<String> = spec.env.iter().map(|(k, v)| format!("{k}={v}")).collect();
 
     let (mut port_bindings, mut exposed_ports) = build_port_config(spec.port, spec.host_port);
-    // `extra_ports` accepts both `host:container` (defaults to tcp) and
-    // `host:container/proto`, e.g. `10000:10000/udp` for Jitsi JVB media.
+    // `extra_ports` accepts the docker-compose forms:
+    //   `host:container`               (defaults to 0.0.0.0 + tcp)
+    //   `host:container/proto`         (e.g. `10000:10000/udp` for Jitsi JVB media)
+    //   `host_ip:host:container[/proto]` (bind to a specific host address)
     for entry in &spec.extra_ports {
-        let Some((host, rest)) = entry.split_once(':') else {
+        let Some(parsed) = parse_extra_port(entry) else {
             continue;
         };
-        let (container, proto) = match rest.rsplit_once('/') {
-            Some((c, p)) => (c, p),
-            None => (rest, "tcp"),
-        };
-        let key = format!("{container}/{proto}");
+        let key = format!("{}/{}", parsed.container_port, parsed.proto);
         exposed_ports.insert(key.clone(), HashMap::new());
         port_bindings.insert(
             key,
             Some(vec![PortBinding {
-                host_ip: Some("0.0.0.0".to_string()),
-                host_port: Some(host.to_string()),
+                host_ip: Some(parsed.host_ip),
+                host_port: Some(parsed.host_port),
             }]),
         );
     }


### PR DESCRIPTION
## Why

The `extra_ports` builder previously hardcoded `host_ip: \"0.0.0.0\"` for every `PortBinding`, so a service couldn't bind only the public interface.

This collides on hosts where another listener already holds a specific-IP bind on the same port — e.g. running a public DNS server on a host that also runs `systemd-resolved` (on `127.0.0.x`) or `netbird` (on the mesh tun). Docker's wildcard `0.0.0.0:53` bind fails with `address already in use` even though no process owns the wildcard, because the kernel disallows a wildcard bind that overlaps with existing specific-IP binds on the same port without `SO_REUSEADDR` cooperation that docker-proxy doesn't provide.

Hit this trying to deploy PowerDNS for the breakpilot stage environment on the orca master.

## What

Teach the `extra_ports` parser the docker-compose-standard 3-segment form:

\`\`\`
\"host_ip:host_port:container_port[/proto]\"
\`\`\`

while keeping the existing 2-segment form working unchanged. The first segment must parse as IPv4 to disambiguate from the legacy form.

Worked example for the breakpilot stage PowerDNS:

\`\`\`toml
extra_ports = [\"46.225.100.82:53:53/udp\", \"46.225.100.82:53:53\"]
\`\`\`

binds pdns-auth only to the master's public IP, sidestepping the collision with the loopback (systemd-resolved) and netbird-tun (netbird) specific-IP listeners on :53.

## Code change

- Extracted the parser into a tested helper `parse_extra_port` in `helpers.rs` returning a small `ExtraPort` struct.
- Rewrote the `extra_ports` loop in `mod.rs` to use it and pass `host_ip` through to the `PortBinding`.
- 8 new unit tests cover backward-compat forms, the new IP-prefixed forms, malformed entries, and loopback binding.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy -j8 -p orca-agent --all-targets -- -D warnings\` — clean
- [x] \`cargo test -j8 -p orca-agent\` — 35 passed (27 existing + 8 new)
- [ ] After merge + rebuild + redeploy of the master: \`extra_ports = [\"46.225.100.82:53:53/udp\", \"46.225.100.82:53:53\"]\` in services/breakpilot/service.toml binds successfully and `dig @46.225.100.82 . SOA` returns a response.

## Notes

- IPv6 brackets (\`[::1]:host:container\`) intentionally not supported in this PR — easy follow-up if needed; not blocking for the current use case.
- The 3-segment form requires a valid IPv4 in the first slot. Anything else falls through to the parse-failure path so callers can skip malformed entries (matching existing behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)