### PR TITLE
fix(deploy): split remote-deploy ACK into receipt + completion phases (#88, #94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Deploys of large images no longer fail with an opaque 30s timeout, and real pull errors now reach the operator.** The master previously waited a hard-coded 30s for a remote agent's deploy ACK — but that single ACK was only sent *after* the agent finished the image pull, awaited inline in the agent's receive loop. So any first-time pull of a multi-GB image (or any unpullable/missing image) blew the 30s budget: the operator saw `deploy timed out after 30 s` (with a misleading "Is `orca server` running?") while the agent's real result — success or the actual `image not found`/pull error — arrived for a request the master had already abandoned, leaving the container running-but-unregistered. The wait is now two-phase: a short **receipt ACK** (new `AgentMessage::DeployReceived`, sent immediately on receipt) confirms the agent is alive — a miss here fails fast with a distinct "agent may be unreachable" message — followed by a long **completion** wait that carries the agent's real terminal result. Both timeouts are configurable via a new `[deploy]` block (`ack_timeout_secs` default 10, `completion_timeout_secs` default 600). The agent now also runs the deploy on a spawned task instead of inline, so a long pull no longer head-of-line-blocks other master→agent commands (Stop, further Deploys). (#88, #94)
+
 ## [0.2.8] - 2026-05-14
 
 ### Fixed

--- a/cluster.toml.example
+++ b/cluster.toml.example
@@ -25,6 +25,15 @@ log_level = "info"
 # count = 2
 # model = "A100"
 
+# -- Remote deploy timeouts --
+# How long the master waits on a remote agent during `orca deploy`. The wait is
+# split so a slow first-time image pull isn't mistaken for an unreachable agent.
+# Raise completion_timeout_secs if you deploy very large (multi-GB) images.
+
+# [deploy]
+# ack_timeout_secs = 10         # agent must acknowledge receipt this fast (else: unreachable)
+# completion_timeout_secs = 600 # agent has this long to finish the pull + start the container
+
 # -- AI Operations Assistant --
 # Enables: `orca ask`, conversational alerts, smart import analysis, log summarization.
 # Works with any OpenAI-compatible API (LiteLLM, Ollama, vLLM, OpenAI, etc.)

--- a/crates/orca-agent/src/ws_client/deploy.rs
+++ b/crates/orca-agent/src/ws_client/deploy.rs
@@ -1,0 +1,71 @@
+//! Deploy handling for the agent WS client.
+//!
+//! Run on a spawned task (not inline in the receive loop) so a long image
+//! pull does not head-of-line-block other master→agent commands such as
+//! `Stop` or subsequent `Deploy`s (#88).
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tracing::{error, info};
+
+use orca_core::runtime::{Runtime, WorkloadHandle};
+use orca_core::types::WorkloadSpec;
+use orca_core::ws_types::AgentMessage;
+
+use crate::grpc::AgentClient;
+
+/// Run a deploy spec and report the terminal result back to the master.
+///
+/// The agent has already sent `DeployReceived` by the time this runs, so the
+/// master knows work is in flight. This function performs the (potentially
+/// multi-minute) image pull + container create, notifies the proxy of any
+/// discovered domain, and finally sends `DeployResult` carrying the real
+/// success/error — never a bare timeout.
+pub async fn deploy_and_report(
+    runtime: Arc<dyn Runtime>,
+    agent: Arc<AgentClient>,
+    domain_tx: mpsc::Sender<(String, String, u16)>,
+    out_tx: mpsc::Sender<AgentMessage>,
+    spec: Box<WorkloadSpec>,
+) {
+    let result = agent.deploy_spec(runtime.as_ref(), &spec).await;
+    let success = result.is_ok();
+    let error = result.err().map(|e| e.to_string());
+
+    // If the spec has a domain, notify for proxy route registration.
+    if success
+        && let Some(domain) = &spec.domain
+        && let Ok(Some(port)) = runtime
+            .resolve_host_port(
+                &WorkloadHandle {
+                    runtime_id: format!("orca-{}", spec.name),
+                    name: format!("orca-{}", spec.name),
+                    metadata: Default::default(),
+                },
+                spec.port.unwrap_or(80),
+            )
+            .await
+    {
+        let _ = domain_tx
+            .send((spec.name.clone(), domain.clone(), port))
+            .await;
+    }
+
+    if success {
+        info!("WS: deploy of {} succeeded", spec.name);
+    } else {
+        error!(
+            "WS: deploy of {} failed: {}",
+            spec.name,
+            error.as_deref().unwrap_or("unknown")
+        );
+    }
+    let _ = out_tx
+        .send(AgentMessage::DeployResult {
+            service_name: spec.name.clone(),
+            success,
+            error,
+        })
+        .await;
+}

--- a/crates/orca-agent/src/ws_client/mod.rs
+++ b/crates/orca-agent/src/ws_client/mod.rs
@@ -5,6 +5,7 @@
 
 mod backup;
 mod backup_status;
+mod deploy;
 mod logs;
 pub mod network_status;
 mod reconcile;
@@ -26,6 +27,7 @@ use crate::grpc::AgentClient;
 
 use backup::run_agent_backup;
 use backup_status::send_backup_status;
+use deploy::deploy_and_report;
 use logs::stream_logs;
 use network_status::send_network_status;
 use reconcile::reconcile_services;
@@ -177,45 +179,25 @@ async fn handle_master_message(
     match msg {
         MasterMessage::Deploy { spec } => {
             info!("WS: deploying {}", spec.name);
-            let result = agent.deploy_spec(runtime.as_ref(), &spec).await;
-            let success = result.is_ok();
-            let error = result.err().map(|e| e.to_string());
-
-            // If the spec has a domain, notify for proxy route registration
-            if success
-                && let Some(domain) = &spec.domain
-                && let Ok(Some(port)) = runtime
-                    .resolve_host_port(
-                        &orca_core::runtime::WorkloadHandle {
-                            runtime_id: format!("orca-{}", spec.name),
-                            name: format!("orca-{}", spec.name),
-                            metadata: Default::default(),
-                        },
-                        spec.port.unwrap_or(80),
-                    )
-                    .await
-            {
-                let _ = domain_tx
-                    .send((spec.name.clone(), domain.clone(), port))
-                    .await;
-            }
-
-            if success {
-                info!("WS: deploy of {} succeeded", spec.name);
-            } else {
-                error!(
-                    "WS: deploy of {} failed: {}",
-                    spec.name,
-                    error.as_deref().unwrap_or("unknown")
-                );
-            }
+            // Acknowledge receipt immediately so the master can tell a slow
+            // image pull apart from an unreachable agent (#88/#94). Sent
+            // before the (potentially multi-minute) deploy work begins.
             let _ = out_tx
-                .send(AgentMessage::DeployResult {
+                .send(AgentMessage::DeployReceived {
                     service_name: spec.name.clone(),
-                    success,
-                    error,
                 })
                 .await;
+
+            // Spawn so a long pull doesn't head-of-line-block other
+            // master→agent commands (Stop, further Deploys), the same way
+            // Logs/Exec/Prune are handled.
+            let rt = runtime.clone();
+            let agent_c = agent.clone();
+            let domain_tx_c = domain_tx.clone();
+            let tx = out_tx.clone();
+            tokio::spawn(async move {
+                deploy_and_report(rt, agent_c, domain_tx_c, tx, spec).await;
+            });
         }
         MasterMessage::Stop { service_name } => {
             info!("WS: stopping {service_name}");

--- a/crates/orca-control/src/reconciler.rs
+++ b/crates/orca-control/src/reconciler.rs
@@ -368,8 +368,20 @@ async fn find_target_node(state: &AppState, config: &ServiceConfig) -> Option<u6
 
 /// Send a deploy command to a remote agent node and await the result.
 ///
-/// Returns an error if the agent is not connected via WebSocket, if the WS
-/// channel is closed, or if the agent reports a deploy failure within 30 s.
+/// The wait is split into two phases so a slow image pull is never reported as
+/// an unreachable agent (#88/#94):
+///
+/// 1. **Receipt ACK** (`deploy.ack_timeout_secs`, default 10s): the agent
+///    confirms it received the command and started work. A miss here means the
+///    WS session is dead / the agent is unreachable — fail fast with a clear
+///    message.
+/// 2. **Completion** (`deploy.completion_timeout_secs`, default 600s): the
+///    agent reports the deploy finished. Long enough to cover multi-GB
+///    first-time pulls. On a real failure the agent's pull error surfaces
+///    verbatim; on timeout the message says the pull may still be running.
+///
+/// Returns an error if the agent is not connected via WebSocket, the WS channel
+/// is closed, either phase times out, or the agent reports a deploy failure.
 async fn queue_remote_deploy(
     state: &AppState,
     node_id: u64,
@@ -383,7 +395,13 @@ async fn queue_remote_deploy(
             .clone()
     };
 
+    let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<()>();
     let (result_tx, result_rx) = tokio::sync::oneshot::channel::<Result<(), String>>();
+    state
+        .pending_deploy_acks
+        .write()
+        .await
+        .insert(spec.name.clone(), ack_tx);
     state
         .pending_deploys
         .write()
@@ -396,20 +414,56 @@ async fn queue_remote_deploy(
         })
         .await
     {
-        state.pending_deploys.write().await.remove(&spec.name);
+        clear_pending_deploy(state, &spec.name).await;
         return Err(anyhow::anyhow!("agent {node_id} channel closed: {e}"));
     }
 
     info!("Sent deploy via WS to node {node_id}: {}", spec.name);
 
-    match tokio::time::timeout(std::time::Duration::from_secs(30), result_rx).await {
+    let ack_timeout = Duration::from_secs(state.cluster_config.deploy.ack_timeout_secs);
+    let completion_timeout =
+        Duration::from_secs(state.cluster_config.deploy.completion_timeout_secs);
+
+    // Phase 1: receipt ACK — distinguishes a dead/unreachable agent from a
+    // slow pull. This is the failure mode that used to masquerade as the
+    // misleading "is `orca server` running?" timeout.
+    match tokio::time::timeout(ack_timeout, ack_rx).await {
+        Ok(Ok(())) => {}
+        Ok(Err(_)) => {
+            clear_pending_deploy(state, &spec.name).await;
+            anyhow::bail!("deploy receipt channel dropped for agent {node_id}");
+        }
+        Err(_) => {
+            clear_pending_deploy(state, &spec.name).await;
+            anyhow::bail!(
+                "agent {node_id} did not acknowledge deploy of {} within {}s — agent may be unreachable or the WS session is dead",
+                spec.name,
+                ack_timeout.as_secs()
+            );
+        }
+    }
+
+    // Phase 2: completion — long enough for multi-GB first-time pulls. The
+    // agent's real pull error surfaces here instead of a bare timeout.
+    match tokio::time::timeout(completion_timeout, result_rx).await {
         Ok(Ok(Ok(()))) => Ok(()),
         Ok(Ok(Err(msg))) => anyhow::bail!("deploy failed on agent {node_id}: {msg}"),
         Ok(Err(_)) => anyhow::bail!("deploy result channel dropped for agent {node_id}"),
         Err(_) => {
             state.pending_deploys.write().await.remove(&spec.name);
-            anyhow::bail!("deploy timed out after 30 s waiting for agent {node_id}")
+            anyhow::bail!(
+                "deploy of {} did not complete within {}s on agent {node_id} (image pull may still be running — raise deploy.completion_timeout_secs if the image is large)",
+                spec.name,
+                completion_timeout.as_secs()
+            )
         }
     }
+}
+
+/// Remove both pending-deploy waiter entries for a service. Used on send
+/// failure and on receipt-ACK timeout so neither map leaks an orphan entry.
+async fn clear_pending_deploy(state: &AppState, name: &str) {
+    state.pending_deploy_acks.write().await.remove(name);
+    state.pending_deploys.write().await.remove(name);
 }
 pub use crate::operations::{promote, redeploy, rollback, scale, stop, stop_all};

--- a/crates/orca-control/src/state.rs
+++ b/crates/orca-control/src/state.rs
@@ -88,6 +88,12 @@ pub struct AppState {
     /// Pending deploy result waiters: service_name → oneshot sender.
     /// Inserted by queue_remote_deploy, resolved by ws_handler on DeployResult.
     pub pending_deploys: RwLock<HashMap<String, tokio::sync::oneshot::Sender<Result<(), String>>>>,
+    /// Pending deploy *receipt* waiters: service_name → oneshot sender.
+    /// Inserted by queue_remote_deploy, resolved by ws_handler on
+    /// DeployReceived. Separate from `pending_deploys` so the master can apply
+    /// a short receipt-ack timeout (catch a dead agent fast) independently of
+    /// the long completion timeout (cover multi-GB image pulls). See #88/#94.
+    pub pending_deploy_acks: RwLock<HashMap<String, tokio::sync::oneshot::Sender<()>>>,
     /// AI conversational-alert engine. `None` when `[ai]` is not configured.
     /// `AiMonitor::run` (spawned in `lib::run_server_with_acme`) feeds it
     /// `open_alert` calls; the HTTP `/api/v1/alerts/...` handlers mutate it
@@ -252,6 +258,7 @@ impl AppState {
             webhook_invocations: RwLock::new(HashMap::new()),
             exec_sessions: RwLock::new(HashMap::new()),
             pending_deploys: RwLock::new(HashMap::new()),
+            pending_deploy_acks: RwLock::new(HashMap::new()),
             alerts: None,
             instance_events: RwLock::new(HashMap::new()),
         }

--- a/crates/orca-control/src/ws_handler/mod.rs
+++ b/crates/orca-control/src/ws_handler/mod.rs
@@ -217,6 +217,17 @@ async fn handle_agent_message(
                 svc.config.domain = Some(domain);
             }
         }
+        AgentMessage::DeployReceived { service_name } => {
+            info!("Node {node_id}: agent acknowledged deploy of {service_name}, work started");
+            if let Some(tx) = state
+                .pending_deploy_acks
+                .write()
+                .await
+                .remove(&service_name)
+            {
+                let _ = tx.send(());
+            }
+        }
         AgentMessage::DeployResult {
             service_name,
             success,

--- a/crates/orca-control/tests/deploy_timeout_test.rs
+++ b/crates/orca-control/tests/deploy_timeout_test.rs
@@ -1,0 +1,183 @@
+//! Tests for the two-phase remote-deploy timeout (#88 / #94).
+//!
+//! The master waits for a short *receipt* ACK (agent got the command) and then
+//! a long *completion* ACK (deploy finished). This ensures:
+//! - an unreachable agent fails fast with a distinct message, and
+//! - a real agent-side error (e.g. image-not-found) surfaces verbatim instead
+//!   of being masked by a bare 30s timeout.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use orca_control::state::{AppState, RegisteredNode};
+use orca_core::config::{ClusterConfig, ServiceConfig};
+use orca_core::testing::MockRuntime;
+use orca_core::types::{PlacementConstraint, Replicas, RuntimeKind};
+use orca_core::ws_types::MasterMessage;
+
+fn make_state(cfg: ClusterConfig) -> Arc<AppState> {
+    let runtime = Arc::new(MockRuntime::new());
+    Arc::new(AppState::new(
+        cfg,
+        runtime,
+        None,
+        Arc::new(RwLock::new(HashMap::new())),
+        Arc::new(RwLock::new(Vec::new())),
+    ))
+}
+
+fn config_placed_on(name: &str, node: &str) -> ServiceConfig {
+    ServiceConfig {
+        name: name.into(),
+        project: None,
+        runtime: RuntimeKind::Container,
+        image: Some("nginx:latest".into()),
+        module: None,
+        replicas: Replicas::Fixed(1),
+        port: Some(8080),
+        host_port: None,
+        domain: None,
+        routes: vec![],
+        health: None,
+        readiness: None,
+        liveness: None,
+        env: HashMap::new(),
+        resources: None,
+        volume: None,
+        deploy: None,
+        placement: Some(PlacementConstraint {
+            labels: None,
+            node: Some(node.into()),
+            requires_gpu: None,
+        }),
+        network: None,
+        aliases: vec![],
+        mounts: vec![],
+        triggers: vec![],
+        assets: None,
+        build: None,
+        tls_cert: None,
+        tls_key: None,
+        internal: false,
+        depends_on: vec![],
+        cmd: vec![],
+        extra_ports: vec![],
+        strip_prefix: None,
+        pull_policy: Default::default(),
+        backup: None,
+    }
+}
+
+async fn register_node(state: &AppState, node_id: u64) {
+    state.registered_nodes.write().await.insert(
+        node_id,
+        RegisteredNode {
+            node_id,
+            address: format!("node-{node_id}:6881"),
+            labels: HashMap::new(),
+            last_heartbeat: chrono::Utc::now(),
+            drain: false,
+            cpu_percent: 0.0,
+            memory_bytes: 0,
+            memory_total: 0,
+            disk_used: 0,
+            disk_total: 0,
+            net_rx: 0,
+            net_tx: 0,
+        },
+    );
+}
+
+/// When the agent is connected but never acknowledges receipt, the deploy must
+/// fail with a distinct "did not acknowledge / unreachable" message after the
+/// short ACK window — NOT the old opaque "timed out after 30 s".
+#[tokio::test]
+async fn ack_timeout_reports_unreachable_distinctly() {
+    let mut cfg = ClusterConfig::default();
+    cfg.deploy.ack_timeout_secs = 1; // keep the test fast
+    let state = make_state(cfg);
+    register_node(&state, 1).await;
+
+    // Register a WS sender whose receiver we hold open, so the Deploy send
+    // succeeds but nothing ever replies with DeployReceived.
+    let (tx, _rx) = tokio::sync::mpsc::channel::<MasterMessage>(8);
+    state.ws_agents.write().await.insert(1, tx);
+
+    let cfg = config_placed_on("svc", "1");
+    let (deployed, errors) = orca_control::reconciler::reconcile(&state, &[cfg]).await;
+
+    assert!(deployed.is_empty(), "deploy should not be recorded");
+    assert_eq!(errors.len(), 1, "expected one error, got {errors:?}");
+    let err = &errors[0];
+    assert!(
+        err.contains("did not acknowledge") && err.contains("unreachable"),
+        "expected a distinct unreachable message, got: {err}"
+    );
+    assert!(
+        !err.contains("timed out after 30"),
+        "must not emit the old opaque 30s timeout: {err}"
+    );
+
+    // Both waiter maps must be cleaned up so they don't leak.
+    assert!(state.pending_deploy_acks.read().await.is_empty());
+    assert!(state.pending_deploys.read().await.is_empty());
+}
+
+/// Once the agent acknowledges receipt, a real deploy failure (e.g. image not
+/// found) must surface verbatim instead of being masked by a timeout.
+#[tokio::test]
+async fn real_agent_error_propagates_after_ack() {
+    let state = make_state(ClusterConfig::default()); // default 10s/600s timeouts
+    register_node(&state, 1).await;
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<MasterMessage>(8);
+    state.ws_agents.write().await.insert(1, tx);
+
+    let cfg = config_placed_on("svc", "1");
+    let state_c = state.clone();
+    let deploy =
+        tokio::spawn(async move { orca_control::reconciler::reconcile(&state_c, &[cfg]).await });
+
+    // The master pushes the Deploy command; receiving it confirms both waiter
+    // entries are registered.
+    let msg = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("master should send a Deploy")
+        .expect("channel open");
+    assert!(matches!(msg, MasterMessage::Deploy { .. }));
+
+    // Simulate the agent: acknowledge receipt, then report a pull failure.
+    state
+        .pending_deploy_acks
+        .write()
+        .await
+        .remove("svc")
+        .expect("ack waiter registered")
+        .send(())
+        .ok();
+    state
+        .pending_deploys
+        .write()
+        .await
+        .remove("svc")
+        .expect("result waiter registered")
+        .send(Err(
+            "pull access denied for ghcr.io/x:nope, not found".into()
+        ))
+        .ok();
+
+    let (deployed, errors) = deploy.await.unwrap();
+    assert!(deployed.is_empty());
+    assert_eq!(errors.len(), 1, "expected one error, got {errors:?}");
+    let err = &errors[0];
+    assert!(
+        err.contains("not found") && err.contains("ghcr.io/x:nope"),
+        "real pull error must propagate verbatim, got: {err}"
+    );
+    assert!(
+        !err.contains("timed out") && !err.contains("did not"),
+        "should not be a timeout once the agent reported a result: {err}"
+    );
+}

--- a/crates/orca-control/tests/ws_integration_test.rs
+++ b/crates/orca-control/tests/ws_integration_test.rs
@@ -239,6 +239,47 @@ async fn ws_master_pushes_deploy_via_channel() {
 }
 
 #[tokio::test]
+async fn ws_deploy_received_resolves_ack_waiter() {
+    let state = test_state();
+
+    // Simulate queue_remote_deploy having registered a receipt waiter.
+    let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<()>();
+    state
+        .pending_deploy_acks
+        .write()
+        .await
+        .insert("svc".into(), ack_tx);
+
+    let addr = start_server(state.clone()).await;
+    let url = format!("ws://{addr}/api/v1/ws/agent?token=test-token-123&node_id=8");
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    let _ = ws.next().await; // consume Ack
+
+    let msg = AgentMessage::DeployReceived {
+        service_name: "svc".into(),
+    };
+    ws.send(tungstenite::Message::Text(
+        serde_json::to_string(&msg).unwrap().into(),
+    ))
+    .await
+    .unwrap();
+
+    // The waiter must fire (agent acknowledged receipt)...
+    tokio::time::timeout(Duration::from_secs(2), ack_rx)
+        .await
+        .expect("ack waiter should resolve after DeployReceived")
+        .expect("ack channel should not be dropped");
+
+    // ...and the handler must remove the entry so it doesn't leak.
+    assert!(
+        !state.pending_deploy_acks.read().await.contains_key("svc"),
+        "DeployReceived must consume the pending ack entry"
+    );
+
+    ws.close(None).await.ok();
+}
+
+#[tokio::test]
 async fn ws_domain_discovered_updates_service_config() {
     let state = test_state();
 

--- a/crates/orca-core/src/config/cluster.rs
+++ b/crates/orca-core/src/config/cluster.rs
@@ -32,6 +32,46 @@ pub struct ClusterConfig {
     /// Fallback proxy for unmatched requests (e.g., point to coolify-proxy).
     #[serde(default)]
     pub fallback: Option<FallbackConfig>,
+    /// Remote-deploy timeouts (agent ACK over WebSocket).
+    #[serde(default)]
+    pub deploy: DeployConfig,
+}
+
+/// Remote-deploy timeout configuration. Controls how long the master waits
+/// for an agent to (1) acknowledge receipt of a deploy command and (2) report
+/// the deploy complete. The two phases are split so a slow first-time image
+/// pull (long, expected) is never conflated with an unreachable agent (short,
+/// a genuine failure) — see #88 / #94.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeployConfig {
+    /// Seconds to wait for the agent to acknowledge it received the deploy
+    /// command and started work. A miss means the agent is unreachable or the
+    /// WS session is dead — fail fast. Default 10s.
+    #[serde(default = "default_deploy_ack_timeout")]
+    pub ack_timeout_secs: u64,
+    /// Seconds to wait for the agent to report the deploy finished — i.e. image
+    /// pull, container create, and start all done. Must cover multi-GB first
+    /// pulls; the old hard-coded 30s ceiling made such services undeployable.
+    /// Default 600s.
+    #[serde(default = "default_deploy_completion_timeout")]
+    pub completion_timeout_secs: u64,
+}
+
+impl Default for DeployConfig {
+    fn default() -> Self {
+        Self {
+            ack_timeout_secs: default_deploy_ack_timeout(),
+            completion_timeout_secs: default_deploy_completion_timeout(),
+        }
+    }
+}
+
+fn default_deploy_ack_timeout() -> u64 {
+    10
+}
+
+fn default_deploy_completion_timeout() -> u64 {
+    600
 }
 
 /// Fallback proxy configuration. When orca's route table has no match,

--- a/crates/orca-core/src/config/mod.rs
+++ b/crates/orca-core/src/config/mod.rs
@@ -15,8 +15,8 @@ pub use ai::{
 };
 pub use cluster::NetworkConfig;
 pub use cluster::{
-    AlertChannelConfig, ApiToken, CleanupConfig, ClusterConfig, ClusterMeta, FallbackConfig,
-    NodeConfig, NodeGpuConfig, ObservabilityConfig, Role,
+    AlertChannelConfig, ApiToken, CleanupConfig, ClusterConfig, ClusterMeta, DeployConfig,
+    FallbackConfig, NodeConfig, NodeGpuConfig, ObservabilityConfig, Role,
 };
 pub use service::{BuildConfig, ProbeConfig, ServiceConfig, ServicesConfig};
 

--- a/crates/orca-core/src/ws_types.rs
+++ b/crates/orca-core/src/ws_types.rs
@@ -24,6 +24,11 @@ pub enum AgentMessage {
         domain: String,
         host_port: u16,
     },
+    /// Agent acknowledges receipt of a `Deploy` command and is starting work
+    /// (image pull + container create). Sent *before* the potentially
+    /// long-running deploy begins so the master can distinguish a slow pull
+    /// from an unreachable agent and apply separate ACK/completion timeouts.
+    DeployReceived { service_name: String },
     DeployResult {
         service_name: String,
         success: bool,
@@ -220,6 +225,17 @@ mod tests {
         assert!(json.contains("\"type\":\"domain_discovered\""));
         let parsed: AgentMessage = serde_json::from_str(&json).unwrap();
         assert!(matches!(parsed, AgentMessage::DomainDiscovered { .. }));
+    }
+
+    #[test]
+    fn agent_message_deploy_received_serde() {
+        let msg = AgentMessage::DeployReceived {
+            service_name: "web".into(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"deploy_received\""));
+        let parsed: AgentMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, AgentMessage::DeployReceived { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the opaque 30s deploy timeout that made large-image services effectively undeployable and hid the real pull error from operators.

The master waited a hard-coded **30s** for a remote agent's deploy ACK — but that single ACK was only sent *after* the agent finished the image pull, which was awaited **inline** in the agent's receive loop. So any first-time multi-GB pull (or any missing/unpullable image) blew the budget: the operator saw `deploy timed out after 30 s` (with a misleading "Is `orca server` running?") while the agent's real result — success, or the actual `image not found`/pull error — arrived for a request the master had already abandoned, leaving the container running-but-unregistered.

## Changes

- **Protocol:** new `AgentMessage::DeployReceived`, sent immediately on receipt.
- **Agent:** runs `deploy_spec` on a spawned task (no more head-of-line blocking of `Stop` / further `Deploy`s) and sends the receipt ack *before* the pull begins. Extracted to `ws_client/deploy.rs`.
- **Master:** `queue_remote_deploy` now waits in two phases:
  1. **Receipt ACK** (`ack_timeout_secs`, default 10s) — a miss fails fast with a distinct "agent may be unreachable" message.
  2. **Completion** (`completion_timeout_secs`, default 600s) — carries the agent's real terminal result; the actual pull error surfaces verbatim.
- **Config:** new `[deploy]` block (`ack_timeout_secs`, `completion_timeout_secs`); documented in `cluster.toml.example`.

## Tests

- `DeployReceived` serde roundtrip
- master resolves the receipt-ack waiter on `DeployReceived` (and removes the entry)
- ack-timeout reports "unreachable" distinctly (not the old 30s timeout) and cleans up both waiter maps
- real agent error (image-not-found) propagates verbatim after ack

`cargo fmt`, `cargo clippy -- -D warnings`, and the full `cargo test` suite all pass.

## Acceptance (#94)

- [x] Deploys of multi-GB images can complete end-to-end (completion timeout now covers the pull)
- [x] Master's registry reflects the agent's real result instead of a premature timeout
- [x] WS-partition / unreachable-agent error is distinct from the slow-pull case

## Related

Self-healing for any orphan that still slips through (e.g. master restart mid-deploy) is tracked separately in #95 (label-based registry reconciler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)