### PR TITLE
docs: document v0.2.11 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,18 +71,14 @@ health = "/"
 orca deploy && orca status
 ```
 
-## What's New in v0.2.3
+## What's New in v0.2.11
 
-- **Secrets in `cluster.toml`** -- `${secrets.X}` now resolves in `ai.api_key`, `ai.endpoint`, and `network.setup_key`, so cluster config is safe to commit (#22).
-- **Per-service stats for remote nodes** -- live CPU and memory for every container on every agent, streamed over the WS heartbeat (#13).
-- **`orca logs <svc> --summarize`** -- AI-summarised log digest with likely causes and next steps (#23).
-- **Multi-arg CLI** -- `orca deploy svc1 svc2 svc3`, `orca redeploy svc1 svc2`, `orca stop svc1 svc2`.
-- **Shell completions** -- `orca completions <bash|zsh|fish|powershell>`.
-- **Find-up config resolution** -- run `orca` from any subdirectory; it walks up to find `cluster.toml` and `services/`.
-- **AMD ROCm GPU passthrough** -- `vendor = "amd"` mounts `/dev/kfd` + `/dev/dri` with auto-detected `video`/`render` GIDs.
-- **Remote placement fix** -- `placement.node = "<agent>"` now resolves correctly over WS, so pinned services start without a master restart.
-- **Proxy preserves Host header** -- fixes apps that emit absolute URLs (e.g. LiteLLM `/ui` redirects).
-- **`orca webhooks add --secret --infra`** flags now wired through the CLI.
+- **Reliable deploys of large images** -- the remote-deploy ack is split into a fast *receipt* ack and a long *completion* wait, so a multi-GB first-time pull no longer hits a bogus 30s timeout, and the agent's real `image not found` / pull error reaches the operator instead of a bare timeout (#88, #94).
+- **Self-healing orphan adoption** -- the master periodically scans agents for `orca.managed` containers missing from its registry and re-registers them, so a container left running by a mid-deploy restart shows up in `orca status` automatically instead of needing a manual `docker rm -f` (#95).
+- **Multiple domains per service** -- `domains = ["a.com", "b.com"]` serves one container on several hostnames, each with its own cert + route. No more duplicating the `[[service]]` block (which spawned a redundant container) for apex+www or dual-TLD migrations (#93).
+- **`orca status` explains failures, K8s-style** -- degraded/stopped services show *why*: classified deploy errors (`ImagePullError`, `DeployTimeout`, …) and runtime crashes (`CrashLoopBackOff`) with exit code, restart count, and a `docker logs` tail.
+- **Declarative reconciliation** -- point `[reconcile].config_dir` at a folder of `service.toml` files and the master continuously applies new/changed services, no manual `orca deploy`.
+- **Large uploads through the proxy** -- registry blob pushes >2 GB no longer die mid-transfer; the proxy uses an inactivity timeout instead of a total request deadline.
 
 See [CHANGELOG.md](CHANGELOG.md) for the full history.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -46,6 +46,34 @@ role = "admin"                        # admin | deployer | viewer
 
 Create tokens via CLI: `orca token create --name ci --role deployer`
 
+### Deploy & Reconciliation
+
+Optional `cluster.toml` blocks controlling how deploys are acknowledged, how
+orphaned containers are recovered, and (optionally) continuous declarative
+reconciliation. Defaults shown:
+
+```toml
+[deploy]
+ack_timeout_secs = 10          # agent must acknowledge a deploy within this, else "unreachable"
+completion_timeout_secs = 600  # time for the agent to pull the image + start (covers multi-GB pulls)
+adopt_orphans = true           # adopt orca.managed containers running on an agent but missing from the registry
+adopt_interval_secs = 30       # how often to scan agents for orphans
+
+# Declarative reconciliation (K8s-style) — opt-in. When set, the master
+# continuously applies a directory of service configs: drop in a service.toml
+# and it deploys, no manual `orca deploy`.
+[reconcile]
+config_dir = "services"        # dir of <project>/service.toml files (or a single services.toml)
+interval_secs = 30             # how often to re-apply
+```
+
+The `[deploy]` wait is two-phase — a short *receipt* ack distinguishes an
+unreachable agent from a slow image pull, and the long *completion* wait
+surfaces the agent's real pull error instead of a bare timeout. `[reconcile]`
+applies only new or changed services each pass; unchanged services are left
+untouched and removed ones are not auto-pruned. See
+[Self-healing](/reference/self-healing).
+
 ## service.toml
 
 Each project directory contains a `service.toml` with one or more `[[service]]` blocks:
@@ -90,6 +118,23 @@ repo = "git@github.com:org/repo.git"
 branch = "main"
 dockerfile = "Dockerfile"
 ```
+
+#### Multiple domains
+
+Serve one container on several hostnames — apex + www, regional aliases, or a
+dual-TLD migration — with `domains` instead of `domain`. Each entry gets its own
+TLS certificate and proxy route to the same backend, so you no longer duplicate
+the `[[service]]` block (which would spawn a redundant container):
+
+```toml
+[[service]]
+name = "marketing"
+image = "myorg/marketing:latest"
+port = 8080
+domains = ["example.com", "www.example.com", "example.org"]
+```
+
+`domain` and `domains` are mutually exclusive — setting both is rejected at deploy.
 
 ### Wasm Services
 

