### PR TITLE
ci: free runner disk before heavy builds (fix "No space left on device")

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Free disk space
+        run: |
+          # ubuntu-latest ships ~14GB free; orca's dep tree + all the
+          # integration-test artifacts can exhaust it ("No space left on
+          # device"). Drop preinstalled SDKs we don't use to reclaim ~20GB.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          sudo docker image prune --all --force 2>/dev/null || true
+          df -h /
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -46,6 +55,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          sudo docker image prune --all --force 2>/dev/null || true
+          df -h /
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-unknown-linux-gnu
@@ -72,6 +87,12 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          sudo docker image prune --all --force 2>/dev/null || true
+          df -h /
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install protoc

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -16,6 +16,14 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+      - name: Free disk space
+        run: |
+          # Reclaim ~20GB of preinstalled SDKs so the release build never hits
+          # "No space left on device" as the dep tree grows.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          sudo docker image prune --all --force 2>/dev/null || true
+          df -h /
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
## Problem

CI on `main` started failing intermittently with:
```
rustc-LLVM ERROR: IO failure on output stream: No space left on device
```
in the **Check, Lint, Test** job (`cargo test` builds every integration-test artifact). `ubuntu-latest` ships only ~14 GB free, and orca's dep tree (wasmtime/bollard/hyper) + test artifacts tips over it. It's intermittent — the same code passed on the PR branch and at rc.5 — so it's runner disk pressure, not a code issue. (The rc.6 *release* binary still published fine; that build is just `cargo build --release -p mallorca`, no test artifacts.)

## Fix

Add a **Free disk space** step to every `ubuntu-latest` job (`check`, `build-arm64`, `e2e`) and the release-binaries build: remove unused preinstalled SDKs (dotnet, android, ghc, CodeQL, boost) + prune docker images → reclaims ~20 GB. Prints `df -h /` for visibility.

No code changes; no version bump.