### PR TITLE
fix(reconciler): stop remote-service deploy churn on missed ACK + v0.2.11-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11-rc.5] - 2026-06-22
+
+### Fixed
+
+- **Declarative reconciler no longer churns remote (placement-pinned) services whose deploy ACK doesn't land.** In the remote-deploy path, `svc.config` was recorded only *after* `queue_remote_deploy` succeeded — but that call waits for the agent's receipt/completion ACK and fails (the `?` returns early) if the ACK doesn't arrive cleanly, which happens with a laggy agent even though it actually created the container. With the config never recorded, the declarative reconciler saw the service as "new/changed" on every pass and re-dispatched the identical deploy ~every interval, recreating the container in a loop (and breaking its logs/CPU/RAM in `orca status`/TUI, since freshly-recreated containers report no stats). Fixed by recording the declared config + placeholder instance **before** dispatching the deploy, so a missed ACK can't leave it stale; genuine deploy failures still surface via `last_failure`, and agent-reconnect still triggers a real reconcile. Regression tests cover a non-acking remote agent (exactly one Deploy dispatched across two passes) and idempotency of a mounts/cmd/env-heavy service. (Surfaced after enabling `[reconcile]` in production.)
+
 ## [0.2.11-rc.4] - 2026-06-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mallorca"
-version = "0.2.11-rc.4"
+version = "0.2.11-rc.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2554,7 +2554,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orca-agent"
-version = "0.2.11-rc.4"
+version = "0.2.11-rc.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "orca-ai"
-version = "0.2.11-rc.4"
+version = "0.2.11-rc.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "orca-control"
-version = "0.2.11-rc.4"
+version = "0.2.11-rc.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "orca-core"
-version = "0.2.11-rc.4"
+version = "0.2.11-rc.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "orca-proxy"
-version = "0.2.11-rc.4"
+version = "0.2.11-rc.5"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "orca-tui"
-version = "0.2.11-rc.4"
+version = "0.2.11-rc.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "orca-web"
-version = "0.2.11-rc.4"
+version = "0.2.11-rc.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/wasm-hello"]
 
 [workspace.package]
