### PR TITLE
chore(release): bump workspace to v0.2.11-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11-rc.3] - 2026-06-22
+
 ### Added
 
 - **Service lifecycle: `stop` now pauses (it doesn't delete), and the reconciler prunes services removed from `service.toml`.** `orca stop <svc>` stops the containers but keeps the service *defined* as a persisted **`paused`** state (a stopped-set in the store) — it stays in `orca status` as `paused`, survives a master restart without being auto-started, and the watchdog never restarts it. `orca start <svc>` resumes it to its configured replica count. Removing a service is now done by deleting it from `service.toml`: the declarative reconciler ([`[reconcile].config_dir`]) prunes (stops + purges) services no longer declared — guarded so an empty/garbled config never mass-deletes, and paused services are never pruned. This fixes services resurrecting after a master restart (`stop` previously dropped a service from memory but left it in the store, so restore recreated it) and lets you retire a service cleanly by removing it from config. `orca status` distinguishes `paused` (intentional, startable) from `stopped`/`degraded` (failed).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mallorca"
-version = "0.2.11-rc.2"
+version = "0.2.11-rc.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2554,7 +2554,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orca-agent"
-version = "0.2.11-rc.2"
+version = "0.2.11-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "orca-ai"
-version = "0.2.11-rc.2"
+version = "0.2.11-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "orca-control"
-version = "0.2.11-rc.2"
+version = "0.2.11-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "orca-core"
-version = "0.2.11-rc.2"
+version = "0.2.11-rc.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "orca-proxy"
-version = "0.2.11-rc.2"
+version = "0.2.11-rc.3"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "orca-tui"
-version = "0.2.11-rc.2"
+version = "0.2.11-rc.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "orca-web"
-version = "0.2.11-rc.2"
+version = "0.2.11-rc.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/wasm-hello"]
 
 [workspace.package]
-version = "0.2.11-rc.2"
+version = "0.2.11-rc.3"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mighty840/orca"
@@ -24,9 +24,9 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Shared across crates
-orca-core = { path = "crates/orca-core", version = "0.2.11-rc.2" }
-orca-ai = { path = "crates/orca-ai", version = "0.2.11-rc.2" }
-orca-proxy = { path = "crates/orca-proxy", version = "0.2.11-rc.2" }
+orca-core = { path = "crates/orca-core", version = "0.2.11-rc.3" }
+orca-ai = { path = "crates/orca-ai", version = "0.2.11-rc.3" }
+orca-proxy = { path = "crates/orca-proxy", version = "0.2.11-rc.3" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/orca-cli/Cargo.toml
+++ b/crates/orca-cli/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/main.rs"
 [dependencies]
 orca-core = { workspace = true }
 orca-ai = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.11-rc.2" }
-orca-control = { path = "../orca-control", version = "0.2.11-rc.2" }
+orca-agent = { path = "../orca-agent", version = "0.2.11-rc.3" }
+orca-control = { path = "../orca-control", version = "0.2.11-rc.3" }
 orca-proxy = { workspace = true }
-orca-tui = { path = "../orca-tui", version = "0.2.11-rc.2" }
+orca-tui = { path = "../orca-tui", version = "0.2.11-rc.3" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 
 [dependencies]
 orca-core = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.11-rc.2" }
+orca-agent = { path = "../orca-agent", version = "0.2.11-rc.3" }
 orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
Release bump for **v0.2.11-rc.3**.

Bundles the two PRs merged since rc.2:
- **#106** — `stop` now *pauses* (keeps the service defined as persisted `paused`), `orca start` resumes, and the declarative reconciler prunes services removed from `service.toml` (guarded; paused services never pruned).
- **#107** — AI monitor applies a deploy **grace window** (`[ai.alerts].alert_grace_secs`, default 120s) before opening a "service down" alert, fixing the open+remediated email spam on every webhook deploy.

Version bumped across the workspace (`Cargo.toml` + per-crate path-dep pins + `Cargo.lock`); CHANGELOG `[Unreleased]` promoted to `[0.2.11-rc.3]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)