### PR TITLE
feat(proxy): baseline security headers (default-on, app-override) + v0.2.11-rc.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.11-rc.5] - 2026-06-22
+## [0.2.11-rc.6] - 2026-06-23
+
+### Added
+
+- **Proxy injects baseline security response headers (on by default, apps override).** The proxy now adds a safe set of security headers to every response it serves — `Strict-Transport-Security` (HTTPS only), `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` — so every service gets them centrally instead of each app reimplementing them. It's **add-if-absent**: a backend that already sets a header keeps its own value, so apps override the defaults just by sending the header (pass-through-plus-defaults, like Traefik/Caddy). `X-Frame-Options` and `Content-Security-Policy` are **off by default** — `X-Frame-Options` breaks iframe-embedded apps (Jitsi/Element/Collabora) and a blanket CSP breaks most apps, so CSP is left to individual apps. Configurable via a new `[security_headers]` block in `cluster.toml` (`enabled`, `hsts`, `content_type_options`, `referrer_policy`, `frame_options`, `csp`, and an `extra` map for arbitrary add-if-absent headers); `enabled = false` turns it off. The agent's node-local proxy applies the default-on set too. Applies uniformly to forwarded responses, the HTTP→HTTPS redirect, and the branded fallback page.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mallorca"
-version = "0.2.11-rc.5"
+version = "0.2.11-rc.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2554,7 +2554,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orca-agent"
-version = "0.2.11-rc.5"
+version = "0.2.11-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "orca-ai"
-version = "0.2.11-rc.5"
+version = "0.2.11-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "orca-control"
-version = "0.2.11-rc.5"
+version = "0.2.11-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "orca-core"
-version = "0.2.11-rc.5"
+version = "0.2.11-rc.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "orca-proxy"
-version = "0.2.11-rc.5"
+version = "0.2.11-rc.6"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "orca-tui"
-version = "0.2.11-rc.5"
+version = "0.2.11-rc.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "orca-web"
-version = "0.2.11-rc.5"
+version = "0.2.11-rc.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/wasm-hello"]
 
 [workspace.package]
