### PR TITLE
fix(proxy): don't re-frame empty-body requests as chunked (rc.1 regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11-rc.2] - 2026-06-22
+
+### Fixed
+
+- **Empty-body POST requests through the proxy were broken (rc.1 regression), breaking app logins.** The rc.1 large-upload fix streams single-target request bodies via `reqwest::Body::wrap_stream` (always `Transfer-Encoding: chunked`) and stripped the client's `Content-Length`. An *empty-body* POST (e.g. a session-refresh call — `Content-Length: 0`, no `Content-Type`) was therefore forwarded as a **chunked** request; strict backends (Fastify/Infisical) treat chunked as "has a body", find no `Content-Type`, and reject it with `415 Unsupported Media Type` → 500. Every empty-body POST through a single-target route failed — observed as Infisical login looping to "Access Restricted" (its `POST /api/v1/auth/token` refresh 500ing). Fixed: only stream (chunked) when the body is actually non-empty; an empty body is forwarded with no chunked framing, so the backend sees an empty request as before. Large-body streaming is unchanged. (regression from the v0.2.11-rc.1 proxy upload fix)
+
 ## [0.2.11-rc.1] - 2026-06-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mallorca"
-version = "0.2.11-rc.1"
+version = "0.2.11-rc.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2554,7 +2554,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orca-agent"
-version = "0.2.11-rc.1"
+version = "0.2.11-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "orca-ai"
-version = "0.2.11-rc.1"
+version = "0.2.11-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "orca-control"
-version = "0.2.11-rc.1"
+version = "0.2.11-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "orca-core"
-version = "0.2.11-rc.1"
+version = "0.2.11-rc.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "orca-proxy"
-version = "0.2.11-rc.1"
+version = "0.2.11-rc.2"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "orca-tui"
-version = "0.2.11-rc.1"
+version = "0.2.11-rc.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "orca-web"
-version = "0.2.11-rc.1"
+version = "0.2.11-rc.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/wasm-hello"]
 
 [workspace.package]