--- a/docs/guide/services.md
+++ b/docs/guide/services.md
@@ -78,6 +78,23 @@ internal = true
 | `internal = true` | Reachable only within the cluster |
 | Both | Public route + internal alias |
 
+### Multiple Domains
+
+Use `domains` (instead of `domain`) to serve one container on several
+hostnames — each gets its own TLS cert and route to the same backend. Useful
+for apex + www, regional aliases, or running two TLDs in parallel during a
+migration:
+
+```toml
+[[service]]
+name = "marketing"
+image = "myorg/marketing:latest"
+port = 8080
+domains = ["meghsakha.com", "www.meghsakha.com", "breakpilot.com"]
+```
+
+`domain` and `domains` are mutually exclusive; setting both fails validation at deploy.
+
 ## Dual Runtime
 
 Orca runs both containers and WebAssembly modules as first-class workloads:

--- a/docs/reference/self-healing.md
+++ b/docs/reference/self-healing.md
@@ -12,6 +12,8 @@ Orca automatically detects and recovers from common failure scenarios without ma
 | Agent disconnect | Heartbeat | Exponential backoff retry | 5-60s |
 | Duplicate deploy | Reconciler | Skip (idempotent) | Instant |
 | Remote service at startup | Agent WS connect | Placeholder upsert + Reconcile | On reconnect |
+| Orphan container (running, unregistered) | Adoption reconciler (30s) | Re-register into the registry | ~30s |
+| Failed / crashing container | Agent heartbeat | Record reason + exit code + log tail | ~5s |
 
 ## Watchdog
 
@@ -67,6 +69,36 @@ All service configurations are persisted to `~/.orca/cluster.db` (redb). This me
 - Server restarts automatically recreate all containers
 - Deploys are idempotent -- redeploying the same config is a no-op
 - Rollback is always available from deploy history
+
+## Orphan Adoption
+
+If a container ends up running on an agent but missing from the master's
+registry — e.g. a master restart mid-deploy, or a deploy whose completion ack
+was missed — the adoption reconciler re-registers it automatically. Every
+`adopt_interval_secs` (default 30) the master scans each agent for
+`orca.managed` containers, and for any **running** one whose service it doesn't
+know, it adopts the container: reconstructs the `ServiceConfig` from the
+container's labels + image, registers a remote placeholder (so `orca status`,
+`orca logs`, and `orca redeploy` work against it), and persists it so the
+adoption survives a restart. Only running containers are adopted, and a service
+the master already knows is never overwritten. Disable with
+`adopt_orphans = false` in `[deploy]`.
+
+## Failure Reasons
+
+When a service is degraded or stopped, `orca status` shows **why** — no log
+scraping required:
+
+- **Deploy-time failures** are classified (`ImagePullError`, `AgentUnreachable`,
+  `DeployTimeout`, `DeployError`) and carry the real underlying error.
+- **Runtime crashes** are detected from agent heartbeats: the agent reports the
+  container's exit code, restart count, and a tail of `docker logs`, and the
+  master classifies them (`CrashLoopBackOff`, `Error`).
+
+The reason appears inline in `orca status` (a `↳ reason: …` line), in the status
+API (`last_failure`), and in the TUI detail pane — only while the service is
+actually degraded, and it clears once the service deploys or reports healthy
+again.
 
 ## Troubleshooting
 

--- a/docs/src/content/docs/guide/configuration.md
+++ b/docs/src/content/docs/guide/configuration.md
@@ -46,6 +46,34 @@ role = "admin"                        # admin | deployer | viewer
 
 Create tokens via CLI: `orca token create --name ci --role deployer`
 
+### Deploy & Reconciliation
+
+Optional `cluster.toml` blocks controlling how deploys are acknowledged, how
+orphaned containers are recovered, and (optionally) continuous declarative
+reconciliation. Defaults shown:
+
+```toml
+[deploy]
+ack_timeout_secs = 10          # agent must acknowledge a deploy within this, else "unreachable"
+completion_timeout_secs = 600  # time for the agent to pull the image + start (covers multi-GB pulls)
+adopt_orphans = true           # adopt orca.managed containers running on an agent but missing from the registry
+adopt_interval_secs = 30       # how often to scan agents for orphans
+
+# Declarative reconciliation (K8s-style) — opt-in. When set, the master
+# continuously applies a directory of service configs: drop in a service.toml
+# and it deploys, no manual `orca deploy`.
+[reconcile]
+config_dir = "services"        # dir of <project>/service.toml files (or a single services.toml)
+interval_secs = 30             # how often to re-apply
+```
+
+The `[deploy]` wait is two-phase — a short *receipt* ack distinguishes an
+unreachable agent from a slow image pull, and the long *completion* wait
+surfaces the agent's real pull error instead of a bare timeout. `[reconcile]`
+applies only new or changed services each pass; unchanged services are left
+untouched and removed ones are not auto-pruned. See
+[Self-healing](/reference/self-healing).
+
 ## service.toml
 
 Each project directory contains a `service.toml` with one or more `[[service]]` blocks:
