### PR TITLE
feat(control): stop=pause, orca start, reconcile-prune of removed services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Service lifecycle: `stop` now pauses (it doesn't delete), and the reconciler prunes services removed from `service.toml`.** `orca stop <svc>` stops the containers but keeps the service *defined* as a persisted **`paused`** state (a stopped-set in the store) — it stays in `orca status` as `paused`, survives a master restart without being auto-started, and the watchdog never restarts it. `orca start <svc>` resumes it to its configured replica count. Removing a service is now done by deleting it from `service.toml`: the declarative reconciler ([`[reconcile].config_dir`]) prunes (stops + purges) services no longer declared — guarded so an empty/garbled config never mass-deletes, and paused services are never pruned. This fixes services resurrecting after a master restart (`stop` previously dropped a service from memory but left it in the store, so restore recreated it) and lets you retire a service cleanly by removing it from config. `orca status` distinguishes `paused` (intentional, startable) from `stopped`/`degraded` (failed).
+
 ## [0.2.11-rc.2] - 2026-06-22
 
 ### Fixed

--- a/crates/orca-cli/src/client.rs
+++ b/crates/orca-cli/src/client.rs
@@ -101,6 +101,18 @@ impl OrcaClient {
         Ok(())
     }
 
+    /// Resume a paused service to its configured replica count.
+    pub async fn start(&self, service: &str) -> anyhow::Result<()> {
+        self.auth(
+            self.client
+                .post(self.url(&format!("/api/v1/services/{service}/start"))),
+        )
+        .send()
+        .await?
+        .error_for_status()?;
+        Ok(())
+    }
+
     pub async fn redeploy(&self, service: &str) -> anyhow::Result<()> {
         self.auth(
             self.client

--- a/crates/orca-cli/src/commands.rs
+++ b/crates/orca-cli/src/commands.rs
@@ -73,6 +73,12 @@ pub enum Command {
         service: Vec<String>,
     },
 
+    /// Start (resume) one or more paused services
+    Start {
+        /// Service name(s)
+        service: Vec<String>,
+    },
+
     /// Force redeploy one or more services (pull image + recreate)
     Redeploy {
         /// Service name(s)

--- a/crates/orca-cli/src/handlers/ops.rs
+++ b/crates/orca-cli/src/handlers/ops.rs
@@ -50,13 +50,21 @@ pub async fn handle_stop(service: Option<String>, api: String) -> anyhow::Result
     match service {
         Some(name) => {
             client.stop(&name).await?;
-            println!("Stopped service: {name}");
+            println!("Paused service: {name} (still defined; `orca start {name}` to resume)");
         }
         None => {
             client.stop_all().await?;
-            println!("Stopped all services.");
+            println!("Paused all services.");
         }
     }
+    Ok(())
+}
+
+/// Resume a paused service to its configured replica count.
+pub async fn handle_start(service: &str, api: String) -> anyhow::Result<()> {
+    let client = OrcaClient::new(api);
+    client.start(service).await?;
+    println!("Started service: {service}");
     Ok(())
 }
 

--- a/crates/orca-cli/src/main.rs
+++ b/crates/orca-cli/src/main.rs
@@ -113,6 +113,11 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         }
+        Command::Start { service } => {
+            for s in service {
+                handlers::ops::handle_start(&s, cli.api.clone()).await?;
+            }
+        }
         Command::Redeploy { service } => {
             for s in service {
                 handlers::ops::handle_redeploy(s, cli.api.clone()).await?;

--- a/crates/orca-control/src/api/handlers/mod.rs
+++ b/crates/orca-control/src/api/handlers/mod.rs
@@ -18,8 +18,8 @@ mod ops;
 pub(crate) mod secrets;
 
 pub(crate) use ops::{
-    cluster_backups, cluster_networks, logs, promote, redeploy, rollback, scale, stop_all,
-    stop_project, stop_service, trigger_cluster_backup,
+    cluster_backups, cluster_networks, logs, promote, redeploy, rollback, scale, start_service,
+    stop_all, stop_project, stop_service, trigger_cluster_backup,
 };
 
 /// Health check endpoint.
@@ -99,7 +99,11 @@ pub(crate) async fn status(
         })
         .map(|svc| {
             let running = svc.running_count();
-            let overall_status = if running == 0 && svc.desired_replicas > 0 {
+            let overall_status = if svc.stopped {
+                // Operator-paused (`orca stop`): defined + startable, distinct
+                // from a service that failed to come up.
+                "paused"
+            } else if running == 0 && svc.desired_replicas > 0 {
                 "stopped"
             } else if running < svc.desired_replicas {
                 "degraded"

--- a/crates/orca-control/src/api/handlers/ops/deploy.rs
+++ b/crates/orca-control/src/api/handlers/ops/deploy.rs
@@ -77,6 +77,18 @@ pub(crate) async fn stop_service(
     )
 }
 
+/// Resume a paused service (`orca start`): clears the stopped mark and deploys
+/// it back to its configured replica count.
+pub(crate) async fn start_service(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    ok_or_500(
+        reconciler::start(&state, &name).await,
+        &format!("start {name}"),
+    )
+}
+
 /// Stop all services in a project.
 pub(crate) async fn stop_project(
     State(state): State<Arc<AppState>>,

--- a/crates/orca-control/src/api/handlers/ops/mod.rs
+++ b/crates/orca-control/src/api/handlers/ops/mod.rs
@@ -12,7 +12,9 @@ use tracing::error;
 
 pub(crate) use backups::{cluster_backups, trigger_cluster_backup};
 pub(crate) use cluster::logs;
-pub(crate) use deploy::{promote, redeploy, rollback, scale, stop_all, stop_project, stop_service};
+pub(crate) use deploy::{
+    promote, redeploy, rollback, scale, start_service, stop_all, stop_project, stop_service,
+};
 pub(crate) use networks::cluster_networks;
 
 fn ok_or_500(result: anyhow::Result<()>, op: &str) -> axum::response::Response {

--- a/crates/orca-control/src/api/mod.rs
+++ b/crates/orca-control/src/api/mod.rs
@@ -32,6 +32,10 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/v1/services/{name}/rollback", post(handlers::rollback))
         .route("/api/v1/services/{name}/redeploy", post(handlers::redeploy))
         .route("/api/v1/services/{name}/promote", post(handlers::promote))
+        .route(
+            "/api/v1/services/{name}/start",
+            post(handlers::start_service),
+        )
         .route("/api/v1/services/{name}", delete(handlers::stop_service))
         .route("/api/v1/projects/{project}", delete(handlers::stop_project))
         .route("/api/v1/stop", post(handlers::stop_all))

--- a/crates/orca-control/src/declarative.rs
+++ b/crates/orca-control/src/declarative.rs
@@ -1,13 +1,17 @@
 //! Declarative reconciler: continuously apply a directory of service configs.
 //!
 //! When `[reconcile].config_dir` is set, the master periodically loads service
-//! definitions from it and applies any that are **new or changed** — so adding
-//! a service is just dropping its `service.toml` in the dir, with no manual
-//! `orca deploy`. Unchanged services are deliberately skipped so we never
-//! re-deploy a steady-state workload (which, for remote services, would
-//! otherwise re-queue a deploy every tick). Healing of degraded-but-unchanged
-//! services stays the watchdog's job; pruning of removed services is left to
-//! the operator.
+//! definitions from it and reconciles the cluster against them:
+//! - **new or changed** services are applied (so adding a service is just
+//!   dropping its `service.toml` in the dir, no manual `orca deploy`);
+//! - services **no longer declared** are pruned (stopped + purged) — guarded so
+//!   an empty/garbled load never mass-deletes;
+//! - **paused** (`orca stop`) services are left alone: not restarted, not pruned.
+//!
+//! Unchanged running services are deliberately skipped so we never re-deploy a
+//! steady-state workload (which, for remote services, would otherwise re-queue a
+//! deploy every tick). Healing of degraded-but-unchanged services stays the
+//! watchdog's job.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -15,6 +19,7 @@ use std::time::Duration;
 use tracing::{info, warn};
 
 use orca_core::config::{ServiceConfig, ServicesConfig};
+use orca_core::ws_types::MasterMessage;
 
 use crate::state::AppState;
 
@@ -68,6 +73,14 @@ pub async fn apply_config_dir(state: &AppState, dir: &str) {
         }
     };
 
+    // Guard: never act on an empty config view — a transient/garbled load must
+    // not mass-prune. (`load_dir` already errors on an empty dir; this covers a
+    // single `services.toml` that parsed to zero services.)
+    if configs.is_empty() {
+        warn!("declarative reconcile: {dir} declared no services; skipping (won't prune)");
+        return;
+    }
+
     // Validate up front; drop invalid configs with a recorded failure so the
     // operator sees the reason in `orca status` rather than silent inaction.
     let mut valid = Vec::with_capacity(configs.len());
@@ -86,13 +99,41 @@ pub async fn apply_config_dir(state: &AppState, dir: &str) {
         }
         valid.push(cfg);
     }
+    if valid.is_empty() {
+        warn!("declarative reconcile: no valid services in {dir}; skipping (won't prune)");
+        return;
+    }
 
-    // Apply only services that are new or whose spec changed. Snapshot the
-    // registry once under a read lock.
+    let declared: std::collections::HashSet<String> =
+        valid.iter().map(|c| c.name.clone()).collect();
+    let stopped: std::collections::HashSet<String> = match &state.store {
+        Some(s) => s.get_stopped().unwrap_or_default(),
+        None => std::collections::HashSet::new(),
+    };
+
+    // Prune services the master knows about that are no longer declared in
+    // `service.toml`. Paused (`stopped`) services are kept — pausing is an
+    // explicit "keep" signal. Guarded above, so an empty/garbled config view
+    // never reaches here.
+    let to_prune: Vec<String> = {
+        let services = state.services.read().await;
+        services
+            .keys()
+            .filter(|n| !declared.contains(n.as_str()) && !stopped.contains(n.as_str()))
+            .cloned()
+            .collect()
+    };
+    for name in &to_prune {
+        prune_service(state, name).await;
+    }
+
+    // Apply new/changed services. Never auto-start a paused service even if its
+    // on-disk spec changed — resuming is an explicit `orca start`.
     let changed: Vec<ServiceConfig> = {
         let services = state.services.read().await;
         valid
             .into_iter()
+            .filter(|cfg| !stopped.contains(&cfg.name))
             .filter(|cfg| match services.get(&cfg.name) {
                 None => true,
                 Some(svc) => !svc.config.spec_matches(cfg),
@@ -125,5 +166,61 @@ pub async fn apply_config_dir(state: &AppState, dir: &str) {
     }
     for e in errors {
         warn!("declarative reconcile error: {e}");
+    }
+}
+
+/// Fully remove a service that's no longer declared: stop its workloads, drop
+/// it from the registry + persisted store, and clear its routes. Unlike
+/// `stop` (which pauses), this is a real removal triggered by the service
+/// disappearing from `service.toml`.
+async fn prune_service(state: &AppState, name: &str) {
+    info!("Declaratively pruning '{name}' (removed from service.toml)");
+
+    let is_remote = {
+        let services = state.services.read().await;
+        services
+            .get(name)
+            .map(|s| {
+                s.config
+                    .placement
+                    .as_ref()
+                    .and_then(|p| p.node.as_ref())
+                    .is_some()
+            })
+            .unwrap_or(false)
+    };
+
+    if is_remote {
+        // Tell agents to stop the container (idempotent — only the agent that
+        // hosts it acts). Stopping it also prevents the adoption reconciler
+        // from re-registering it (it only adopts *running* containers).
+        let agents = state.ws_agents.read().await;
+        for tx in agents.values() {
+            let _ = tx
+                .send(MasterMessage::Stop {
+                    service_name: name.to_string(),
+                })
+                .await;
+        }
+    } else {
+        // Local: scale to 0 tears down the containers.
+        let _ = crate::reconciler::scale(state, name, 0).await;
+    }
+
+    state.services.write().await.remove(name);
+    if let Some(store) = &state.store {
+        let _ = store.remove_service(name);
+        let _ = store.unmark_stopped(name);
+    }
+    {
+        let mut routes = state.route_table.write().await;
+        routes.retain(|_, targets| {
+            targets.retain(|t| t.service_name != name);
+            !targets.is_empty()
+        });
+    }
+    {
+        let mut triggers = state.wasm_triggers.write().await;
+        triggers.retain(|t| t.service_name != name);
     }
 }

--- a/crates/orca-control/src/lib.rs
+++ b/crates/orca-control/src/lib.rs
@@ -106,10 +106,24 @@ pub async fn run_server_with_acme(
 
     // Restore persisted services, re-attaching to existing containers
     if let Some(store) = &state.store {
+        let stopped = store.get_stopped().unwrap_or_default();
         match store.get_all_services() {
             Ok(services) if !services.is_empty() => {
                 info!("Restoring {} persisted services", services.len());
                 for config in services.values() {
+                    // Paused services come back registered-but-not-started, so
+                    // the watchdog/reconciler never auto-start them.
+                    if stopped.contains(&config.name) {
+                        let mut svcs = state.services.write().await;
+                        let svc = svcs
+                            .entry(config.name.clone())
+                            .or_insert_with(|| state::ServiceState::from_config(config.clone()));
+                        svc.config = config.clone();
+                        svc.stopped = true;
+                        svc.desired_replicas = 0;
+                        info!(service = %config.name, "Restored as stopped (paused)");
+                        continue;
+                    }
                     if let Err(e) = restore_or_reconcile(&state, config).await {
                         tracing::warn!(service = %config.name, "Failed to restore: {e}");
                     }

--- a/crates/orca-control/src/operations/lifecycle.rs
+++ b/crates/orca-control/src/operations/lifecycle.rs
@@ -15,19 +15,80 @@ use super::GRACEFUL_TIMEOUT;
 /// Connection drain period: wait for in-flight requests after route update.
 const DRAIN_PERIOD: Duration = Duration::from_secs(5);
 
-/// Stop a service: scale to 0 and remove from state.
+/// Stop a service: pause it. Stops + removes its containers but keeps the
+/// service *defined* as a persisted `stopped` state — it stays in `orca status`
+/// (paused), survives a master restart without being auto-started, and is not
+/// purged. Use [`start`] to resume it, or remove it from `service.toml` to have
+/// the reconciler prune it. (Removal is intentionally NOT what stop does.)
 pub async fn stop(state: &AppState, service_name: &str) -> anyhow::Result<()> {
-    scale(state, service_name, 0).await?;
-    let mut services = state.services.write().await;
-    services.remove(service_name);
-    let mut routes = state.route_table.write().await;
-    routes.retain(|_, targets| {
-        targets.retain(|t| t.service_name != service_name);
-        !targets.is_empty()
-    });
-    let mut triggers = state.wasm_triggers.write().await;
-    triggers.retain(|t| t.service_name != service_name);
-    info!("Stopped service: {service_name}");
+    // Snapshot the configured replica count before scaling to 0 so resuming
+    // restores it (scale() rewrites the in-memory config's replicas).
+    let original_replicas = {
+        let services = state.services.read().await;
+        services
+            .get(service_name)
+            .map(|s| s.config.replicas.clone())
+    };
+
+    scale(state, service_name, 0).await?; // stop + remove the containers
+
+    {
+        let mut services = state.services.write().await;
+        if let Some(svc) = services.get_mut(service_name) {
+            svc.stopped = true;
+            svc.desired_replicas = 0;
+            if let Some(r) = original_replicas {
+                svc.config.replicas = r; // keep the real count for start
+            }
+        }
+    }
+
+    // Persist the pause mark so a restart restores the service as stopped
+    // (not running) and the watchdog/reconciler never auto-start it. The store
+    // already holds the original config (scale() doesn't persist), so the
+    // configured replica count is preserved across restart.
+    if let Some(store) = &state.store
+        && let Err(e) = store.mark_stopped(service_name)
+    {
+        tracing::warn!("failed to persist stopped mark for {service_name}: {e}");
+    }
+
+    // Drop routes + triggers — a paused service receives no traffic.
+    {
+        let mut routes = state.route_table.write().await;
+        routes.retain(|_, targets| {
+            targets.retain(|t| t.service_name != service_name);
+            !targets.is_empty()
+        });
+    }
+    {
+        let mut triggers = state.wasm_triggers.write().await;
+        triggers.retain(|t| t.service_name != service_name);
+    }
+    info!("Paused service: {service_name}");
+    Ok(())
+}
+
+/// Resume a paused service: clear the stopped mark and deploy it back to its
+/// configured replica count.
+pub async fn start(state: &AppState, service_name: &str) -> anyhow::Result<()> {
+    // Prefer the persisted (original) config — on a fresh boot the in-memory
+    // config is restored from the store with the real replica count.
+    let config = {
+        let mut services = state.services.write().await;
+        let svc = services
+            .get_mut(service_name)
+            .ok_or_else(|| anyhow::anyhow!("service '{service_name}' not found"))?;
+        svc.stopped = false;
+        svc.config.clone()
+    };
+    if let Some(store) = &state.store
+        && let Err(e) = store.unmark_stopped(service_name)
+    {
+        tracing::warn!("failed to clear stopped mark for {service_name}: {e}");
+    }
+    reconcile_service(state, &config).await?;
+    info!("Started service: {service_name}");
     Ok(())
 }
 

--- a/crates/orca-control/src/operations/mod.rs
+++ b/crates/orca-control/src/operations/mod.rs
@@ -12,7 +12,7 @@ use crate::reconciler::{get_runtime, reconcile_service};
 use crate::state::AppState;
 
 pub(crate) use lifecycle::{canary_deploy, rolling_update};
-pub use lifecycle::{promote, rollback, scale, stop, stop_all};
+pub use lifecycle::{promote, rollback, scale, start, stop, stop_all};
 
 /// Returned when a redeploy targets a remote node that is not currently connected.
 /// Callers can downcast to distinguish this from internal errors (e.g. map to 503).

--- a/crates/orca-control/src/reconciler.rs
+++ b/crates/orca-control/src/reconciler.rs
@@ -478,4 +478,4 @@ async fn clear_pending_deploy(state: &AppState, name: &str) {
     state.pending_deploy_acks.write().await.remove(name);
     state.pending_deploys.write().await.remove(name);
 }
-pub use crate::operations::{promote, redeploy, rollback, scale, stop, stop_all};
+pub use crate::operations::{promote, redeploy, rollback, scale, start, stop, stop_all};

--- a/crates/orca-control/src/state.rs
+++ b/crates/orca-control/src/state.rs
@@ -212,6 +212,10 @@ pub struct ServiceState {
     pub desired_replicas: u32,
     /// Running instances.
     pub instances: Vec<InstanceState>,
+    /// Operator-paused: defined but intentionally not running (`orca stop`).
+    /// Persisted in the store's stopped-set so it survives restarts and is
+    /// never auto-started by the watchdog or the declarative reconciler.
+    pub stopped: bool,
 }
 
 /// State of a single workload instance (one replica).
@@ -330,6 +334,7 @@ impl ServiceState {
             config,
             desired_replicas,
             instances: Vec::new(),
+            stopped: false,
         }
     }
 

--- a/crates/orca-control/src/store/kv.rs
+++ b/crates/orca-control/src/store/kv.rs
@@ -14,6 +14,10 @@ use super::types::{Assignment, NodeEntry, RaftEntry, RaftSnapshot};
 pub(super) const NODES: TableDefinition<u64, &[u8]> = TableDefinition::new("nodes");
 pub(super) const SERVICES: TableDefinition<&str, &[u8]> = TableDefinition::new("services");
 pub(super) const ASSIGNMENTS: TableDefinition<&str, &[u8]> = TableDefinition::new("assignments");
+/// Operator-stopped (paused) services, keyed by name. Persisted separately
+/// from the service config so the declarative reconciler — which loads
+/// `service.toml` (no `stopped` field) — never un-stops a paused service.
+pub(super) const STOPPED: TableDefinition<&str, &[u8]> = TableDefinition::new("stopped");
 
 /// Persistent cluster state store.
 pub struct ClusterStore {
@@ -30,6 +34,7 @@ impl ClusterStore {
             let _ = tx.open_table(NODES)?;
             let _ = tx.open_table(SERVICES)?;
             let _ = tx.open_table(ASSIGNMENTS)?;
+            let _ = tx.open_table(STOPPED)?;
         }
         tx.commit()?;
         Ok(Self { db })
@@ -175,6 +180,41 @@ impl ClusterStore {
         }
         tx.commit()?;
         Ok(())
+    }
+
+    /// Mark a service as operator-stopped (paused). Survives restart; the
+    /// service stays known but is not started until explicitly resumed.
+    pub fn mark_stopped(&self, name: &str) -> anyhow::Result<()> {
+        let tx = self.db.begin_write()?;
+        {
+            let mut table = tx.open_table(STOPPED)?;
+            table.insert(name, [1u8].as_slice())?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Clear the stopped mark for a service (on `orca start`).
+    pub fn unmark_stopped(&self, name: &str) -> anyhow::Result<()> {
+        let tx = self.db.begin_write()?;
+        {
+            let mut table = tx.open_table(STOPPED)?;
+            table.remove(name)?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Names of all operator-stopped (paused) services.
+    pub fn get_stopped(&self) -> anyhow::Result<std::collections::HashSet<String>> {
+        let tx = self.db.begin_read()?;
+        let table = tx.open_table(STOPPED)?;
+        let mut out = std::collections::HashSet::new();
+        for entry in table.iter()? {
+            let (k, _) = entry?;
+            out.insert(k.value().to_string());
+        }
+        Ok(out)
     }
 
     /// Get all service configs.

--- a/crates/orca-control/src/watchdog.rs
+++ b/crates/orca-control/src/watchdog.rs
@@ -184,6 +184,12 @@ async fn check_and_prune(state: &AppState, service_name: &str, runtime_kind: Run
         return false;
     };
 
+    // Paused services (`orca stop`) are intentionally not running — never
+    // auto-restart them.
+    if svc.stopped {
+        return false;
+    }
+
     // Remote-placed services are reconciled by send_reconcile when the agent
     // connects. The watchdog must not trigger local reconcile for them —
     // instances.len() is 0 until the agent's first heartbeat, so without

--- a/crates/orca-control/tests/declarative_test.rs
+++ b/crates/orca-control/tests/declarative_test.rs
@@ -8,6 +8,7 @@ use tokio::sync::RwLock;
 
 use orca_control::declarative::apply_config_dir;
 use orca_control::state::AppState;
+use orca_control::store::ClusterStore;
 use orca_core::config::ClusterConfig;
 use orca_core::testing::MockRuntime;
 
@@ -20,6 +21,29 @@ fn state() -> Arc<AppState> {
         Arc::new(RwLock::new(Vec::new())),
     ))
 }
+
+/// State backed by a real redb store (needed for the stopped-set + prune purge).
+fn state_with_store(db_path: &std::path::Path) -> Arc<AppState> {
+    let store = ClusterStore::open(db_path).unwrap();
+    Arc::new(
+        AppState::new(
+            ClusterConfig::default(),
+            Arc::new(MockRuntime::with_host_port(9000)),
+            None,
+            Arc::new(RwLock::new(HashMap::new())),
+            Arc::new(RwLock::new(Vec::new())),
+        )
+        .with_store(Arc::new(store)),
+    )
+}
+
+const WEB: &str = r#"
+    [[service]]
+    name = "web"
+    image = "nginx:latest"
+    port = 8080
+    replicas = 1
+"#;
 
 /// Write `<dir>/<project>/service.toml` with the given body.
 fn write_service(dir: &std::path::Path, project: &str, body: &str) {
@@ -97,5 +121,150 @@ async fn invalid_config_is_skipped_and_recorded() {
         f.message.contains("domain") && f.message.contains("domains"),
         "failure should explain the conflict: {}",
         f.message
+    );
+}
+
+#[tokio::test]
+async fn prunes_service_removed_from_config() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tempfile::tempdir().unwrap();
+    write_service(tmp.path(), "web", WEB);
+    write_service(
+        tmp.path(),
+        "api",
+        r#"
+        [[service]]
+        name = "api"
+        image = "nginx:latest"
+        port = 9090
+        replicas = 1
+        "#,
+    );
+    let state = state_with_store(&db.path().join("c.db"));
+    let dir = tmp.path().to_str().unwrap();
+
+    apply_config_dir(&state, dir).await;
+    {
+        let s = state.services.read().await;
+        assert!(
+            s.contains_key("web") && s.contains_key("api"),
+            "both deployed"
+        );
+    }
+
+    // Drop "api" from the config dir → next reconcile must prune it.
+    std::fs::remove_dir_all(tmp.path().join("api")).unwrap();
+    apply_config_dir(&state, dir).await;
+
+    let s = state.services.read().await;
+    assert!(s.contains_key("web"), "still-declared service kept");
+    assert!(
+        !s.contains_key("api"),
+        "service removed from service.toml must be pruned"
+    );
+}
+
+#[tokio::test]
+async fn empty_config_dir_does_not_prune() {
+    // Guard: a transient/empty load must never mass-delete declared services.
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tempfile::tempdir().unwrap();
+    write_service(tmp.path(), "web", WEB);
+    let state = state_with_store(&db.path().join("c.db"));
+    let dir = tmp.path().to_str().unwrap();
+    apply_config_dir(&state, dir).await;
+    assert!(state.services.read().await.contains_key("web"));
+
+    // Remove ALL service.toml files, then reconcile — must NOT prune "web".
+    std::fs::remove_dir_all(tmp.path().join("web")).unwrap();
+    apply_config_dir(&state, dir).await;
+    assert!(
+        state.services.read().await.contains_key("web"),
+        "empty/garbled config must not trigger a prune"
+    );
+}
+
+#[tokio::test]
+async fn paused_service_is_not_pruned_or_restarted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tempfile::tempdir().unwrap();
+    write_service(tmp.path(), "web", WEB);
+    let state = state_with_store(&db.path().join("c.db"));
+    let dir = tmp.path().to_str().unwrap();
+
+    apply_config_dir(&state, dir).await;
+    orca_control::reconciler::stop(&state, "web").await.unwrap();
+    assert!(state.services.read().await.get("web").unwrap().stopped);
+
+    // Reconcile again with "web" still declared — it must stay paused, not be
+    // restarted, and not be pruned.
+    apply_config_dir(&state, dir).await;
+    let s = state.services.read().await;
+    let web = s
+        .get("web")
+        .expect("paused + still-declared service must be kept");
+    assert!(
+        web.stopped,
+        "paused service must stay paused (not restarted)"
+    );
+    assert_eq!(web.running_count(), 0, "paused service must not be running");
+}
+
+#[tokio::test]
+async fn stop_pauses_then_start_resumes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tempfile::tempdir().unwrap();
+    write_service(tmp.path(), "web", WEB);
+    let state = state_with_store(&db.path().join("c.db"));
+    apply_config_dir(&state, tmp.path().to_str().unwrap()).await;
+    assert_eq!(
+        state
+            .services
+            .read()
+            .await
+            .get("web")
+            .unwrap()
+            .running_count(),
+        1
+    );
+
+    // stop = pause: kept in registry, marked stopped + persisted, 0 running.
+    orca_control::reconciler::stop(&state, "web").await.unwrap();
+    {
+        let s = state.services.read().await;
+        let w = s.get("web").expect("paused service stays in the registry");
+        assert!(w.stopped);
+        assert_eq!(w.running_count(), 0);
+    }
+    assert!(
+        state
+            .store
+            .as_ref()
+            .unwrap()
+            .get_stopped()
+            .unwrap()
+            .contains("web"),
+        "stopped mark persisted"
+    );
+
+    // start = resume: cleared + back to configured replicas.
+    orca_control::reconciler::start(&state, "web")
+        .await
+        .unwrap();
+    {
+        let s = state.services.read().await;
+        let w = s.get("web").unwrap();
+        assert!(!w.stopped);
+        assert_eq!(w.running_count(), 1, "resumed to configured replicas");
+    }
+    assert!(
+        !state
+            .store
+            .as_ref()
+            .unwrap()
+            .get_stopped()
+            .unwrap()
+            .contains("web"),
+        "stopped mark cleared on start"
     );
 }

--- a/crates/orca-control/tests/state_edge_test.rs
+++ b/crates/orca-control/tests/state_edge_test.rs
@@ -139,11 +139,18 @@ async fn test_deploy_then_immediately_stop() {
         resp.status()
     );
 
-    // Verify service is gone from state (no orphans).
+    // `stop` now *pauses* rather than deletes: the service stays defined (so it
+    // survives a restart and can be resumed with `orca start`) but is marked
+    // paused with no running instances — and crucially no orphaned containers.
     let services = state.services.read().await;
-    assert!(
-        !services.contains_key("fast-stop"),
-        "service should be removed after stop"
+    let svc = services
+        .get("fast-stop")
+        .expect("stopped service stays defined (paused), not deleted");
+    assert!(svc.stopped, "service should be marked paused after stop");
+    assert_eq!(
+        svc.running_count(),
+        0,
+        "paused service must have no running instances (no orphans)"
     );
 }
 


### PR DESCRIPTION
## Summary

Reworks the service lifecycle so the registry reconciles against `service.toml`, and fixes the **service-resurrection bug** (a stopped service came back after a master restart — `stop` dropped it from memory but never purged the store, so restore recreated it; nothing pruned services removed from config).

## Model
- **`stop` = pause, not delete.** Stops/removes containers but keeps the service *defined* as a persisted **`paused`** state — a stopped-set table in redb, kept **separate from the config** so the reconciler (which loads `service.toml`, no `stopped` field) never un-pauses it. Stays in `orca status` as `paused`, survives restart without auto-starting, watchdog won't restart it.
- **`orca start <svc>`** (+ `POST /api/v1/services/{name}/start`) resumes to configured replicas.
- **Removal = absence from `service.toml`.** The declarative reconciler prunes services no longer declared (stops + purges store/registry; remote via agent `Stop`). **Guarded**: an empty/garbled config load never prunes; paused services are never pruned.
- Boot-restore + watchdog respect `paused`; status distinguishes `paused` (intentional, startable) from `stopped`/`degraded` (failed).

This retires e.g. `searxng` cleanly (remove from `service.toml` → pruned) instead of it resurrecting on restart.

## Tests
Store stopped-set; and over a temp `service.toml` dir: prune-on-removal, empty-config guard (no mass-delete), paused-not-pruned/restarted, and `stop`→`start` roundtrip. Full `cargo test -p orca-control` + clippy + fmt + >500-line gate clean.

> Note: only takes effect when `[reconcile].config_dir` is set (opt-in). Builds on the v0.2.11 declarative reconciler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)