-version = "0.2.11-rc.1"
+version = "0.2.11-rc.2"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mighty840/orca"
@@ -24,9 +24,9 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Shared across crates
-orca-core = { path = "crates/orca-core", version = "0.2.11-rc.1" }
-orca-ai = { path = "crates/orca-ai", version = "0.2.11-rc.1" }
-orca-proxy = { path = "crates/orca-proxy", version = "0.2.11-rc.1" }
+orca-core = { path = "crates/orca-core", version = "0.2.11-rc.2" }
+orca-ai = { path = "crates/orca-ai", version = "0.2.11-rc.2" }
+orca-proxy = { path = "crates/orca-proxy", version = "0.2.11-rc.2" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/orca-cli/Cargo.toml
+++ b/crates/orca-cli/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/main.rs"
 [dependencies]
 orca-core = { workspace = true }
 orca-ai = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.11-rc.1" }
-orca-control = { path = "../orca-control", version = "0.2.11-rc.1" }
+orca-agent = { path = "../orca-agent", version = "0.2.11-rc.2" }
+orca-control = { path = "../orca-control", version = "0.2.11-rc.2" }
 orca-proxy = { workspace = true }
-orca-tui = { path = "../orca-tui", version = "0.2.11-rc.1" }
+orca-tui = { path = "../orca-tui", version = "0.2.11-rc.2" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 
 [dependencies]
 orca-core = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.11-rc.1" }
+orca-agent = { path = "../orca-agent", version = "0.2.11-rc.2" }
 orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }

--- a/crates/orca-proxy/src/forward.rs
+++ b/crates/orca-proxy/src/forward.rs
@@ -263,9 +263,20 @@ pub(crate) async fn forward_streaming(
     );
     debug!("Proxying (stream) {host}{path_and_query} -> {uri}");
 
-    // Wrap the incoming hyper body as a byte stream for reqwest — data frames
-    // flow through without ever materializing the full body in memory.
-    let forward_req = forward_req.body(reqwest::Body::wrap_stream(BodyDataStream::new(body)));
+    // Attach the body. An *empty* body (e.g. `Content-Length: 0` — a session-
+    // refresh POST, a bodyless POST) must be forwarded as a zero-length body so
+    // reqwest emits `Content-Length: 0`, NOT `Transfer-Encoding: chunked`:
+    // `wrap_stream` produces an unknown-length (chunked) body, and a chunked
+    // *empty* request makes strict backends (Fastify/Infisical) treat it as a
+    // body to parse and reject it with `415 Unsupported Media Type` when there's
+    // no `Content-Type` — which broke every empty-body POST through the proxy.
+    // Only non-empty bodies are streamed (the large-blob case #102 targets).
+    use hyper::body::Body as _;
+    let forward_req = if body.size_hint().exact() == Some(0) {
+        forward_req.body(reqwest::Body::from(Vec::<u8>::new()))
+    } else {
+        forward_req.body(reqwest::Body::wrap_stream(BodyDataStream::new(body)))
+    };
 
     match forward_req.send().await {
         Ok(resp) => build_response(resp),

--- a/crates/orca-proxy/tests/request_streaming_test.rs
+++ b/crates/orca-proxy/tests/request_streaming_test.rs
@@ -31,6 +31,43 @@ use orca_proxy::run_proxy_with_fallback;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
 
+/// Spawn a backend that reports, in response headers, the body-framing it
+/// *received* — `transfer-encoding` and `content-length`. Lets a test assert
+/// how the proxy framed the forwarded request.
+async fn spawn_framing_backend() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            tokio::spawn(async move {
+                let svc = service_fn(|req: Request<Incoming>| async move {
+                    let te = req
+                        .headers()
+                        .get("transfer-encoding")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("none")
+                        .to_string();
+                    let cl = req
+                        .headers()
+                        .get("content-length")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("none")
+                        .to_string();
+                    let _ = req.into_body().collect().await;
+                    let mut resp = Response::new(Full::new(hyper::body::Bytes::new()));
+                    resp.headers_mut().insert("x-seen-te", te.parse().unwrap());
+                    resp.headers_mut().insert("x-seen-cl", cl.parse().unwrap());
+                    Ok::<_, hyper::Error>(resp)
+                });
+                let _ = http1::Builder::new().serve_connection(io, svc).await;
+            });
+        }
+    });
+    addr
+}
+
 /// Spawn a backend that echoes the received request body back verbatim.
 async fn spawn_echo_backend() -> SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -178,6 +215,49 @@ async fn proxy_streams_large_upload_arriving_over_time() {
         echoed.len(),
         CHUNK * CHUNKS,
         "every streamed byte must round-trip through the proxy"
+    );
+}
+
+#[tokio::test]
+async fn proxy_empty_body_post_forwards_content_length_not_chunked() {
+    // Regression (#102 follow-up): an empty-body POST (e.g. a session-refresh
+    // call: `Content-Length: 0`, no `Content-Type`) must NOT be re-framed as
+    // `Transfer-Encoding: chunked` by the streaming path. A chunked *empty*
+    // request makes strict backends (Fastify/Infisical) treat it as a body to
+    // parse and reject it with 415 → 500, which broke logins. It must arrive
+    // with `Content-Length: 0` and no chunked encoding.
+    let backend = spawn_framing_backend().await;
+    let port = spawn_proxy(backend).await;
+
+    let resp = client()
+        .post(format!("http://127.0.0.1:{port}/api/v1/auth/token"))
+        .header("Host", "registry.example.com")
+        .send() // no body → Content-Length: 0
+        .await
+        .expect("empty-body POST must succeed through the proxy");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let seen_te = resp
+        .headers()
+        .get("x-seen-te")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let seen_cl = resp
+        .headers()
+        .get("x-seen-cl")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    // The regression was the proxy re-framing this as chunked. It must NOT be
+    // chunked; an empty body arrives as Content-Length: 0 or no framing at all
+    // (both mean "no body" — strict backends accept either, but reject chunked
+    // without a Content-Type).
+    assert_ne!(
+        seen_te, "chunked",
+        "empty-body POST must NOT be forwarded chunked (backend saw Transfer-Encoding: chunked)"
+    );
+    assert!(
+        seen_cl == "0" || seen_cl == "none",
+        "empty-body POST should have no positive Content-Length (saw cl={seen_cl}, te={seen_te})"
     );
 }
 


### PR DESCRIPTION
## Critical regression (v0.2.11-rc.1, from #102)

The single-target streaming path forwards bodies via `reqwest::Body::wrap_stream` (always `Transfer-Encoding: chunked`). With #102 also stripping the client's `Content-Length`, an **empty-body POST** (`Content-Length: 0`, no `Content-Type` — e.g. a session-refresh call) reached the backend as a **chunked** request. Strict backends (Fastify/Infisical) treat chunked as "has a body", find no `Content-Type`, and reject with `415 Unsupported Media Type` → 500.

**Impact:** every empty-body POST through a single-target route broke. Surfaced as **Infisical login looping to "Access Restricted"** — its `POST /api/v1/auth/token` session refresh 500'd. Confirmed by direct-vs-proxy parity: empty-body POST direct → `404` (clean), via proxy → `500`.

## Fix
In `forward_streaming`, only stream (chunked) when the body is non-empty. For an empty body (`size_hint().exact() == Some(0)`), forward a zero-length body so reqwest emits no chunked framing and the backend sees an empty request. Large-body streaming (#102's purpose) is unchanged.

## Test
`proxy_empty_body_post_forwards_content_length_not_chunked` — an empty-body POST through the proxy must reach the backend **not** chunked. `cargo test -p orca-proxy` green (4 streaming tests + suite), clippy + fmt clean.

Targeting a **v0.2.11-rc.2** hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)