@@ -90,6 +118,23 @@ repo = "git@github.com:org/repo.git"
 branch = "main"
 dockerfile = "Dockerfile"
 ```
+
+#### Multiple domains
+
+Serve one container on several hostnames — apex + www, regional aliases, or a
+dual-TLD migration — with `domains` instead of `domain`. Each entry gets its own
+TLS certificate and proxy route to the same backend, so you no longer duplicate
+the `[[service]]` block (which would spawn a redundant container):
+
+```toml
+[[service]]
+name = "marketing"
+image = "myorg/marketing:latest"
+port = 8080
+domains = ["example.com", "www.example.com", "example.org"]
+```
+
+`domain` and `domains` are mutually exclusive — setting both is rejected at deploy.
 
 ### Wasm Services
 

--- a/docs/src/content/docs/guide/services.md
+++ b/docs/src/content/docs/guide/services.md
@@ -78,6 +78,23 @@ internal = true
 | `internal = true` | Reachable only within the cluster |
 | Both | Public route + internal alias |
 
+### Multiple Domains
+
+Use `domains` (instead of `domain`) to serve one container on several
+hostnames — each gets its own TLS cert and route to the same backend. Useful
+for apex + www, regional aliases, or running two TLDs in parallel during a
+migration:
+
+```toml
+[[service]]
+name = "marketing"
+image = "myorg/marketing:latest"
+port = 8080
+domains = ["meghsakha.com", "www.meghsakha.com", "breakpilot.com"]
+```
+
+`domain` and `domains` are mutually exclusive; setting both fails validation at deploy.
+
 ## Dual Runtime
 
 Orca runs both containers and WebAssembly modules as first-class workloads:

--- a/docs/src/content/docs/reference/self-healing.md
+++ b/docs/src/content/docs/reference/self-healing.md
@@ -12,6 +12,8 @@ Orca automatically detects and recovers from common failure scenarios without ma
 | Agent disconnect | Heartbeat | Exponential backoff retry | 5-60s |
 | Duplicate deploy | Reconciler | Skip (idempotent) | Instant |
 | Remote service at startup | Agent WS connect | Placeholder upsert + Reconcile | On reconnect |
+| Orphan container (running, unregistered) | Adoption reconciler (30s) | Re-register into the registry | ~30s |
+| Failed / crashing container | Agent heartbeat | Record reason + exit code + log tail | ~5s |
 
 ## Watchdog
 
@@ -67,6 +69,36 @@ All service configurations are persisted to `~/.orca/cluster.db` (redb). This me
 - Server restarts automatically recreate all containers
 - Deploys are idempotent -- redeploying the same config is a no-op
 - Rollback is always available from deploy history
+
+## Orphan Adoption
+
+If a container ends up running on an agent but missing from the master's
+registry — e.g. a master restart mid-deploy, or a deploy whose completion ack
+was missed — the adoption reconciler re-registers it automatically. Every
+`adopt_interval_secs` (default 30) the master scans each agent for
+`orca.managed` containers, and for any **running** one whose service it doesn't
+know, it adopts the container: reconstructs the `ServiceConfig` from the
+container's labels + image, registers a remote placeholder (so `orca status`,
+`orca logs`, and `orca redeploy` work against it), and persists it so the
+adoption survives a restart. Only running containers are adopted, and a service
+the master already knows is never overwritten. Disable with
+`adopt_orphans = false` in `[deploy]`.
+
+## Failure Reasons
+
+When a service is degraded or stopped, `orca status` shows **why** — no log
+scraping required:
+
+- **Deploy-time failures** are classified (`ImagePullError`, `AgentUnreachable`,
+  `DeployTimeout`, `DeployError`) and carry the real underlying error.
+- **Runtime crashes** are detected from agent heartbeats: the agent reports the
+  container's exit code, restart count, and a tail of `docker logs`, and the
+  master classifies them (`CrashLoopBackOff`, `Error`).
+
+The reason appears inline in `orca status` (a `↳ reason: …` line), in the status
+API (`last_failure`), and in the TUI detail pane — only while the service is
+actually degraded, and it clears once the service deploys or reports healthy
+again.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Public-facing docs for **v0.2.11-rc.1**, applied to both the published Astro source (`docs/src/content/docs/`) and the root `docs/` mirror, plus the README.

- **configuration.md** — new `[deploy]` block (ack/completion timeouts, orphan adoption) and `[reconcile]` block (declarative config-dir); multi-domain `domains = [..]` note.
- **services.md** — "Multiple Domains" section.
- **self-healing.md** — Orphan Adoption + K8s-style Failure Reasons sections, plus two recovery-matrix rows.
- **README.md** — "What's New" refreshed from v0.2.3 → v0.2.11.

Verified with `astro build` (16 pages, clean). No build artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)