### PR TITLE
feat(proxy): branded fallback page for unrouted hosts + v0.2.11-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11-rc.4] - 2026-06-22
+
+### Added
+
+- **Branded fallback page for unrouted hosts.** When the proxy can't route a request it used to return a bare plain-text body (`no service for host: <host>`). It now serves a self-contained, docs-themed HTML page (inline CSS + logo, no external assets — renders even on a degraded/offline box) with the requested host and links to the docs and GitHub. Two variants: **404** for an unknown host (`no service for host`) and **503** for a known host with no healthy backend (`no backends for host`). The requested host is HTML-escaped (it's attacker-controllable via the `Host` header). The existing `[fallback].http` forward-to-a-target behavior is unchanged — the page only appears when no fallback target is configured. (#111)
+
 ## [0.2.11-rc.3] - 2026-06-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mallorca"
-version = "0.2.11-rc.3"
+version = "0.2.11-rc.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2554,7 +2554,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orca-agent"
-version = "0.2.11-rc.3"
+version = "0.2.11-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "orca-ai"
-version = "0.2.11-rc.3"
+version = "0.2.11-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "orca-control"
-version = "0.2.11-rc.3"
+version = "0.2.11-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "orca-core"
-version = "0.2.11-rc.3"
+version = "0.2.11-rc.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "orca-proxy"
-version = "0.2.11-rc.3"
+version = "0.2.11-rc.4"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "orca-tui"
-version = "0.2.11-rc.3"
+version = "0.2.11-rc.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "orca-web"
-version = "0.2.11-rc.3"
+version = "0.2.11-rc.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/wasm-hello"]
 
 [workspace.package]
