### PR TITLE
fix(ai): debounce "service down" alerts with a deploy grace window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Service lifecycle: `stop` now pauses (it doesn't delete), and the reconciler prunes services removed from `service.toml`.** `orca stop <svc>` stops the containers but keeps the service *defined* as a persisted **`paused`** state (a stopped-set in the store) — it stays in `orca status` as `paused`, survives a master restart without being auto-started, and the watchdog never restarts it. `orca start <svc>` resumes it to its configured replica count. Removing a service is now done by deleting it from `service.toml`: the declarative reconciler ([`[reconcile].config_dir`]) prunes (stops + purges) services no longer declared — guarded so an empty/garbled config never mass-deletes, and paused services are never pruned. This fixes services resurrecting after a master restart (`stop` previously dropped a service from memory but left it in the store, so restore recreated it) and lets you retire a service cleanly by removing it from config. `orca status` distinguishes `paused` (intentional, startable) from `stopped`/`degraded` (failed).
 
+### Fixed
+
+- **Webhook deploys no longer spam "critical issue opened" + "remediated" alert emails.** The AI monitor opened a `Critical` "service down" alert the instant it observed `0` running replicas — but a webhook deploy/rollout briefly drops a service to 0 replicas while the new container pulls and starts. The next monitor cycle opened an alert (one email), the container came up, and the following cycle auto-remediated it (a second email) — every single deploy. The monitor now applies a **grace window** (Prometheus `for:` semantics): a "service down" alert only opens once the outage has persisted past `[ai.alerts].alert_grace_secs` (default **120s**), measured per service and reset when it recovers. A normal rollout settles well inside the grace window so it never pages, while a genuine sustained outage still opens exactly one alert. Raise `alert_grace_secs` for services whose image pulls/health checks routinely exceed the default.
+
 ## [0.2.11-rc.2] - 2026-06-22
 
 ### Fixed

--- a/crates/orca-ai/src/monitor.rs
+++ b/crates/orca-ai/src/monitor.rs
@@ -1,5 +1,6 @@
-use std::sync::Arc;
-use std::time::Duration;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use tokio::sync::RwLock;
 use tracing::{info, warn};
@@ -20,13 +21,27 @@ use orca_core::types::AlertSeverity;
 pub struct AiMonitor<B: LlmBackend> {
     engine: Arc<RwLock<ConversationEngine<B>>>,
     analysis_interval: Duration,
+    /// A service must be observed down (0 running, >0 desired) for at least this
+    /// long before a Critical "service down" alert opens. Without it, a deploy's
+    /// brief 0-replica window opens + auto-remediates an alert every rollout.
+    down_grace: Duration,
+    /// First time each service was seen down in the current outage. Cleared when
+    /// it recovers, so the grace clock restarts per outage. Interior-mutable so
+    /// the monitor loop keeps a `&self` API.
+    down_since: Mutex<HashMap<String, Instant>>,
 }
 
 impl<B: LlmBackend> AiMonitor<B> {
-    pub fn new(engine: Arc<RwLock<ConversationEngine<B>>>, analysis_interval_secs: u64) -> Self {
+    pub fn new(
+        engine: Arc<RwLock<ConversationEngine<B>>>,
+        analysis_interval_secs: u64,
+        alert_grace_secs: u64,
+    ) -> Self {
         Self {
             engine,
             analysis_interval: Duration::from_secs(analysis_interval_secs),
+            down_grace: Duration::from_secs(alert_grace_secs),
+            down_since: Mutex::new(HashMap::new()),
         }
     }
 
@@ -54,34 +69,62 @@ impl<B: LlmBackend> AiMonitor<B> {
     }
 
     async fn analyze_cycle(&self, ctx: &ClusterContext) -> anyhow::Result<()> {
+        let now = Instant::now();
         let mut engine = self.engine.write().await;
 
         // Check each service for anomalies
         for svc in &ctx.services {
-            // Service down / crash-looping
+            // Service down — but debounce transient deploy/rollout blips. A
+            // webhook deploy briefly drops replicas to 0; we only page once the
+            // outage has outlasted `down_grace`, so a normal rollout never opens
+            // (and then auto-remediates) an alert.
             if svc.replicas_running == 0 && svc.replicas_desired > 0 {
-                let already_tracking = engine
-                    .active_conversations()
-                    .iter()
-                    .any(|c| c.service == svc.name);
+                let down_for = {
+                    let mut down_since = self.down_since.lock().expect("down_since lock poisoned");
+                    let since = down_since.entry(svc.name.clone()).or_insert(now);
+                    now.saturating_duration_since(*since)
+                };
 
-                if !already_tracking {
+                if down_for < self.down_grace {
                     info!(
-                        "Opening alert conversation for {}: no running replicas",
-                        svc.name
+                        "Service '{}' has 0/{} replicas but only down {}s (< {}s grace) — deferring alert (likely a deploy)",
+                        svc.name,
+                        svc.replicas_desired,
+                        down_for.as_secs(),
+                        self.down_grace.as_secs()
                     );
-                    engine
-                        .open_alert(
-                            &svc.name,
-                            AlertSeverity::Critical,
-                            &format!(
-                                "Service '{}' has 0/{} replicas running. Restarts in 24h: {}. Recent errors: {}",
-                                svc.name, svc.replicas_desired, svc.restart_count_24h, svc.error_count_1h
-                            ),
-                            ctx,
-                        )
-                        .await?;
+                } else {
+                    let already_tracking = engine
+                        .active_conversations()
+                        .iter()
+                        .any(|c| c.service == svc.name);
+
+                    if !already_tracking {
+                        info!(
+                            "Opening alert conversation for {}: no running replicas for {}s",
+                            svc.name,
+                            down_for.as_secs()
+                        );
+                        engine
+                            .open_alert(
+                                &svc.name,
+                                AlertSeverity::Critical,
+                                &format!(
+                                    "Service '{}' has 0/{} replicas running. Restarts in 24h: {}. Recent errors: {}",
+                                    svc.name, svc.replicas_desired, svc.restart_count_24h, svc.error_count_1h
+                                ),
+                                ctx,
+                            )
+                            .await?;
+                    }
                 }
+            } else {
+                // Recovered or scaled up — reset the grace clock so the next
+                // outage measures from its own start, not a stale timestamp.
+                self.down_since
+                    .lock()
+                    .expect("down_since lock poisoned")
+                    .remove(&svc.name);
             }
 
             // High restart count (crash-looping)
@@ -138,6 +181,17 @@ impl<B: LlmBackend> AiMonitor<B> {
                         .await?;
                 }
             }
+        }
+
+        // Drop grace timers for services no longer in the cluster (pruned while
+        // down) so the map can't grow unbounded.
+        {
+            let live: std::collections::HashSet<&str> =
+                ctx.services.iter().map(|s| s.name.as_str()).collect();
+            self.down_since
+                .lock()
+                .expect("down_since lock poisoned")
+                .retain(|name, _| live.contains(name.as_str()));
         }
 
         // Check nodes for GPU issues
@@ -231,4 +285,100 @@ impl<B: LlmBackend> AiMonitor<B> {
 #[async_trait::async_trait]
 pub trait ContextProvider: Send + Sync + 'static {
     async fn snapshot(&self) -> anyhow::Result<ClusterContext>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::{ChatMessage, ChatResponse, LlmBackend};
+    use crate::context::ServiceSummary;
+    use crate::conversation::ConversationEngine;
+
+    /// Canned backend so `open_alert` doesn't hit the network.
+    struct StubBackend;
+
+    #[async_trait::async_trait]
+    impl LlmBackend for StubBackend {
+        async fn chat(&self, _messages: &[ChatMessage]) -> anyhow::Result<ChatResponse> {
+            Ok(ChatResponse {
+                content: "Service appears down. Fix: `orca redeploy api`".to_string(),
+                tokens_used: None,
+            })
+        }
+        fn name(&self) -> &str {
+            "stub"
+        }
+    }
+
+    fn ctx_with_down_service() -> ClusterContext {
+        ClusterContext {
+            cluster_name: "test".into(),
+            nodes: Vec::new(),
+            services: vec![ServiceSummary {
+                name: "api".into(),
+                runtime: "container".into(),
+                replicas_running: 0,
+                replicas_desired: 2,
+                status: "degraded".into(),
+                uses_gpu: false,
+                recent_logs: Vec::new(),
+                error_count_1h: 0,
+                restart_count_24h: 0,
+            }],
+            recent_events: Vec::new(),
+            active_alerts: Vec::new(),
+        }
+    }
+
+    fn monitor(grace_secs: u64) -> AiMonitor<StubBackend> {
+        let engine = Arc::new(RwLock::new(ConversationEngine::new(StubBackend)));
+        AiMonitor::new(engine, 60, grace_secs)
+    }
+
+    #[tokio::test]
+    async fn down_within_grace_does_not_open_alert() {
+        // A webhook deploy briefly drops replicas to 0. With a grace window the
+        // monitor must NOT page on that transient blip — this is the regression
+        // that was spamming open+remediate emails on every deploy.
+        let mon = monitor(120);
+        let ctx = ctx_with_down_service();
+        mon.analyze_cycle(&ctx).await.unwrap();
+        mon.analyze_cycle(&ctx).await.unwrap();
+        assert!(
+            mon.engine.read().await.active_conversations().is_empty(),
+            "a service down only within the deploy grace window must not open an alert"
+        );
+    }
+
+    #[tokio::test]
+    async fn down_past_grace_opens_single_alert() {
+        // grace=0 → a genuine outage still pages, exactly once.
+        let mon = monitor(0);
+        let ctx = ctx_with_down_service();
+        mon.analyze_cycle(&ctx).await.unwrap();
+        mon.analyze_cycle(&ctx).await.unwrap();
+        assert_eq!(
+            mon.engine.read().await.active_conversations().len(),
+            1,
+            "a sustained outage must open exactly one alert (not one per cycle)"
+        );
+    }
+
+    #[tokio::test]
+    async fn recovery_resets_grace_clock() {
+        // Down past grace opens an alert; once healthy the timer is cleared so a
+        // later outage is measured from its own start, not the first one.
+        let mon = monitor(0);
+        let mut ctx = ctx_with_down_service();
+        mon.analyze_cycle(&ctx).await.unwrap();
+        assert_eq!(mon.engine.read().await.active_conversations().len(), 1);
+
+        // Service recovers — the grace timer for "api" must be dropped.
+        ctx.services[0].replicas_running = 2;
+        mon.analyze_cycle(&ctx).await.unwrap();
+        assert!(
+            mon.down_since.lock().unwrap().is_empty(),
+            "recovery must clear the per-service down timer"
+        );
+    }
 }

--- a/crates/orca-control/src/alerts.rs
+++ b/crates/orca-control/src/alerts.rs
@@ -68,11 +68,12 @@ pub fn spawn_alert_monitor(state: Arc<AppState>) -> Option<tokio::task::JoinHand
         return None;
     }
     let interval = alerts_cfg.analysis_interval_secs;
+    let grace = alerts_cfg.alert_grace_secs;
     let provider: Arc<dyn ContextProvider> =
         Arc::new(StateContextProvider::for_state(state.clone()));
-    info!("Spawning AI alert monitor (interval: {interval}s)");
+    info!("Spawning AI alert monitor (interval: {interval}s, down-grace: {grace}s)");
     Some(tokio::spawn(async move {
-        let monitor = AiMonitor::new(engine, interval);
+        let monitor = AiMonitor::new(engine, interval, grace);
         monitor.run(provider).await;
     }))
 }

--- a/crates/orca-core/src/config/ai.rs
+++ b/crates/orca-core/src/config/ai.rs
@@ -31,6 +31,13 @@ pub struct AiAlertConfig {
     /// How often to analyze cluster health (seconds, default: 60).
     #[serde(default = "default_analysis_interval")]
     pub analysis_interval_secs: u64,
+    /// Grace window (seconds) a service must stay down before a "service down"
+    /// alert fires (default: 120). A deploy/rollout briefly drops replicas to 0;
+    /// without this grace every webhook deploy would open + auto-remediate an
+    /// alert, spamming the configured channels. Raise it for services whose
+    /// image pulls/health checks routinely take longer than the default.
+    #[serde(default = "default_alert_grace")]
+    pub alert_grace_secs: u64,
     /// Channels to deliver conversation updates.
     pub channels: Option<AlertDeliveryChannels>,
 }
@@ -41,6 +48,10 @@ fn default_true() -> bool {
 
 fn default_analysis_interval() -> u64 {
     60
+}
+
+fn default_alert_grace() -> u64 {
+    120
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/docs/guide/ai-ops.md
+++ b/docs/guide/ai-ops.md
@@ -74,6 +74,11 @@ Configure AI-powered alert analysis:
 [ai.alerts]
 enabled = true
 analysis_interval_secs = 60
+# A "service down" alert only fires once a service has been at 0 running
+# replicas for this many seconds. Deploys/rollouts briefly drop to 0 replicas
+# while the new container pulls and starts; the grace window keeps a normal
+# rollout from opening (and then auto-remediating) an alert on every deploy.
+alert_grace_secs = 120
 
 [ai.alerts.channels]
 slack = "https://hooks.slack.com/services/..."
@@ -81,6 +86,8 @@ webhook = "https://my-pagerduty-webhook/..."
 ```
 
 When an alert fires, the AI investigates the root cause, suggests fixes, and tracks resolution.
+
+`alert_grace_secs` (default 120) debounces transient outages: a service must stay down longer than the grace window before it pages, so a webhook deploy doesn't spam open/remediated notifications. Raise it for services whose image pulls or health checks routinely take longer than two minutes; a genuine sustained outage still opens exactly one alert.
 
 ## Auto-Remediation
 

--- a/docs/src/content/docs/guide/ai-ops.md
+++ b/docs/src/content/docs/guide/ai-ops.md
@@ -74,6 +74,11 @@ Configure AI-powered alert analysis:
 [ai.alerts]
 enabled = true
 analysis_interval_secs = 60
+# A "service down" alert only fires once a service has been at 0 running
+# replicas for this many seconds. Deploys/rollouts briefly drop to 0 replicas
+# while the new container pulls and starts; the grace window keeps a normal
+# rollout from opening (and then auto-remediating) an alert on every deploy.
+alert_grace_secs = 120
 
 [ai.alerts.channels]
 slack = "https://hooks.slack.com/services/..."
@@ -81,6 +86,8 @@ webhook = "https://my-pagerduty-webhook/..."
 ```
 
 When an alert fires, the AI investigates the root cause, suggests fixes, and tracks resolution.
+
+`alert_grace_secs` (default 120) debounces transient outages: a service must stay down longer than the grace window before it pages, so a webhook deploy doesn't spam open/remediated notifications. Raise it for services whose image pulls or health checks routinely take longer than two minutes; a genuine sustained outage still opens exactly one alert.
 
 ## Auto-Remediation
 


### PR DESCRIPTION
## Problem

Every webhook deploy spammed two alert emails: a **"critical issue opened"** followed by a **"remediated"**.

The AI monitor (`crates/orca-ai/src/monitor.rs`) opened a `Critical` "service down" alert the instant it observed `replicas_running == 0 && replicas_desired > 0`. But a webhook deploy/rollout briefly drops a service to **0 running replicas** while the new container pulls and starts (`replicas_running` counts only `WorkloadStatus::Running`). So on every deploy:

1. a monitor cycle catches the 0-replica window → `open_alert(Critical)` → `dispatch(Opened)` → **email #1**;
2. the container comes up → next cycle hits the self-resolve path → `mark_remediated` → `dispatch(Remediated)` → **email #2**.

Slow image pulls make it worse (0-running for minutes).

## Fix

Add a **grace window** to the down-alert (Prometheus `for:` semantics). The monitor tracks, per service, when it was first seen down, and only opens the `Critical` alert once the outage has persisted past `[ai.alerts].alert_grace_secs` (**default 120s**). The timer resets when the service recovers (and stale entries for pruned services are reaped each cycle).

- A normal rollout settles inside the grace window → **no alert, no emails**.
- A genuine sustained outage still opens **exactly one** alert after the grace elapses.
- Tunable: raise `alert_grace_secs` for services whose pulls/health checks routinely exceed 2 min.

Only the instantaneous down-check is debounced; the crash-loop (`restart_count_24h`) and high-error (`error_count_1h`) heuristics are cumulative windows, not per-deploy transients, so they're unchanged.

## Changes

- `orca-core`: new `[ai.alerts].alert_grace_secs` config field (default 120).
- `orca-ai/monitor.rs`: per-service `down_since` timer + grace gate on the Critical down-alert; reset on recovery; reap pruned services.
- `orca-control/alerts.rs`: thread the grace into `AiMonitor::new`.
- Docs (both trees) + CHANGELOG.

## Tests

3 new unit tests in `monitor.rs`:
- `down_within_grace_does_not_open_alert` — the regression: a deploy-window blip must not page.
- `down_past_grace_opens_single_alert` — a sustained outage opens exactly one alert.
- `recovery_resets_grace_clock` — recovery clears the per-service timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)