-version = "0.2.11-rc.5"
+version = "0.2.11-rc.6"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mighty840/orca"
@@ -24,9 +24,9 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Shared across crates
-orca-core = { path = "crates/orca-core", version = "0.2.11-rc.5" }
-orca-ai = { path = "crates/orca-ai", version = "0.2.11-rc.5" }
-orca-proxy = { path = "crates/orca-proxy", version = "0.2.11-rc.5" }
+orca-core = { path = "crates/orca-core", version = "0.2.11-rc.6" }
+orca-ai = { path = "crates/orca-ai", version = "0.2.11-rc.6" }
+orca-proxy = { path = "crates/orca-proxy", version = "0.2.11-rc.6" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/orca-cli/Cargo.toml
+++ b/crates/orca-cli/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/main.rs"
 [dependencies]
 orca-core = { workspace = true }
 orca-ai = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.11-rc.5" }
-orca-control = { path = "../orca-control", version = "0.2.11-rc.5" }
+orca-agent = { path = "../orca-agent", version = "0.2.11-rc.6" }
+orca-control = { path = "../orca-control", version = "0.2.11-rc.6" }
 orca-proxy = { workspace = true }
-orca-tui = { path = "../orca-tui", version = "0.2.11-rc.5" }
+orca-tui = { path = "../orca-tui", version = "0.2.11-rc.6" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/orca-cli/src/handlers/join.rs
+++ b/crates/orca-cli/src/handlers/join.rs
@@ -226,6 +226,11 @@ async fn spawn_local_proxy(
         .map(|r| r.domain)
         .collect();
 
+    // The agent's local proxy serves node-local domains directly, so it also
+    // injects the security-header policy. The agent has no cluster.toml, so it
+    // uses the default-on safe set (matches the master's defaults).
+    orca_proxy::init_security_headers(None);
+
     let acme_for_proxy = acme.clone();
     let routes_for_proxy = route_table.clone();
     let triggers_for_proxy = triggers.clone();

--- a/crates/orca-cli/src/handlers/server.rs
+++ b/crates/orca-cli/src/handlers/server.rs
@@ -98,6 +98,11 @@ pub async fn handle_server(config: &str, proxy_port: u16) -> anyhow::Result<()> 
         domains.len()
     );
 
+    // Install the proxy's security-header policy before serving (default-on
+    // safe set — HSTS on HTTPS, nosniff, Referrer-Policy; backend-set headers
+    // always win). Configurable via `[security_headers]` in cluster.toml.
+    orca_proxy::init_security_headers(cluster_config.security_headers.clone());
+
     // Start proxy and get ACME components for hot cert provisioning
     let proxy_routes = route_table.clone();
     let proxy_triggers = wasm_triggers.clone();

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 
 [dependencies]
 orca-core = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.11-rc.5" }
+orca-agent = { path = "../orca-agent", version = "0.2.11-rc.6" }
 orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }

--- a/crates/orca-core/src/config/cluster.rs
+++ b/crates/orca-core/src/config/cluster.rs
@@ -39,6 +39,77 @@ pub struct ClusterConfig {
     /// continuously applies declared services (K8s-style), no manual deploy.
     #[serde(default)]
     pub reconcile: Option<ReconcileConfig>,
+    /// Baseline security response headers the proxy injects. Add-if-absent, so
+    /// a backend's own headers always win. Unset = on with a safe default set
+    /// (HSTS on HTTPS + nosniff + Referrer-Policy); see [`SecurityHeadersConfig`].
+    #[serde(default)]
+    pub security_headers: Option<SecurityHeadersConfig>,
+}
+
+/// Security response headers the proxy adds to every response it returns —
+/// **add-if-absent**, so a backend that sets its own `Content-Security-Policy`,
+/// `X-Frame-Options`, `Strict-Transport-Security`, etc. is never overridden
+/// (pass-through-plus-defaults, as Traefik/Caddy do). HSTS is applied only to
+/// HTTPS responses. The defaults are deliberately non-breaking; `X-Frame-Options`
+/// and CSP are off by default (they break iframe-embedded apps and most apps
+/// respectively) and are opt-in here or per app.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SecurityHeadersConfig {
+    /// Master switch. Default true.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// `Strict-Transport-Security` value (HTTPS responses only). Empty disables
+    /// HSTS. Default `max-age=31536000` (1y, no `includeSubDomains`/`preload`).
+    #[serde(default = "default_hsts")]
+    pub hsts: String,
+    /// `X-Content-Type-Options` value. Empty disables. Default `nosniff`.
+    #[serde(default = "default_nosniff")]
+    pub content_type_options: String,
+    /// `Referrer-Policy` value. Empty disables. Default
+    /// `strict-origin-when-cross-origin`.
+    #[serde(default = "default_referrer_policy")]
+    pub referrer_policy: String,
+    /// `X-Frame-Options` value. Empty (default) = off — leave it to apps, since
+    /// `SAMEORIGIN`/`DENY` break services meant to be embedded in an iframe.
+    #[serde(default)]
+    pub frame_options: String,
+    /// `Content-Security-Policy` value. Empty (default) = off — a blanket CSP
+    /// breaks most apps; set per app instead.
+    #[serde(default)]
+    pub csp: String,
+    /// Arbitrary extra response headers to add-if-absent (name → value).
+    #[serde(default)]
+    pub extra: std::collections::HashMap<String, String>,
+}
+
+impl Default for SecurityHeadersConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            hsts: default_hsts(),
+            content_type_options: default_nosniff(),
+            referrer_policy: default_referrer_policy(),
+            frame_options: String::new(),
+            csp: String::new(),
+            extra: std::collections::HashMap::new(),
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_hsts() -> String {
+    "max-age=31536000".to_string()
+}
+
+fn default_nosniff() -> String {
+    "nosniff".to_string()
+}
+
+fn default_referrer_policy() -> String {
+    "strict-origin-when-cross-origin".to_string()
 }
 
 /// Declarative-reconciliation configuration. When `config_dir` is set, the

