### PR TITLE
chore(release): bump workspace to v0.2.10-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mallorca"
-version = "0.2.9"
+version = "0.2.10-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2554,7 +2554,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orca-agent"
-version = "0.2.9"
+version = "0.2.10-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "orca-ai"
-version = "0.2.9"
+version = "0.2.10-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "orca-control"
-version = "0.2.9"
+version = "0.2.10-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "orca-core"
-version = "0.2.9"
+version = "0.2.10-rc.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "orca-proxy"
-version = "0.2.9"
+version = "0.2.10-rc.1"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "orca-tui"
-version = "0.2.9"
+version = "0.2.10-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "orca-web"
-version = "0.2.9"
+version = "0.2.10-rc.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/wasm-hello"]
 
 [workspace.package]
-version = "0.2.9"
+version = "0.2.10-rc.1"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mighty840/orca"
@@ -24,9 +24,9 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Shared across crates
-orca-core = { path = "crates/orca-core", version = "0.2.9" }
-orca-ai = { path = "crates/orca-ai", version = "0.2.9" }
-orca-proxy = { path = "crates/orca-proxy", version = "0.2.9" }
+orca-core = { path = "crates/orca-core", version = "0.2.10-rc.1" }
+orca-ai = { path = "crates/orca-ai", version = "0.2.10-rc.1" }
+orca-proxy = { path = "crates/orca-proxy", version = "0.2.10-rc.1" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/orca-cli/Cargo.toml
+++ b/crates/orca-cli/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/main.rs"
 [dependencies]
 orca-core = { workspace = true }
 orca-ai = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.9" }
-orca-control = { path = "../orca-control", version = "0.2.9" }
+orca-agent = { path = "../orca-agent", version = "0.2.10-rc.1" }
+orca-control = { path = "../orca-control", version = "0.2.10-rc.1" }
 orca-proxy = { workspace = true }
-orca-tui = { path = "../orca-tui", version = "0.2.9" }
+orca-tui = { path = "../orca-tui", version = "0.2.10-rc.1" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 
 [dependencies]
 orca-core = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.9" }
+orca-agent = { path = "../orca-agent", version = "0.2.10-rc.1" }
 orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
## Release: v0.2.10-rc.1

First release candidate for v0.2.10. Version bumped across the workspace (`[workspace.package]` + intra-workspace path deps + `Cargo.lock`).

### Changes since v0.2.9
- **#85** — fix: node-sync orphaning, single-target request streaming, bind-mount backup warning
  - Master no longer prunes nodes that have a live `ws_agents` entry → ends the desync that forced a systemd restart on master + all agents to recover sync.
  - Single-target routes stream the request body straight through (no buffering) → registry blob pushes no longer materialize in the proxy task.
  - `orca backup all` warns about host bind mounts that have no named volume (previously exited silently with "No orca volumes found").
- **#86** — feat(agent): `extra_ports` supports specific `host_ip` binding
  - Adds the docker-compose 3-segment `host_ip:host:container[/proto]` form so a service can bind only the public interface, sidestepping collisions with loopback (systemd-resolved) / mesh (netbird) specific-IP listeners on the same port (PowerDNS on `:53`).

### After merge
Annotated tag `v0.2.10-rc.1` will be placed on the squash-merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)