-version = "0.2.11-rc.3"
+version = "0.2.11-rc.4"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mighty840/orca"
@@ -24,9 +24,9 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Shared across crates
-orca-core = { path = "crates/orca-core", version = "0.2.11-rc.3" }
-orca-ai = { path = "crates/orca-ai", version = "0.2.11-rc.3" }
-orca-proxy = { path = "crates/orca-proxy", version = "0.2.11-rc.3" }
+orca-core = { path = "crates/orca-core", version = "0.2.11-rc.4" }
+orca-ai = { path = "crates/orca-ai", version = "0.2.11-rc.4" }
+orca-proxy = { path = "crates/orca-proxy", version = "0.2.11-rc.4" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/orca-cli/Cargo.toml
+++ b/crates/orca-cli/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/main.rs"
 [dependencies]
 orca-core = { workspace = true }
 orca-ai = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.11-rc.3" }
-orca-control = { path = "../orca-control", version = "0.2.11-rc.3" }
+orca-agent = { path = "../orca-agent", version = "0.2.11-rc.4" }
+orca-control = { path = "../orca-control", version = "0.2.11-rc.4" }
 orca-proxy = { workspace = true }
-orca-tui = { path = "../orca-tui", version = "0.2.11-rc.3" }
+orca-tui = { path = "../orca-tui", version = "0.2.11-rc.4" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 
 [dependencies]
 orca-core = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.11-rc.3" }
+orca-agent = { path = "../orca-agent", version = "0.2.11-rc.4" }
 orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }

--- a/crates/orca-proxy/src/error_page.html
+++ b/crates/orca-proxy/src/error_page.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{STATUS}} · {{TITLE}} · Orca</title>
+<style>
+  :root {
+    --bg: #0f172a; --fg: #e2e8f0; --muted: #94a3b8;
+    --accent: #06b6d4; --accent2: #0891b2;
+    --card: #111c33; --border: #1e293b;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; margin: 0; }
+  body {
+    background: radial-gradient(1200px 600px at 50% -10%, #14233f 0%, var(--bg) 55%);
+    color: var(--fg);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    display: flex; align-items: center; justify-content: center;
+    min-height: 100vh; padding: 2rem;
+  }
+  .card { max-width: 560px; width: 100%; text-align: center; }
+  .logo { width: 88px; height: 88px; margin: 0 auto 1.5rem; display: block; }
+  .status { color: var(--accent); font-weight: 600; letter-spacing: .08em; text-transform: uppercase; font-size: .78rem; }
+  h1 { font-size: 1.6rem; margin: .4rem 0 .6rem; font-weight: 650; }
+  p { color: var(--muted); line-height: 1.6; margin: 0 0 1.25rem; }
+  .host {
+    display: inline-block; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    background: var(--card); border: 1px solid var(--border); color: var(--fg);
+    padding: .4rem .75rem; border-radius: 8px; font-size: .9rem; margin-bottom: 1.75rem; word-break: break-all;
+  }
+  .links { display: flex; gap: .65rem; justify-content: center; flex-wrap: wrap; }
+  a.btn {
+    text-decoration: none; color: var(--fg); background: var(--card);
+    border: 1px solid var(--border); padding: .55rem 1rem; border-radius: 10px;
+    font-size: .9rem; transition: border-color .15s ease, color .15s ease;
+  }
+  a.btn:hover { border-color: var(--accent); color: var(--accent); }
+  a.btn.primary { background: linear-gradient(135deg, var(--accent), var(--accent2)); color: #06121a; border: none; font-weight: 600; }
+  footer { margin-top: 2.25rem; color: var(--muted); font-size: .8rem; }
+  footer a { color: var(--accent); text-decoration: none; }
+</style>
+</head>
+<body>
+  <main class="card">
+    <svg class="logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Orca">
+      <defs>
+        <linearGradient id="body" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stop-color="#06B6D4"/>
+          <stop offset="100%" stop-color="#0891B2"/>
+        </linearGradient>
+      </defs>
+      <rect width="512" height="512" rx="80" fill="#0F172A"/>
+      <path d="M 130 310 C 135 230, 185 170, 260 155 C 310 145, 355 155, 385 180 C 415 210, 425 260, 415 305 C 405 340, 375 360, 340 368 L 280 372 C 230 374, 180 365, 155 345 C 138 332, 130 320, 130 310Z" fill="url(#body)"/>
+      <path d="M 275 155 C 268 110, 290 65, 310 52 C 305 90, 308 125, 318 155Z" fill="url(#body)"/>
+      <path d="M 130 310 C 115 298, 88 270, 78 252 C 92 268, 108 280, 120 286 C 106 298, 94 312, 80 328 C 100 326, 118 318, 130 310Z" fill="url(#body)"/>
+      <ellipse cx="365" cy="215" rx="18" ry="13" fill="#0F172A"/>
+      <ellipse cx="367" cy="213" rx="7" ry="5" fill="#E2E8F0"/>
+      <path d="M 240 368 C 265 348, 310 345, 335 365 C 305 362, 265 362, 240 368Z" fill="#E2E8F0" opacity="0.35"/>
+    </svg>
+    <div class="status">{{STATUS}} · {{TITLE}}</div>
+    <h1>{{TITLE}}</h1>
+    <p>{{MESSAGE}}</p>
+    <div class="host">{{HOST}}</div>
+    <div class="links">
+      <a class="btn primary" href="{{DOCS}}">Documentation</a>
+      <a class="btn" href="{{REPO}}">GitHub</a>
+      <a class="btn" href="{{DOCS}}/guide/getting-started">Getting started</a>
+    </div>
+    <footer>Served by <a href="{{REPO}}">Orca</a> — container + Wasm orchestrator</footer>
+  </main>
+</body>
+</html>

--- a/crates/orca-proxy/src/error_page.rs
+++ b/crates/orca-proxy/src/error_page.rs
@@ -1,0 +1,110 @@
+//! Branded static HTML page served when the proxy can't route a request:
+//! an unknown host (404) or a known host with no healthy backend (503).
+//! Replaces the bare plain-text body with a docs-themed page that links to
+//! the repo and docs. The page is fully self-contained (inline CSS + logo,
+//! no external assets) so it renders even on a degraded / offline box.
+
+use hyper::{Response, StatusCode, header};
+
+use crate::body::{ProxyBody, full_body};
+
+const REPO_URL: &str = "https://github.com/mighty840/orca";
+const DOCS_URL: &str = "https://mighty840.github.io/orca";
+const TEMPLATE: &str = include_str!("error_page.html");
+
+/// Render the branded error page for a no-route / no-backend response.
+///
+/// `host` is the (untrusted) request `Host` header and is HTML-escaped before
+/// being interpolated, so a hostile `Host` can't inject markup.
+pub(crate) fn branded_error(status: StatusCode, host: &str) -> Response<ProxyBody> {
+    let (title, message) = match status {
+        StatusCode::SERVICE_UNAVAILABLE => (
+            "Service unavailable",
+            "This host is served by Orca, but none of its backends are reachable right now.",
+        ),
+        _ => (
+            "Not found",
+            "No service is configured for this host on this Orca cluster.",
+        ),
+    };
+
+    // Substitute trusted tokens first; HOST (escaped, attacker-controllable)
+    // last so its contents can never trigger a further replacement.
+    let html = TEMPLATE
+        .replace("{{STATUS}}", status.as_str())
+        .replace("{{TITLE}}", title)
+        .replace("{{MESSAGE}}", message)
+        .replace("{{DOCS}}", DOCS_URL)
+        .replace("{{REPO}}", REPO_URL)
+        .replace("{{HOST}}", &escape(host));
+
+    let mut resp = Response::new(full_body(hyper::body::Bytes::from(html)));
+    *resp.status_mut() = status;
+    resp.headers_mut().insert(
+        header::CONTENT_TYPE,
+        header::HeaderValue::from_static("text/html; charset=utf-8"),
+    );
+    resp
+}
+
+/// Minimal HTML-escape for text interpolated into the page body / attributes.
+fn escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#x27;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::BodyExt;
+
+    async fn body_string(resp: Response<ProxyBody>) -> String {
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn not_found_page_reflects_host_and_links() {
+        let resp = branded_error(StatusCode::NOT_FOUND, "dashboard.swarmhaul.defited.com");
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/html; charset=utf-8"
+        );
+        let html = body_string(resp).await;
+        assert!(html.contains("dashboard.swarmhaul.defited.com"));
+        assert!(html.contains("Not found"));
+        assert!(html.contains(REPO_URL));
+        assert!(html.contains(DOCS_URL));
+        // No unsubstituted tokens left behind.
+        assert!(!html.contains("{{"));
+    }
+
+    #[tokio::test]
+    async fn service_unavailable_uses_503_copy() {
+        let resp = branded_error(StatusCode::SERVICE_UNAVAILABLE, "api.example.com");
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let html = body_string(resp).await;
+        assert!(html.contains("Service unavailable"));
+        assert!(html.contains("503"));
+    }
+
+    #[tokio::test]
+    async fn host_is_html_escaped() {
+        // A hostile Host header must not break out into markup.
+        let resp = branded_error(StatusCode::NOT_FOUND, "x\"><script>alert(1)</script>");
+        let html = body_string(resp).await;
+        assert!(!html.contains("<script>alert(1)</script>"));
+        assert!(html.contains("&lt;script&gt;"));
+    }
+}

--- a/crates/orca-proxy/src/handler.rs
+++ b/crates/orca-proxy/src/handler.rs
@@ -193,18 +193,18 @@ pub(crate) async fn handle_request(
     };
     let matched: Vec<RouteTarget> = match lookup {
         None => {
-            return Ok(error_response(
+            return Ok(crate::error_page::branded_error(
                 StatusCode::SERVICE_UNAVAILABLE,
-                &format!("no backends for host: {host}"),
+                &host,
             ));
         }
         Some(sel) if sel.is_empty() => {
             if let Some(target) = fallback_target(fallback) {
                 vec![target]
             } else {
-                return Ok(error_response(
+                return Ok(crate::error_page::branded_error(
                     StatusCode::NOT_FOUND,
-                    &format!("no service for host: {host}"),
+                    &host,
                 ));
             }
         }

--- a/crates/orca-proxy/src/lib.rs
+++ b/crates/orca-proxy/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod acme;
 mod body;
+mod error_page;
 mod forward;
 mod handler;
 pub mod rate_limit;


### PR DESCRIPTION
Closes #111.

When the proxy can't route a request it returned a bare plain-text body (`no service for host: <host>`). It now serves a **self-contained, docs-themed HTML page** — inline CSS + inline orca logo, **no external assets**, so it renders even when the box is degraded or has no outbound network.

- **404** — unknown host (`handler.rs` no-service case)
- **503** — host known but no healthy backend (no-backends case)
- The requested host is **HTML-escaped** (it's attacker-controllable via the `Host` header) and reflected into the page.
- Existing `[fallback].http` forward-to-a-target behavior is **unchanged** — the page only shows when no fallback target is configured.

Theme matches the logo/docs palette (slate `#0F172A`, cyan `#06B6D4`→`#0891B2`). Page lives in `crates/orca-proxy/src/error_page.{rs,html}` (template via `include_str!`, kept separate so `handler.rs` stays under the file-size gate).

Bumps the workspace to **v0.2.11-rc.4**.

### Tests
3 unit tests: host reflected + links present + no leftover tokens; 503 copy; host HTML-escaped (XSS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)