--- a/crates/orca-core/src/config/mod.rs
+++ b/crates/orca-core/src/config/mod.rs
@@ -17,6 +17,7 @@ pub use cluster::NetworkConfig;
 pub use cluster::{
     AlertChannelConfig, ApiToken, CleanupConfig, ClusterConfig, ClusterMeta, DeployConfig,
     FallbackConfig, NodeConfig, NodeGpuConfig, ObservabilityConfig, ReconcileConfig, Role,
+    SecurityHeadersConfig,
 };
 pub use service::{BuildConfig, ProbeConfig, ServiceConfig, ServicesConfig};
 

--- a/crates/orca-proxy/src/lib.rs
+++ b/crates/orca-proxy/src/lib.rs
@@ -11,11 +11,15 @@ mod forward;
 mod handler;
 pub mod rate_limit;
 mod routing;
+mod security_headers;
 pub mod sni;
 pub mod tls;
 mod websocket;
 
-pub use orca_core::config::FallbackConfig;
+pub use orca_core::config::{FallbackConfig, SecurityHeadersConfig};
+/// Install the proxy's security-header policy (call once at startup). See
+/// [`security_headers`].
+pub use security_headers::init as init_security_headers;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -371,7 +375,7 @@ pub(crate) async fn serve_loop_with_fallback(
                     if let Some(resp) = handle_acme_challenge(&req, acme.as_deref()).await {
                         return Ok(resp);
                     }
-                    handle_request(
+                    let mut resp = handle_request(
                         req,
                         &routes,
                         &triggers,
@@ -383,7 +387,11 @@ pub(crate) async fn serve_loop_with_fallback(
                         peer,
                         fb.as_ref().as_ref(),
                     )
-                    .await
+                    .await?;
+                    // Inject baseline security headers (add-if-absent; HSTS only
+                    // over TLS). No-op unless a policy was installed at startup.
+                    security_headers::apply(&mut resp, is_tls);
+                    Ok::<_, hyper::Error>(resp)
                 }
             });
             if let Some(acceptor) = tls {

--- a/crates/orca-proxy/src/security_headers.rs
+++ b/crates/orca-proxy/src/security_headers.rs
@@ -1,0 +1,199 @@
+//! Baseline security response headers injected by the proxy.
+//!
+//! The proxy is the TLS terminator and the single ingress for every service, so
+//! it's the right place to add safe defaults (HSTS, `nosniff`, `Referrer-Policy`)
+//! once rather than per app. Headers are added **only if the backend didn't set
+//! them**, so an app's own `Content-Security-Policy` / `X-Frame-Options` /
+//! `Strict-Transport-Security` always wins — this is the pass-through-plus-
+//! defaults model used by Traefik/Caddy.
+//!
+//! The policy is process-global, installed once at startup from `cluster.toml`
+//! via [`init`]. If `init` is never called (e.g. library/test callers), [`apply`]
+//! is a no-op, so it never changes behavior for those paths.
+
+use std::sync::OnceLock;
+
+use hyper::Response;
+use hyper::header::{HeaderMap, HeaderName, HeaderValue};
+
+use crate::body::ProxyBody;
+use orca_core::config::SecurityHeadersConfig;
+
+static POLICY: OnceLock<Policy> = OnceLock::new();
+
+/// Resolved header set, precomputed once from config.
+struct Policy {
+    /// Added to every response (e.g. `nosniff`, `Referrer-Policy`).
+    always: Vec<(HeaderName, HeaderValue)>,
+    /// Added only to HTTPS responses — HSTS is invalid/ignored over plain HTTP.
+    https_only: Vec<(HeaderName, HeaderValue)>,
+}
+
+/// Install the proxy's security-header policy from config. Call once at startup
+/// before serving. `None` installs the safe default set (on); a disabled config
+/// installs an empty (no-op) policy.
+pub fn init(config: Option<SecurityHeadersConfig>) {
+    let _ = POLICY.set(build(config.unwrap_or_default()));
+}
+
+fn build(cfg: SecurityHeadersConfig) -> Policy {
+    if !cfg.enabled {
+        return Policy {
+            always: Vec::new(),
+            https_only: Vec::new(),
+        };
+    }
+    let mut always = Vec::new();
+    let mut https_only = Vec::new();
+
+    push(
+        &mut always,
+        "x-content-type-options",
+        &cfg.content_type_options,
+    );
+    push(&mut always, "referrer-policy", &cfg.referrer_policy);
+    // Off by default (empty) — opt-in, since these break embedded / most apps.
+    push(&mut always, "x-frame-options", &cfg.frame_options);
+    push(&mut always, "content-security-policy", &cfg.csp);
+    // HSTS only makes sense over TLS.
+    push(&mut https_only, "strict-transport-security", &cfg.hsts);
+
+    // Arbitrary operator-supplied extras (add-if-absent like the rest).
+    for (k, v) in &cfg.extra {
+        if let (Ok(name), Ok(val)) = (
+            HeaderName::try_from(k.as_str()),
+            HeaderValue::try_from(v.as_str()),
+        ) {
+            always.push((name, val));
+        }
+    }
+
+    Policy { always, https_only }
+}
+
+/// Push a `(name, value)` pair, skipping empty values (= "disable this header")
+/// and any value that isn't a valid header value.
+fn push(out: &mut Vec<(HeaderName, HeaderValue)>, name: &'static str, value: &str) {
+    if value.is_empty() {
+        return;
+    }
+    if let Ok(val) = HeaderValue::try_from(value) {
+        out.push((HeaderName::from_static(name), val));
+    }
+}
+
+/// Apply the configured security headers to a response — **add-if-absent**, so a
+/// header the backend already set is never overwritten. HSTS is added only when
+/// `is_tls`. No-op if [`init`] was never called.
+pub(crate) fn apply(resp: &mut Response<ProxyBody>, is_tls: bool) {
+    let Some(policy) = POLICY.get() else {
+        return;
+    };
+    let headers = resp.headers_mut();
+    add_if_absent(headers, &policy.always);
+    if is_tls {
+        add_if_absent(headers, &policy.https_only);
+    }
+}
+
+fn add_if_absent(map: &mut HeaderMap, entries: &[(HeaderName, HeaderValue)]) {
+    for (name, value) in entries {
+        if !map.contains_key(name) {
+            map.insert(name.clone(), value.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::body::full_body;
+
+    fn resp() -> Response<ProxyBody> {
+        Response::new(full_body(hyper::body::Bytes::new()))
+    }
+
+    fn policy_from(cfg: SecurityHeadersConfig) -> Policy {
+        build(cfg)
+    }
+
+    fn apply_with(policy: &Policy, resp: &mut Response<ProxyBody>, is_tls: bool) {
+        let headers = resp.headers_mut();
+        add_if_absent(headers, &policy.always);
+        if is_tls {
+            add_if_absent(headers, &policy.https_only);
+        }
+    }
+
+    #[test]
+    fn defaults_add_safe_set_on_https() {
+        let p = policy_from(SecurityHeadersConfig::default());
+        let mut r = resp();
+        apply_with(&p, &mut r, true);
+        let h = r.headers();
+        assert_eq!(h.get("x-content-type-options").unwrap(), "nosniff");
+        assert_eq!(
+            h.get("referrer-policy").unwrap(),
+            "strict-origin-when-cross-origin"
+        );
+        assert_eq!(
+            h.get("strict-transport-security").unwrap(),
+            "max-age=31536000"
+        );
+        // Off by default.
+        assert!(h.get("x-frame-options").is_none());
+        assert!(h.get("content-security-policy").is_none());
+    }
+
+    #[test]
+    fn hsts_only_on_tls() {
+        let p = policy_from(SecurityHeadersConfig::default());
+        let mut r = resp();
+        apply_with(&p, &mut r, false);
+        assert!(r.headers().get("strict-transport-security").is_none());
+        assert!(r.headers().get("x-content-type-options").is_some());
+    }
+
+    #[test]
+    fn never_clobbers_backend_header() {
+        let p = policy_from(SecurityHeadersConfig::default());
+        let mut r = resp();
+        r.headers_mut()
+            .insert("referrer-policy", HeaderValue::from_static("no-referrer"));
+        apply_with(&p, &mut r, true);
+        // Backend's value is preserved (pass-through), not overwritten.
+        assert_eq!(r.headers().get("referrer-policy").unwrap(), "no-referrer");
+    }
+
+    #[test]
+    fn disabled_adds_nothing() {
+        let p = policy_from(SecurityHeadersConfig {
+            enabled: false,
+            ..Default::default()
+        });
+        let mut r = resp();
+        apply_with(&p, &mut r, true);
+        assert!(r.headers().is_empty());
+    }
+
+    #[test]
+    fn opt_in_frame_options_and_extra() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "permissions-policy".to_string(),
+            "geolocation=()".to_string(),
+        );
+        let p = policy_from(SecurityHeadersConfig {
+            frame_options: "SAMEORIGIN".to_string(),
+            extra,
+            ..Default::default()
+        });
+        let mut r = resp();
+        apply_with(&p, &mut r, true);
+        assert_eq!(r.headers().get("x-frame-options").unwrap(), "SAMEORIGIN");
+        assert_eq!(
+            r.headers().get("permissions-policy").unwrap(),
+            "geolocation=()"
+        );
+    }
+}

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -65,6 +65,18 @@ adopt_interval_secs = 30       # how often to scan agents for orphans
 [reconcile]
 config_dir = "services"        # dir of <project>/service.toml files (or a single services.toml)
 interval_secs = 30             # how often to re-apply
+
+# Security response headers the proxy injects. On by default — omit this block
+# to get the safe set below. Headers are add-if-absent, so an app that sets its
+# own value always wins.
+[security_headers]
+enabled = true
+hsts = "max-age=31536000"                       # HTTPS only; "" to disable; add "; includeSubDomains; preload" if you want it
+content_type_options = "nosniff"
+referrer_policy = "strict-origin-when-cross-origin"
+frame_options = ""                              # off by default (SAMEORIGIN/DENY breaks iframe-embedded apps)
+csp = ""                                        # off by default — set Content-Security-Policy per app
+# extra = { "Permissions-Policy" = "geolocation=()" }   # arbitrary add-if-absent headers
 ```
 
 The `[deploy]` wait is two-phase — a short *receipt* ack distinguishes an
@@ -73,6 +85,16 @@ surfaces the agent's real pull error instead of a bare timeout. `[reconcile]`
 applies only new or changed services each pass; unchanged services are left
 untouched and removed ones are not auto-pruned. See
 [Self-healing](/reference/self-healing).
+
+`[security_headers]` makes the proxy add a baseline set of security headers
+(`Strict-Transport-Security` on HTTPS, `X-Content-Type-Options`,
+`Referrer-Policy`) to every response — once, centrally, instead of per app. It's
+**add-if-absent**: a backend that already sets a header keeps its own value
+(apps override the defaults just by sending the header). `X-Frame-Options` and
+`Content-Security-Policy` are off by default — `X-Frame-Options` breaks apps
+meant to be embedded in an iframe (Jitsi, Element, Collabora), and a blanket CSP
+breaks most apps, so set CSP per app. Set `enabled = false` to turn it off
+entirely. The agent's node-local proxy uses the default-on set.
 
 ## service.toml
 

--- a/docs/src/content/docs/guide/configuration.md
+++ b/docs/src/content/docs/guide/configuration.md
@@ -65,6 +65,18 @@ adopt_interval_secs = 30       # how often to scan agents for orphans
 [reconcile]
 config_dir = "services"        # dir of <project>/service.toml files (or a single services.toml)
 interval_secs = 30             # how often to re-apply
+
+# Security response headers the proxy injects. On by default — omit this block
+# to get the safe set below. Headers are add-if-absent, so an app that sets its
+# own value always wins.
+[security_headers]
+enabled = true
+hsts = "max-age=31536000"                       # HTTPS only; "" to disable; add "; includeSubDomains; preload" if you want it
+content_type_options = "nosniff"
+referrer_policy = "strict-origin-when-cross-origin"
+frame_options = ""                              # off by default (SAMEORIGIN/DENY breaks iframe-embedded apps)
+csp = ""                                        # off by default — set Content-Security-Policy per app
+# extra = { "Permissions-Policy" = "geolocation=()" }   # arbitrary add-if-absent headers
 ```
 
 The `[deploy]` wait is two-phase — a short *receipt* ack distinguishes an
@@ -73,6 +85,16 @@ surfaces the agent's real pull error instead of a bare timeout. `[reconcile]`
 applies only new or changed services each pass; unchanged services are left
 untouched and removed ones are not auto-pruned. See
 [Self-healing](/reference/self-healing).
+
+`[security_headers]` makes the proxy add a baseline set of security headers
+(`Strict-Transport-Security` on HTTPS, `X-Content-Type-Options`,
+`Referrer-Policy`) to every response — once, centrally, instead of per app. It's
+**add-if-absent**: a backend that already sets a header keeps its own value
+(apps override the defaults just by sending the header). `X-Frame-Options` and
+`Content-Security-Policy` are off by default — `X-Frame-Options` breaks apps
+meant to be embedded in an iframe (Jitsi, Element, Collabora), and a blanket CSP
+breaks most apps, so set CSP per app. Set `enabled = false` to turn it off
+entirely. The agent's node-local proxy uses the default-on set.
 
 ## service.toml
 


### PR DESCRIPTION
Adds proxy-injected security response headers — the "better solution" than plain pass-through (pass-through already worked; the gap was that apps which *don't* set their own got nothing).

## Behavior
- **Default on**, safe set: `Strict-Transport-Security` (HTTPS only), `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`.
- **Add-if-absent** — a backend that sets its own header keeps it, so **apps override** just by sending the header.
- **`X-Frame-Options` and CSP off by default** — `X-Frame-Options` breaks iframe-embedded apps (Jitsi/Element/Collabora); a blanket CSP breaks most apps, so **CSP is left to apps**.
- Applies to forwarded responses, the HTTP→HTTPS redirect, and the branded fallback page. HSTS only over TLS.

## Config (`cluster.toml`)
```toml
[security_headers]
enabled = true
hsts = "max-age=31536000"     # "" disables; add "; includeSubDomains; preload" if wanted
content_type_options = "nosniff"
referrer_policy = "strict-origin-when-cross-origin"
frame_options = ""            # opt-in
csp = ""                      # opt-in (per app)
# extra = { "Permissions-Policy" = "geolocation=()" }
```
Omit the block → defaults on. `enabled = false` → off.

## Implementation
Policy is installed once at startup (`orca_proxy::init_security_headers`, called from `server.rs` + `join.rs`) into a process-global `OnceLock`, and applied in the serve-loop chokepoint — so **no proxy entry-fn signatures change** and existing tests/callers are untouched (no init = no-op). New `crates/orca-proxy/src/security_headers.rs` (5 unit tests: default set, HSTS-TLS-only, never-clobber, disabled, opt-in+extra). Docs updated in both trees.

Bumps workspace to **v0.2.11-rc.6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)