-version = "0.2.11-rc.4"
+version = "0.2.11-rc.5"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mighty840/orca"
@@ -24,9 +24,9 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Shared across crates
-orca-core = { path = "crates/orca-core", version = "0.2.11-rc.4" }
-orca-ai = { path = "crates/orca-ai", version = "0.2.11-rc.4" }
-orca-proxy = { path = "crates/orca-proxy", version = "0.2.11-rc.4" }
+orca-core = { path = "crates/orca-core", version = "0.2.11-rc.5" }
+orca-ai = { path = "crates/orca-ai", version = "0.2.11-rc.5" }
+orca-proxy = { path = "crates/orca-proxy", version = "0.2.11-rc.5" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/orca-cli/Cargo.toml
+++ b/crates/orca-cli/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/main.rs"
 [dependencies]
 orca-core = { workspace = true }
 orca-ai = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.11-rc.4" }
-orca-control = { path = "../orca-control", version = "0.2.11-rc.4" }
+orca-agent = { path = "../orca-agent", version = "0.2.11-rc.5" }
+orca-control = { path = "../orca-control", version = "0.2.11-rc.5" }
 orca-proxy = { workspace = true }
-orca-tui = { path = "../orca-tui", version = "0.2.11-rc.4" }
+orca-tui = { path = "../orca-tui", version = "0.2.11-rc.5" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 
 [dependencies]
 orca-core = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.11-rc.4" }
+orca-agent = { path = "../orca-agent", version = "0.2.11-rc.5" }
 orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }

--- a/crates/orca-control/src/reconciler.rs
+++ b/crates/orca-control/src/reconciler.rs
@@ -102,41 +102,43 @@ pub(crate) async fn reconcile_service(
 
     // Check if placement targets a specific remote node
     if let Some(target_node_id) = find_target_node(state, config).await {
-        queue_remote_deploy(state, target_node_id, &spec).await?;
-        // Record the service + a placeholder instance on the master so
-        // `orca status` shows remote-scheduled workloads alongside local
-        // ones. Heartbeats from the target node will update the status
-        // field; until the first update arrives we optimistically mark
-        // the instance Running so the TUI doesn't paint it red during
-        // the first few seconds after a deploy.
-        let mut services = state.services.write().await;
-        let svc_state = services
-            .entry(config.name.clone())
-            .or_insert_with(|| ServiceState::from_config(config.clone()));
-        svc_state.config = config.clone();
-        let desired = match &config.replicas {
-            Replicas::Fixed(n) => *n,
-            Replicas::Auto => 1,
-        };
-        svc_state.desired_replicas = desired;
-        // If the instance list doesn't already have a placeholder for this
-        // remote node, add one. Placeholder handles have no runtime_id
-        // because the master doesn't own the container.
-        if svc_state.instances.is_empty() {
-            svc_state.instances.push(crate::state::InstanceState {
-                handle: orca_core::runtime::WorkloadHandle {
-                    runtime_id: format!("remote-{target_node_id}"),
-                    name: format!("orca-{}", config.name),
-                    metadata: Default::default(),
-                },
-                status: WorkloadStatus::Running,
-                host_port: None,
-                container_address: None,
-                health: orca_core::types::HealthState::NoCheck,
-                started_at: std::time::Instant::now(),
-                is_canary: false,
-            });
+        // Record the declared spec + a placeholder instance on the master
+        // BEFORE dispatching the deploy. `orca status` then shows the
+        // remote-scheduled workload (placeholder optimistically Running so the
+        // TUI doesn't paint it red), and — crucially — recording the config
+        // here rather than after `queue_remote_deploy` means a deploy whose
+        // ack/completion doesn't land cleanly (a flaky agent) can't leave
+        // `svc.config` stale. Previously the config update sat after the
+        // fallible `?`, so a missed ack made the declarative reconciler see a
+        // spec "mismatch" every cycle and redeploy the identical spec forever,
+        // churning the container (and breaking its logs/stats).
+        {
+            let mut services = state.services.write().await;
+            let svc_state = services
+                .entry(config.name.clone())
+                .or_insert_with(|| ServiceState::from_config(config.clone()));
+            svc_state.config = config.clone();
+            svc_state.desired_replicas = desired;
+            // If the instance list doesn't already have a placeholder for this
+            // remote node, add one. Placeholder handles have no runtime_id
+            // because the master doesn't own the container.
+            if svc_state.instances.is_empty() {
+                svc_state.instances.push(crate::state::InstanceState {
+                    handle: orca_core::runtime::WorkloadHandle {
+                        runtime_id: format!("remote-{target_node_id}"),
+                        name: format!("orca-{}", config.name),
+                        metadata: Default::default(),
+                    },
+                    status: WorkloadStatus::Running,
+                    host_port: None,
+                    container_address: None,
+                    health: orca_core::types::HealthState::NoCheck,
+                    started_at: std::time::Instant::now(),
+                    is_canary: false,
+                });
+            }
         }
+        queue_remote_deploy(state, target_node_id, &spec).await?;
         info!(
             "Queued deploy of {} to remote node {}",
             config.name, target_node_id

--- a/crates/orca-control/tests/declarative_test.rs
+++ b/crates/orca-control/tests/declarative_test.rs
@@ -52,6 +52,140 @@ fn write_service(dir: &std::path::Path, project: &str, body: &str) {
     std::fs::write(sub.join("service.toml"), body).unwrap();
 }
 
+/// Reproduces the rc.4 churn: an erp-frontend-shaped service (mounts, cmd,
+/// aliases, network, env, domain) must be left ALONE on the second reconcile
+/// pass — i.e. its container is not replaced. We detect a needless redeploy by
+/// the instance's runtime_id changing between passes.
+#[tokio::test]
+async fn erp_like_service_is_idempotent_across_reconciles() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_service(
+        tmp.path(),
+        "erp",
+        r#"
+        [[service]]
+        name = "erp-frontend"
+        image = "ghcr.io/x/erpnext:v15"
+        port = 8080
+        domain = "erp.example.com"
+        network = "erp-net"
+        aliases = ["erp-frontend"]
+        cmd = ["nginx-entrypoint.sh"]
+        mounts = ["erp-data:/home/frappe/sites/erp.example.com"]
+        replicas = 1
+        [service.env]
+        BACKEND = "erp-backend:8000"
+        SOCKETIO = "erp-websocket:9000"
+        "#,
+    );
+
+    let state = state();
+    let dir = tmp.path().to_str().unwrap();
+
+    apply_config_dir(&state, dir).await;
+    let first_id = {
+        let services = state.services.read().await;
+        let svc = services.get("erp-frontend").expect("deployed");
+        assert_eq!(svc.instances.len(), 1);
+        svc.instances[0].handle.runtime_id.clone()
+    };
+
+    // Second pass with the IDENTICAL config must not redeploy → same container.
+    apply_config_dir(&state, dir).await;
+    {
+        let services = state.services.read().await;
+        let svc = services.get("erp-frontend").unwrap();
+        assert_eq!(svc.instances.len(), 1, "must not duplicate");
+        assert_eq!(
+            svc.instances[0].handle.runtime_id, first_id,
+            "identical config must NOT replace the container (churn bug)"
+        );
+    }
+}
+
+/// Regression for the rc.4 remote container-churn: a placement-pinned service
+/// whose agent never acks the deploy must STILL have its declared config
+/// recorded, so the next reconcile pass sees no spec change and does NOT
+/// re-dispatch the deploy. Before the fix, `svc.config` was set only after a
+/// successful `queue_remote_deploy`, so a missed ack left the service
+/// unrecorded and every cycle re-deployed it — churning the container.
+#[tokio::test]
+async fn remote_deploy_without_ack_is_not_redeployed_every_cycle() {
+    use orca_control::state::RegisteredNode;
+    use orca_core::ws_types::MasterMessage;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tempfile::tempdir().unwrap();
+    write_service(
+        tmp.path(),
+        "remote",
+        r#"
+        [[service]]
+        name = "remote-web"
+        image = "nginx:latest"
+        port = 8080
+        replicas = 1
+        [service.placement]
+        node = "node-7"
+        "#,
+    );
+
+    // Fast ack timeout so the no-ack deploy errors quickly; real store for the
+    // stopped-set the reconciler reads.
+    let mut cfg = ClusterConfig::default();
+    cfg.deploy.ack_timeout_secs = 1;
+    let store = ClusterStore::open(&db.path().join("c.db")).unwrap();
+    let state = Arc::new(
+        AppState::new(
+            cfg,
+            Arc::new(MockRuntime::with_host_port(9000)),
+            None,
+            Arc::new(RwLock::new(HashMap::new())),
+            Arc::new(RwLock::new(Vec::new())),
+        )
+        .with_store(Arc::new(store)),
+    );
+
+    // Node "node-7" + an agent that is connected but never acks (rx held open).
+    state.registered_nodes.write().await.insert(
+        7,
+        RegisteredNode {
+            node_id: 7,
+            address: "node-7:6881".into(),
+            labels: HashMap::new(),
+            last_heartbeat: chrono::Utc::now(),
+            drain: false,
+            cpu_percent: 0.0,
+            memory_bytes: 0,
+            memory_total: 0,
+            disk_used: 0,
+            disk_total: 0,
+            net_rx: 0,
+            net_tx: 0,
+        },
+    );
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<MasterMessage>(16);
+    state.ws_agents.write().await.insert(7, tx);
+
+    let dir = tmp.path().to_str().unwrap();
+    // Two reconcile passes — the agent never acks, so each deploy attempt errors,
+    // but the config recorded on the first pass must stop the second from
+    // re-dispatching.
+    apply_config_dir(&state, dir).await;
+    apply_config_dir(&state, dir).await;
+
+    let mut deploys = 0;
+    while let Ok(msg) = rx.try_recv() {
+        if matches!(msg, MasterMessage::Deploy { .. }) {
+            deploys += 1;
+        }
+    }
+    assert_eq!(
+        deploys, 1,
+        "an unchanged remote spec must be dispatched once, not re-deployed every reconcile cycle"
+    );
+}
+
 #[tokio::test]
 async fn applies_new_services_from_dir_and_is_idempotent() {
     let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Problem

After enabling `[reconcile]` in production, placement-pinned services on a slightly-laggy agent (the 16GB node) were **recreated every ~60s**. Symptoms: `orca logs` timed out, CPU/RAM showed blank in the TUI, and the TUI felt janky for that node.

## Root cause

In `reconciler.rs` the remote path recorded `svc.config` **after** `queue_remote_deploy`:

```rust
queue_remote_deploy(...).await?;   // waits for the agent ACK; '?' bails on failure
svc_state.config = config.clone(); // only runs on success
```

`queue_remote_deploy` waits for the agent's receipt/completion ACK. When that ACK doesn't land cleanly (laggy agent) the `?` returns early — but the agent had *already* created the container. With `svc.config` never recorded, the declarative reconciler saw the service as "new/changed" every pass and re-dispatched the identical deploy forever. Blank CPU/RAM is downstream: the heartbeat only caches stats when `>0`, and freshly-recreated containers report 0.

## Fix

Record the declared config + placeholder instance **before** dispatching the deploy, so a missed ACK can't leave `svc.config` stale. Genuine deploy failures still surface via `last_failure`, and agent-reconnect still triggers a real reconcile — the identical spec just isn't re-dispatched every cycle.

## Tests

- `remote_deploy_without_ack_is_not_redeployed_every_cycle` — two reconcile passes against a connected-but-non-acking agent assert exactly **one** Deploy is dispatched (churn would be two).
- `erp_like_service_is_idempotent_across_reconciles` — a mounts/cmd/aliases/env-heavy service isn't replaced on the second pass.

Bumps the workspace to **v0.2.11-rc.5**.

> Re-enable `[reconcile]` in `orca-infra` once the master is on rc.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)