### PR TITLE
fix(proxy): don't force HTTP→HTTPS redirect when no TLS endpoint exists

### DIFF
--- a/crates/orca-proxy/src/handler.rs
+++ b/crates/orca-proxy/src/handler.rs
@@ -85,6 +85,7 @@ pub(crate) async fn handle_request(
     counter: &Arc<AtomicUsize>,
     client: &Arc<reqwest::Client>,
     is_tls: bool,
+    https_enabled: bool,
     rate_limiter: &RateLimiter,
     peer: SocketAddr,
     fallback: Option<&FallbackConfig>,
@@ -154,10 +155,12 @@ pub(crate) async fn handle_request(
         ));
     };
 
-    // HTTP -> HTTPS redirect: if not TLS and host has routes, redirect.
-    // Take the read in a tight scope so the lock releases before further
-    // awaits — see comment below.
-    if !is_tls {
+    // HTTP -> HTTPS redirect: if not TLS and host has routes, redirect —
+    // but only when a TLS endpoint actually exists (#123: with ACME
+    // unconfigured there is no HTTPS listener, so redirecting sends
+    // clients into a wall). Take the read in a tight scope so the lock
+    // releases before further awaits — see comment below.
+    if !is_tls && https_enabled {
         let known = {
             let routes = route_table.read().await;
             routes.contains_key(&host)

--- a/crates/orca-proxy/src/lib.rs
+++ b/crates/orca-proxy/src/lib.rs
@@ -335,6 +335,14 @@ pub(crate) async fn serve_loop_with_fallback(
             .build()
             .expect("failed to build HTTP client"),
     );
+    // A TLS endpoint exists if this listener terminates TLS itself, or if
+    // an ACME manager is present — the plain-HTTP listener of the ACME
+    // dual-listener setup carries one for HTTP-01 challenges, which is
+    // exactly the "HTTPS runs alongside on 443" signal. With neither, the
+    // HTTP→HTTPS redirect has nowhere to send clients and must not fire
+    // (#123: ACME unconfigured meant every routed host redirected into a
+    // closed port).
+    let https_enabled = tls_acceptor.is_some() || acme_manager.is_some();
     let acme = acme_manager.map(Arc::new);
     let is_tls = tls_acceptor.is_some();
     let rate_limiter = RateLimiter::new();
@@ -383,6 +391,7 @@ pub(crate) async fn serve_loop_with_fallback(
                         &counter,
                         &client,
                         is_tls,
+                        https_enabled,
                         &rl,
                         peer,
                         fb.as_ref().as_ref(),

--- a/crates/orca-proxy/tests/https_redirect_test.rs
+++ b/crates/orca-proxy/tests/https_redirect_test.rs
@@ -1,0 +1,155 @@
+//! Regression tests for #123: the HTTP→HTTPS redirect must only fire when a
+//! TLS endpoint actually exists. With ACME unconfigured the proxy runs a
+//! single plain-HTTP listener — redirecting a routed host to `https://` then
+//! sends clients to a closed port (and redirect-loops behind an external
+//! TLS-terminating proxy).
+//!
+//! Fast tests (no Docker, no network beyond loopback) — not `#[ignore]`d.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use hyper::StatusCode;
+use orca_proxy::acme::AcmeManager;
+use orca_proxy::{RouteTarget, run_proxy_with_fallback};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::RwLock;
+
+/// Reserve a loopback port that nothing listens on: bind, read, drop.
+/// Connections to it fail instantly with ECONNREFUSED, so forwarding
+/// attempts surface as a fast 502 instead of a timeout.
+async fn dead_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+/// Spawn the proxy (plain HTTP listener) with the given route table and
+/// optional ACME manager. Returns the bound port once it accepts TCP.
+async fn spawn_proxy(
+    route_table: Arc<RwLock<HashMap<String, Vec<RouteTarget>>>>,
+    acme: Option<AcmeManager>,
+) -> u16 {
+    let port = dead_port().await;
+    let triggers = Arc::new(RwLock::new(Vec::new()));
+    tokio::spawn(async move {
+        let _ = run_proxy_with_fallback(route_table, triggers, None, port, None, acme, None).await;
+    });
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    while tokio::time::Instant::now() < deadline {
+        if TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+            return port;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("orca proxy did not bind on port {port} within 3s");
+}
+
+fn routed_table(host: &str, target_port: u16) -> Arc<RwLock<HashMap<String, Vec<RouteTarget>>>> {
+    let mut routes = HashMap::new();
+    routes.insert(
+        host.to_string(),
+        vec![RouteTarget {
+            address: format!("127.0.0.1:{target_port}"),
+            service_name: "app".to_string(),
+            path_pattern: None,
+            weight: 100,
+            strip_prefix: None,
+        }],
+    );
+    Arc::new(RwLock::new(routes))
+}
+
+fn no_redirect_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .no_proxy()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap()
+}
+
+/// HTTP-only proxy (no TLS acceptor, no ACME): a routed host must be
+/// forwarded, never redirected to an HTTPS endpoint that doesn't exist.
+/// The route target is a dead port, so a forwarding attempt shows up as a
+/// fast 502 — any 3xx means the redirect fired.
+#[tokio::test]
+async fn http_only_proxy_never_redirects_routed_host() {
+    let table = routed_table("app.local", dead_port().await);
+    let proxy_port = spawn_proxy(table, None).await;
+
+    let resp = no_redirect_client()
+        .get(format!("http://127.0.0.1:{proxy_port}/dashboard"))
+        .header("Host", "app.local")
+        .send()
+        .await
+        .expect("request to proxy");
+
+    assert!(
+        !resp.status().is_redirection(),
+        "HTTP-only proxy must not redirect to HTTPS (#123), got {} with Location {:?}",
+        resp.status(),
+        resp.headers().get("location"),
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_GATEWAY,
+        "request should have been forwarded (and failed on the dead target)"
+    );
+}
+
+/// With an ACME manager present (the dual-listener setup's port-80 half),
+/// HTTPS does exist on 443 — the redirect must keep firing.
+#[tokio::test]
+async fn acme_http_listener_still_redirects_routed_host() {
+    let table = routed_table("app.local", dead_port().await);
+    let acme = AcmeManager::new(
+        "test@example.com",
+        std::env::temp_dir().join("orca-test-acme-cache"),
+    );
+    let proxy_port = spawn_proxy(table, Some(acme)).await;
+
+    let resp = no_redirect_client()
+        .get(format!("http://127.0.0.1:{proxy_port}/dashboard"))
+        .header("Host", "app.local")
+        .send()
+        .await
+        .expect("request to proxy");
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::MOVED_PERMANENTLY,
+        "with ACME running, HTTP requests for routed hosts must redirect"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("location")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default(),
+        "https://app.local/dashboard"
+    );
+}
+
+/// Unknown hosts never redirect regardless of TLS availability — they fall
+/// through to 404 (no fallback configured). Guards against widening the
+/// redirect condition beyond routed hosts.
+#[tokio::test]
+async fn unknown_host_is_never_redirected() {
+    let table = routed_table("app.local", dead_port().await);
+    let acme = AcmeManager::new(
+        "test@example.com",
+        std::env::temp_dir().join("orca-test-acme-cache"),
+    );
+    let proxy_port = spawn_proxy(table, Some(acme)).await;
+
+    let resp = no_redirect_client()
+        .get(format!("http://127.0.0.1:{proxy_port}/"))
+        .header("Host", "unknown.local")
+        .send()
+        .await
+        .expect("request to proxy");
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
## Summary

With ACME unconfigured (no `acme_email`), the proxy runs a single plain-HTTP listener, but `handle_request` still 301'd every routed host to `https://` — a closed port. The same redirect also loops forever when orca runs behind an external TLS-terminating proxy (NGINX/Caddy), since that proxy forwards plain HTTP back to orca.

The fix derives `https_enabled = tls_acceptor.is_some() || acme_manager.is_some()` inside `serve_loop_with_fallback` and gates the redirect on it. The plain-HTTP listener of the ACME dual-listener setup carries an `AcmeManager` for HTTP-01 challenges, which is exactly the "HTTPS runs alongside on 443" signal — so no public signatures change (the alternative patch in the issue threads a parameter through five signatures).

| Setup | `tls_acceptor` | `acme_manager` | Redirect |
|---|---|---|---|
| No ACME (bug case) | None | None | **no** (was: yes, into a wall) |
| ACME port-80 listener | None | Some | yes (unchanged) |
| TLS listener | Some | — | n/a (`is_tls` short-circuits) |

## Test plan

- New fast (non-ignored) integration tests in `crates/orca-proxy/tests/https_redirect_test.rs`:
  - HTTP-only proxy forwards a routed host instead of redirecting (502 from dead target, no 3xx)
  - ACME port-80 listener still 301s with the correct `Location`
  - unknown hosts still 404
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test -p orca-proxy` all green locally

Fixes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)