### PR TITLE
chore(release): bump workspace to v0.2.11-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11-rc.1] - 2026-06-22
+
 ### Added
 
 - **Declarative reconciliation: the master can continuously apply a directory of service configs (K8s-style), no manual `orca deploy`.** Set `[reconcile].config_dir` (a directory of `<project>/service.toml` files, or a single `services.toml`) and a background loop on the master loads it every `interval_secs` (default 30) and applies any service that is **new or whose spec changed** — so bringing up a new service is just dropping its `service.toml` in the dir. Unchanged services are deliberately skipped (no steady-state churn / remote re-deploys); invalid configs are skipped with the reason recorded for `orca status`; applied services are persisted so they survive a master restart. Healing of degraded-but-unchanged services remains the watchdog's job, and removed services are not auto-pruned. Disabled unless `config_dir` is set.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mallorca"
-version = "0.2.10-rc.1"
+version = "0.2.11-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2554,7 +2554,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orca-agent"
-version = "0.2.10-rc.1"
+version = "0.2.11-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "orca-ai"
-version = "0.2.10-rc.1"
+version = "0.2.11-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "orca-control"
-version = "0.2.10-rc.1"
+version = "0.2.11-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "orca-core"
-version = "0.2.10-rc.1"
+version = "0.2.11-rc.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "orca-proxy"
-version = "0.2.10-rc.1"
+version = "0.2.11-rc.1"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "orca-tui"
-version = "0.2.10-rc.1"
+version = "0.2.11-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "orca-web"
-version = "0.2.10-rc.1"
+version = "0.2.11-rc.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/wasm-hello"]
 
 [workspace.package]
-version = "0.2.10-rc.1"
+version = "0.2.11-rc.1"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mighty840/orca"
@@ -24,9 +24,9 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Shared across crates
-orca-core = { path = "crates/orca-core", version = "0.2.10-rc.1" }
-orca-ai = { path = "crates/orca-ai", version = "0.2.10-rc.1" }
-orca-proxy = { path = "crates/orca-proxy", version = "0.2.10-rc.1" }
+orca-core = { path = "crates/orca-core", version = "0.2.11-rc.1" }
+orca-ai = { path = "crates/orca-ai", version = "0.2.11-rc.1" }
+orca-proxy = { path = "crates/orca-proxy", version = "0.2.11-rc.1" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/orca-cli/Cargo.toml
+++ b/crates/orca-cli/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/main.rs"
 [dependencies]
 orca-core = { workspace = true }
 orca-ai = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.10-rc.1" }
-orca-control = { path = "../orca-control", version = "0.2.10-rc.1" }
+orca-agent = { path = "../orca-agent", version = "0.2.11-rc.1" }
+orca-control = { path = "../orca-control", version = "0.2.11-rc.1" }
 orca-proxy = { workspace = true }
-orca-tui = { path = "../orca-tui", version = "0.2.10-rc.1" }
+orca-tui = { path = "../orca-tui", version = "0.2.11-rc.1" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 
 [dependencies]
 orca-core = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.10-rc.1" }
+orca-agent = { path = "../orca-agent", version = "0.2.11-rc.1" }
 orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
Release bump for **v0.2.11-rc.1**. Bumps the workspace version `0.2.10-rc.1 → 0.2.11-rc.1` (Cargo.toml + per-crate path-dep pins + Cargo.lock) and dates the CHANGELOG section.

Rolls up everything merged to `main` since v0.2.10-rc.1:
- `#96` deploy ACK split — receipt + completion timeouts (#88, #94)
- `#101` orphan-container adoption reconciler (#95)
- `#98` multiple domains per service (#93)
- `#99` K8s-style failure reasons in `orca status`
- `#100` declarative reconciler — auto-apply a config dir
- `#102` proxy: inactivity timeout so large (>2 GB) registry uploads aren't capped

`cargo fmt` + `cargo clippy -- -D warnings` + full `cargo test` (73 groups) + the >500-line file gate all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)