### PR TITLE
fix(control): exact placement-pin matching — no more substring split-brain

### DIFF
--- a/crates/orca-control/src/api/handlers/ops/backups.rs
+++ b/crates/orca-control/src/api/handlers/ops/backups.rs
@@ -44,7 +44,7 @@ async fn collect_master_status(state: &AppState) -> NodeBackupStatus {
     let last_result = state.master_last_backup_result.read().await.clone();
     NodeBackupStatus {
         node_id: None,
-        hostname: master_hostname(),
+        hostname: crate::placement::master_hostname(),
         role: NodeRole::Master,
         snapshots,
         last_result,
@@ -156,13 +156,6 @@ async fn collect_agent_statuses(state: &AppState) -> Vec<NodeBackupStatus> {
             }
         })
         .collect()
-}
-
-fn master_hostname() -> String {
-    std::fs::read_to_string("/etc/hostname")
-        .map(|s| s.trim().to_string())
-        .or_else(|_| std::env::var("HOSTNAME"))
-        .unwrap_or_else(|_| "master".to_string())
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/orca-control/src/api/handlers/ops/networks.rs
+++ b/crates/orca-control/src/api/handlers/ops/networks.rs
@@ -118,7 +118,7 @@ async fn collect_master(
     let domains = routes_by_node.get(&None).cloned().unwrap_or_default();
     NodeNetworks {
         node_id: None,
-        hostname: master_hostname(),
+        hostname: crate::placement::master_hostname(),
         role: NodeRole::Master,
         networks,
         domains,
@@ -369,13 +369,6 @@ fn service_name_from_container(container: &str) -> String {
 /// enumerator so master and agent always see the same shape.
 async fn enumerate_local_orca_networks() -> Vec<DockerNetwork> {
     orca_agent::ws_client::network_status::list_local_orca_networks().await
-}
-
-fn master_hostname() -> String {
-    std::fs::read_to_string("/etc/hostname")
-        .map(|s| s.trim().to_string())
-        .or_else(|_| std::env::var("HOSTNAME"))
-        .unwrap_or_else(|_| "master".to_string())
 }
 
 #[cfg(test)]

--- a/crates/orca-control/src/lib.rs
+++ b/crates/orca-control/src/lib.rs
@@ -15,6 +15,7 @@ pub mod health;
 pub(crate) mod instance;
 pub mod metrics;
 pub(crate) mod operations;
+pub(crate) mod placement;
 pub mod proto;
 pub mod raft;
 pub mod reconciler;

--- a/crates/orca-control/src/placement.rs
+++ b/crates/orca-control/src/placement.rs
@@ -1,0 +1,194 @@
+//! Exact placement-pin resolution, shared by deploy targeting
+//! (`reconciler::find_target_node`) and the per-node expected-services
+//! filter (`ws_handler::reconcile::send_reconcile`) so the two always agree
+//! on where a pinned service belongs.
+//!
+//! Regression context (#124): pins were matched with
+//! `node.address.contains(pin)`, so `node = "ubuntu"` matched both a node
+//! named `ubuntu` and one named `ubuntu-16gb-fsn1-1` — every pinned service
+//! deployed to both machines (split-brain, duplicate databases), with the
+//! winner of `orca deploy` decided by HashMap iteration order.
+
+use std::collections::HashMap;
+
+use crate::state::RegisteredNode;
+
+/// Outcome of resolving a placement pin against the registered nodes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PlacementResolution {
+    /// No registered node matches. Callers keep their existing behavior
+    /// (the master itself is not in `registered_nodes`, so master-pinned
+    /// services resolve here and deploy locally).
+    NoMatch,
+    /// Exactly one node matches.
+    Node(u64),
+    /// More than one node matches the pin (duplicate identity). Never
+    /// schedule on an arbitrary winner — callers must refuse loudly.
+    /// Node IDs are sorted for deterministic messages.
+    Ambiguous(Vec<u64>),
+}
+
+/// Exact-identity match of a placement pin against a single node — never a
+/// substring. A pin matches when it equals the node ID, the full
+/// `ip:port` address, the address's host portion, or the `hostname` label.
+fn node_matches_pin(node: &RegisteredNode, pin: &str) -> bool {
+    if pin == node.address || pin == node.node_id.to_string() {
+        return true;
+    }
+    // Addresses are `ip:port` (or `host:port`); pins usually name just the
+    // host — `node = "217.154.26.121"` must keep matching `…121:9443`.
+    if let Some((host, _port)) = node.address.rsplit_once(':')
+        && pin == host
+    {
+        return true;
+    }
+    node.labels.get("hostname").is_some_and(|h| h == pin)
+}
+
+/// Resolve a pin across all registered nodes. Drained nodes never match —
+/// same rule the deploy path has always applied.
+pub(crate) fn resolve_placement(
+    nodes: &HashMap<u64, RegisteredNode>,
+    pin: &str,
+) -> PlacementResolution {
+    let mut matches: Vec<u64> = nodes
+        .values()
+        .filter(|n| !n.drain && node_matches_pin(n, pin))
+        .map(|n| n.node_id)
+        .collect();
+    match matches.len() {
+        0 => PlacementResolution::NoMatch,
+        1 => PlacementResolution::Node(matches[0]),
+        _ => {
+            matches.sort_unstable();
+            PlacementResolution::Ambiguous(matches)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(id: u64, address: &str, hostname: Option<&str>) -> RegisteredNode {
+        let mut labels = HashMap::new();
+        if let Some(h) = hostname {
+            labels.insert("hostname".to_string(), h.to_string());
+        }
+        RegisteredNode {
+            node_id: id,
+            address: address.to_string(),
+            labels,
+            last_heartbeat: chrono::Utc::now(),
+            drain: false,
+            cpu_percent: 0.0,
+            memory_bytes: 0,
+            memory_total: 0,
+            disk_used: 0,
+            disk_total: 0,
+            net_rx: 0,
+            net_tx: 0,
+        }
+    }
+
+    fn registry(nodes: Vec<RegisteredNode>) -> HashMap<u64, RegisteredNode> {
+        nodes.into_iter().map(|n| (n.node_id, n)).collect()
+    }
+
+    /// The #124 incident: hostnames where one is a prefix of the other.
+    /// `"ubuntu"` must resolve to exactly the `ubuntu` node, never both.
+    #[test]
+    fn prefix_hostname_resolves_to_exactly_one_node() {
+        let nodes = registry(vec![
+            node(1, "217.154.26.121:9443", Some("ubuntu")),
+            node(2, "178.105.159.224:9443", Some("ubuntu-16gb-fsn1-1")),
+        ]);
+        assert_eq!(
+            resolve_placement(&nodes, "ubuntu"),
+            PlacementResolution::Node(1)
+        );
+        assert_eq!(
+            resolve_placement(&nodes, "ubuntu-16gb-fsn1-1"),
+            PlacementResolution::Node(2)
+        );
+    }
+
+    /// Same incident shape when the prefix collision is in the address
+    /// itself (agents can register with a hostname address).
+    #[test]
+    fn prefix_address_resolves_to_exactly_one_node() {
+        let nodes = registry(vec![
+            node(1, "ubuntu:9443", None),
+            node(2, "ubuntu-16gb-fsn1-1:9443", None),
+        ]);
+        assert_eq!(
+            resolve_placement(&nodes, "ubuntu"),
+            PlacementResolution::Node(1)
+        );
+    }
+
+    /// The prod workaround pins by bare IP while addresses carry a port —
+    /// host-portion matching must keep that working.
+    #[test]
+    fn ip_pin_matches_address_host_portion() {
+        let nodes = registry(vec![
+            node(1, "217.154.26.121:9443", Some("ubuntu")),
+            node(2, "178.105.159.224:9443", Some("ubuntu-16gb-fsn1-1")),
+        ]);
+        assert_eq!(
+            resolve_placement(&nodes, "217.154.26.121"),
+            PlacementResolution::Node(1)
+        );
+        assert_eq!(
+            resolve_placement(&nodes, "217.154.26.121:9443"),
+            PlacementResolution::Node(1)
+        );
+    }
+
+    #[test]
+    fn node_id_pin_matches() {
+        let nodes = registry(vec![node(42, "10.0.0.5:9443", None)]);
+        assert_eq!(
+            resolve_placement(&nodes, "42"),
+            PlacementResolution::Node(42)
+        );
+    }
+
+    /// Substrings that are not exact identities never match.
+    #[test]
+    fn substring_pin_no_longer_matches() {
+        let nodes = registry(vec![node(1, "217.154.26.121:9443", Some("ubuntu"))]);
+        assert_eq!(
+            resolve_placement(&nodes, "154.26"),
+            PlacementResolution::NoMatch
+        );
+        assert_eq!(
+            resolve_placement(&nodes, "ubun"),
+            PlacementResolution::NoMatch
+        );
+    }
+
+    /// Genuinely duplicated identity is reported, sorted, never picked from.
+    #[test]
+    fn duplicate_hostname_is_ambiguous() {
+        let nodes = registry(vec![
+            node(2, "10.0.0.2:9443", Some("worker")),
+            node(1, "10.0.0.1:9443", Some("worker")),
+        ]);
+        assert_eq!(
+            resolve_placement(&nodes, "worker"),
+            PlacementResolution::Ambiguous(vec![1, 2])
+        );
+    }
+
+    #[test]
+    fn drained_node_never_matches() {
+        let mut drained = node(1, "10.0.0.1:9443", Some("worker"));
+        drained.drain = true;
+        let nodes = registry(vec![drained, node(2, "10.0.0.2:9443", Some("worker"))]);
+        assert_eq!(
+            resolve_placement(&nodes, "worker"),
+            PlacementResolution::Node(2)
+        );
+    }
+}

--- a/crates/orca-control/src/placement.rs
+++ b/crates/orca-control/src/placement.rs
@@ -11,7 +11,9 @@
 
 use std::collections::HashMap;
 
-use crate::state::RegisteredNode;
+use orca_core::config::ServiceConfig;
+
+use crate::state::{AppState, RegisteredNode};
 
 /// Outcome of resolving a placement pin against the registered nodes.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -95,6 +97,93 @@ pub(crate) fn master_hostname() -> String {
 /// these pins resolve to a local deploy instead of an error.
 pub(crate) fn pin_matches_master(pin: &str) -> bool {
     pin == "master" || pin == "localhost" || pin == "127.0.0.1" || pin == master_hostname()
+}
+
+/// Find a registered node matching the service's placement constraint.
+///
+/// Returns `Ok(None)` when no placement node is set, or when the pin
+/// explicitly names the master (`master`, `localhost`, `127.0.0.1`, or the
+/// master's hostname — the master is not in `registered_nodes`), in which
+/// case the caller deploys locally. Errors when the pin matches more than
+/// one node (#124) — never schedule on an arbitrary winner — or matches
+/// nothing at all: a pin for a vanished/mistyped node must fail the deploy,
+/// not silently land the service on the master.
+pub(crate) async fn find_target_node(
+    state: &AppState,
+    config: &ServiceConfig,
+) -> anyhow::Result<Option<u64>> {
+    let Some(target) = config.placement.as_ref().and_then(|p| p.node.as_ref()) else {
+        return Ok(None);
+    };
+    let nodes = state.registered_nodes.read().await;
+    match resolve_placement(&nodes, target) {
+        PlacementResolution::Node(id) => Ok(Some(id)),
+        PlacementResolution::NoMatch => {
+            if pin_matches_master(target) {
+                return Ok(None);
+            }
+            let drained = drained_matches(&nodes, target);
+            if !drained.is_empty() {
+                tracing::error!(
+                    service = %config.name,
+                    pin = %target,
+                    drained_nodes = ?drained,
+                    "placement pin matches only drained node(s) — refusing to schedule"
+                );
+                anyhow::bail!(
+                    "placement pin {target:?} for service {:?} matches only drained node(s) \
+                     {drained:?} — refusing to deploy; undrain the node or repin the service",
+                    config.name,
+                )
+            }
+            let known: Vec<String> = nodes
+                .values()
+                .map(|n| {
+                    format!(
+                        "{} ({}{})",
+                        n.node_id,
+                        n.address,
+                        n.labels
+                            .get("hostname")
+                            .map(|h| format!(", hostname {h}"))
+                            .unwrap_or_default()
+                    )
+                })
+                .collect();
+            tracing::error!(
+                service = %config.name,
+                pin = %target,
+                known_nodes = ?known,
+                "placement pin matches no registered node and is not the master — refusing to schedule"
+            );
+            anyhow::bail!(
+                "placement pin {target:?} for service {:?} matches no registered node and is \
+                 not the master ({:?}) — refusing to deploy; registered nodes: [{}]",
+                config.name,
+                master_hostname(),
+                known.join(", "),
+            )
+        }
+        PlacementResolution::Ambiguous(ids) => {
+            let described: Vec<String> = ids
+                .iter()
+                .filter_map(|id| nodes.get(id))
+                .map(|n| format!("{} ({})", n.node_id, n.address))
+                .collect();
+            tracing::error!(
+                service = %config.name,
+                pin = %target,
+                nodes = ?described,
+                "placement pin matches multiple nodes — refusing to schedule (#124)"
+            );
+            anyhow::bail!(
+                "placement pin {target:?} for service {:?} matches multiple nodes: {} — \
+                 refusing to schedule; make the pin unique (node id, full address, or hostname)",
+                config.name,
+                described.join(", "),
+            )
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/orca-control/src/placement.rs
+++ b/crates/orca-control/src/placement.rs
@@ -16,9 +16,11 @@ use crate::state::RegisteredNode;
 /// Outcome of resolving a placement pin against the registered nodes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PlacementResolution {
-    /// No registered node matches. Callers keep their existing behavior
-    /// (the master itself is not in `registered_nodes`, so master-pinned
-    /// services resolve here and deploy locally).
+    /// No registered node matches. The master itself is not in
+    /// `registered_nodes`, so callers must then check
+    /// [`pin_matches_master`]: deploy locally when the pin names the
+    /// master, refuse when it names nothing — a pin for a vanished node
+    /// must never silently land the service on the master.
     NoMatch,
     /// Exactly one node matches.
     Node(u64),
@@ -64,6 +66,35 @@ pub(crate) fn resolve_placement(
             PlacementResolution::Ambiguous(matches)
         }
     }
+}
+
+/// Node IDs of *drained* nodes the pin would otherwise match. Used only for
+/// diagnostics: "your pin is fine, the node is draining" is a different
+/// operator action than "your pin names nothing".
+pub(crate) fn drained_matches(nodes: &HashMap<u64, RegisteredNode>, pin: &str) -> Vec<u64> {
+    let mut ids: Vec<u64> = nodes
+        .values()
+        .filter(|n| n.drain && node_matches_pin(n, pin))
+        .map(|n| n.node_id)
+        .collect();
+    ids.sort_unstable();
+    ids
+}
+
+/// The master's own hostname — same convention the ops dashboards use to
+/// label the master node.
+pub(crate) fn master_hostname() -> String {
+    std::fs::read_to_string("/etc/hostname")
+        .map(|s| s.trim().to_string())
+        .or_else(|_| std::env::var("HOSTNAME"))
+        .unwrap_or_else(|_| "master".to_string())
+}
+
+/// Whether a placement pin explicitly names the master itself. Checked only
+/// after no registered agent matched: the master runs workloads locally, so
+/// these pins resolve to a local deploy instead of an error.
+pub(crate) fn pin_matches_master(pin: &str) -> bool {
+    pin == "master" || pin == "localhost" || pin == "127.0.0.1" || pin == master_hostname()
 }
 
 #[cfg(test)]
@@ -179,6 +210,18 @@ mod tests {
             resolve_placement(&nodes, "worker"),
             PlacementResolution::Ambiguous(vec![1, 2])
         );
+    }
+
+    /// Master pins resolve locally; anything else that matches no node is
+    /// the caller's cue to refuse, not to fall through to a master deploy.
+    #[test]
+    fn master_pins_are_recognized() {
+        assert!(pin_matches_master("master"));
+        assert!(pin_matches_master("localhost"));
+        assert!(pin_matches_master("127.0.0.1"));
+        assert!(pin_matches_master(&master_hostname()));
+        assert!(!pin_matches_master("ubuntu"));
+        assert!(!pin_matches_master("10.0.0.99"));
     }
 
     #[test]

--- a/crates/orca-control/src/reconciler.rs
+++ b/crates/orca-control/src/reconciler.rs
@@ -101,7 +101,7 @@ pub(crate) async fn reconcile_service(
     }
 
     // Check if placement targets a specific remote node
-    if let Some(target_node_id) = find_target_node(state, config).await {
+    if let Some(target_node_id) = find_target_node(state, config).await? {
         // Record the declared spec + a placeholder instance on the master
         // BEFORE dispatching the deploy. `orca status` then shows the
         // remote-scheduled workload (placeholder optimistically Running so the
@@ -358,26 +358,39 @@ pub(crate) async fn reconcile_service(
 }
 
 /// Find a registered node matching the service's placement constraint.
-/// Returns `None` if no placement node is set or no matching node is found.
-async fn find_target_node(state: &AppState, config: &ServiceConfig) -> Option<u64> {
-    let placement = config.placement.as_ref()?;
-    let target = placement.node.as_ref()?;
+///
+/// Returns `Ok(None)` if no placement node is set or no node matches (the
+/// master itself is not in `registered_nodes`, so master-pinned services
+/// resolve to `None` and deploy locally). Errors when the pin matches more
+/// than one node (#124) — never schedule on an arbitrary winner.
+async fn find_target_node(state: &AppState, config: &ServiceConfig) -> anyhow::Result<Option<u64>> {
+    let Some(target) = config.placement.as_ref().and_then(|p| p.node.as_ref()) else {
+        return Ok(None);
+    };
     let nodes = state.registered_nodes.read().await;
-    for node in nodes.values() {
-        if node.drain {
-            continue;
-        }
-        if node.address.contains(target.as_str()) || target == &node.node_id.to_string() {
-            return Some(node.node_id);
-        }
-        // Check hostname label
-        if let Some(hostname) = node.labels.get("hostname")
-            && hostname == target
-        {
-            return Some(node.node_id);
+    match crate::placement::resolve_placement(&nodes, target) {
+        crate::placement::PlacementResolution::Node(id) => Ok(Some(id)),
+        crate::placement::PlacementResolution::NoMatch => Ok(None),
+        crate::placement::PlacementResolution::Ambiguous(ids) => {
+            let described: Vec<String> = ids
+                .iter()
+                .filter_map(|id| nodes.get(id))
+                .map(|n| format!("{} ({})", n.node_id, n.address))
+                .collect();
+            tracing::error!(
+                service = %config.name,
+                pin = %target,
+                nodes = ?described,
+                "placement pin matches multiple nodes — refusing to schedule (#124)"
+            );
+            anyhow::bail!(
+                "placement pin {target:?} for service {:?} matches multiple nodes: {} — \
+                 refusing to schedule; make the pin unique (node id, full address, or hostname)",
+                config.name,
+                described.join(", "),
+            )
         }
     }
-    None
 }
 
 /// Send a deploy command to a remote agent node and await the result.

--- a/crates/orca-control/src/reconciler.rs
+++ b/crates/orca-control/src/reconciler.rs
@@ -359,10 +359,13 @@ pub(crate) async fn reconcile_service(
 
 /// Find a registered node matching the service's placement constraint.
 ///
-/// Returns `Ok(None)` if no placement node is set or no node matches (the
-/// master itself is not in `registered_nodes`, so master-pinned services
-/// resolve to `None` and deploy locally). Errors when the pin matches more
-/// than one node (#124) — never schedule on an arbitrary winner.
+/// Returns `Ok(None)` when no placement node is set, or when the pin
+/// explicitly names the master (`master`, `localhost`, `127.0.0.1`, or the
+/// master's hostname — the master is not in `registered_nodes`), in which
+/// case the caller deploys locally. Errors when the pin matches more than
+/// one node (#124) — never schedule on an arbitrary winner — or matches
+/// nothing at all: a pin for a vanished/mistyped node must fail the deploy,
+/// not silently land the service on the master.
 async fn find_target_node(state: &AppState, config: &ServiceConfig) -> anyhow::Result<Option<u64>> {
     let Some(target) = config.placement.as_ref().and_then(|p| p.node.as_ref()) else {
         return Ok(None);
@@ -370,7 +373,52 @@ async fn find_target_node(state: &AppState, config: &ServiceConfig) -> anyhow::R
     let nodes = state.registered_nodes.read().await;
     match crate::placement::resolve_placement(&nodes, target) {
         crate::placement::PlacementResolution::Node(id) => Ok(Some(id)),
-        crate::placement::PlacementResolution::NoMatch => Ok(None),
+        crate::placement::PlacementResolution::NoMatch => {
+            if crate::placement::pin_matches_master(target) {
+                return Ok(None);
+            }
+            let drained = crate::placement::drained_matches(&nodes, target);
+            if !drained.is_empty() {
+                tracing::error!(
+                    service = %config.name,
+                    pin = %target,
+                    drained_nodes = ?drained,
+                    "placement pin matches only drained node(s) — refusing to schedule"
+                );
+                anyhow::bail!(
+                    "placement pin {target:?} for service {:?} matches only drained node(s) \
+                     {drained:?} — refusing to deploy; undrain the node or repin the service",
+                    config.name,
+                )
+            }
+            let known: Vec<String> = nodes
+                .values()
+                .map(|n| {
+                    format!(
+                        "{} ({}{})",
+                        n.node_id,
+                        n.address,
+                        n.labels
+                            .get("hostname")
+                            .map(|h| format!(", hostname {h}"))
+                            .unwrap_or_default()
+                    )
+                })
+                .collect();
+            tracing::error!(
+                service = %config.name,
+                pin = %target,
+                known_nodes = ?known,
+                "placement pin matches no registered node and is not the master — refusing to schedule"
+            );
+            anyhow::bail!(
+                "placement pin {target:?} for service {:?} matches no registered node and is \
+                 not the master ({:?}) — refusing to deploy; registered nodes: [{}]",
+                config.name,
+                crate::placement::master_hostname(),
+                known.join(", "),
+            )
+        }
         crate::placement::PlacementResolution::Ambiguous(ids) => {
             let described: Vec<String> = ids
                 .iter()

--- a/crates/orca-control/src/reconciler.rs
+++ b/crates/orca-control/src/reconciler.rs
@@ -9,6 +9,7 @@ use orca_core::runtime::Runtime;
 use orca_core::types::{DeployKind, Replicas, RuntimeKind, WorkloadSpec, WorkloadStatus};
 
 use crate::instance::create_and_start_instance;
+use crate::placement::find_target_node;
 use crate::routes::{service_config_to_spec, update_container_routes, update_wasm_triggers};
 use crate::state::{AppState, ServiceState};
 
@@ -355,90 +356,6 @@ pub(crate) async fn reconcile_service(
     }
 
     Ok(())
-}
-
-/// Find a registered node matching the service's placement constraint.
-///
-/// Returns `Ok(None)` when no placement node is set, or when the pin
-/// explicitly names the master (`master`, `localhost`, `127.0.0.1`, or the
-/// master's hostname — the master is not in `registered_nodes`), in which
-/// case the caller deploys locally. Errors when the pin matches more than
-/// one node (#124) — never schedule on an arbitrary winner — or matches
-/// nothing at all: a pin for a vanished/mistyped node must fail the deploy,
-/// not silently land the service on the master.
-async fn find_target_node(state: &AppState, config: &ServiceConfig) -> anyhow::Result<Option<u64>> {
-    let Some(target) = config.placement.as_ref().and_then(|p| p.node.as_ref()) else {
-        return Ok(None);
-    };
-    let nodes = state.registered_nodes.read().await;
-    match crate::placement::resolve_placement(&nodes, target) {
-        crate::placement::PlacementResolution::Node(id) => Ok(Some(id)),
-        crate::placement::PlacementResolution::NoMatch => {
-            if crate::placement::pin_matches_master(target) {
-                return Ok(None);
-            }
-            let drained = crate::placement::drained_matches(&nodes, target);
-            if !drained.is_empty() {
-                tracing::error!(
-                    service = %config.name,
-                    pin = %target,
-                    drained_nodes = ?drained,
-                    "placement pin matches only drained node(s) — refusing to schedule"
-                );
-                anyhow::bail!(
-                    "placement pin {target:?} for service {:?} matches only drained node(s) \
-                     {drained:?} — refusing to deploy; undrain the node or repin the service",
-                    config.name,
-                )
-            }
-            let known: Vec<String> = nodes
-                .values()
-                .map(|n| {
-                    format!(
-                        "{} ({}{})",
-                        n.node_id,
-                        n.address,
-                        n.labels
-                            .get("hostname")
-                            .map(|h| format!(", hostname {h}"))
-                            .unwrap_or_default()
-                    )
-                })
-                .collect();
-            tracing::error!(
-                service = %config.name,
-                pin = %target,
-                known_nodes = ?known,
-                "placement pin matches no registered node and is not the master — refusing to schedule"
-            );
-            anyhow::bail!(
-                "placement pin {target:?} for service {:?} matches no registered node and is \
-                 not the master ({:?}) — refusing to deploy; registered nodes: [{}]",
-                config.name,
-                crate::placement::master_hostname(),
-                known.join(", "),
-            )
-        }
-        crate::placement::PlacementResolution::Ambiguous(ids) => {
-            let described: Vec<String> = ids
-                .iter()
-                .filter_map(|id| nodes.get(id))
-                .map(|n| format!("{} ({})", n.node_id, n.address))
-                .collect();
-            tracing::error!(
-                service = %config.name,
-                pin = %target,
-                nodes = ?described,
-                "placement pin matches multiple nodes — refusing to schedule (#124)"
-            );
-            anyhow::bail!(
-                "placement pin {target:?} for service {:?} matches multiple nodes: {} — \
-                 refusing to schedule; make the pin unique (node id, full address, or hostname)",
-                config.name,
-                described.join(", "),
-            )
-        }
-    }
 }
 
 /// Send a deploy command to a remote agent node and await the result.

--- a/crates/orca-control/src/ws_handler/reconcile.rs
+++ b/crates/orca-control/src/ws_handler/reconcile.rs
@@ -54,14 +54,15 @@ pub(super) async fn send_reconcile(
     node_id: u64,
     tx: &mpsc::Sender<MasterMessage>,
 ) {
-    // Find the node's address/hostname for placement matching
-    let node_address = {
-        let nodes = state.registered_nodes.read().await;
-        nodes.get(&node_id).map(|n| n.address.clone())
-    };
-    let Some(node_addr) = node_address else {
+    // Snapshot the node registry once; placement pins are resolved with the
+    // same exact-match resolver the deploy path uses (#124), so what a node
+    // is told to run on reconcile always agrees with deploy targeting. A pin
+    // matching multiple nodes resolves Ambiguous — expected on no node —
+    // mirroring the deploy path's refusal to schedule.
+    let nodes = state.registered_nodes.read().await;
+    if !nodes.contains_key(&node_id) {
         return;
-    };
+    }
 
     // Collect all services whose placement targets this node
     let services = state.services.read().await;
@@ -73,17 +74,8 @@ pub(super) async fn send_reconcile(
                 .as_ref()
                 .and_then(|p| p.node.as_ref())
                 .is_some_and(|target| {
-                    node_addr.contains(target.as_str()) || target == &node_id.to_string() || {
-                        let nodes_guard =
-                            futures_util::FutureExt::now_or_never(state.registered_nodes.read());
-                        nodes_guard
-                            .and_then(|nodes| {
-                                nodes
-                                    .get(&node_id)
-                                    .and_then(|n| n.labels.get("hostname").map(|h| h == target))
-                            })
-                            .unwrap_or(false)
-                    }
+                    crate::placement::resolve_placement(&nodes, target)
+                        == crate::placement::PlacementResolution::Node(node_id)
                 })
         })
         .filter_map(|svc| {
@@ -92,6 +84,11 @@ pub(super) async fn send_reconcile(
                 .map(Box::new)
         })
         .collect();
+    // Release both read guards before the channel send below — holding a
+    // read across an await lets a queued writer (heartbeats write
+    // registered_nodes constantly) block every subsequent reader.
+    drop(services);
+    drop(nodes);
 
     if expected.is_empty() {
         return;

--- a/crates/orca-control/tests/cluster_test.rs
+++ b/crates/orca-control/tests/cluster_test.rs
@@ -121,11 +121,9 @@ async fn test_drained_node_skipped_by_scheduler() {
 
     let services: Vec<orca_core::config::ServiceConfig> =
         serde_json::from_value(deploy_body["services"].clone()).unwrap();
-    let (deployed, _errors) = orca_control::reconciler::reconcile(&state, &services).await;
+    let (deployed, errors) = orca_control::reconciler::reconcile(&state, &services).await;
 
-    // The service should be "deployed" (reconcile returns it) but
-    // since the target node is drained, nothing should be queued
-    // for remote dispatch.
+    // Nothing may be queued for the drained node.
     let pending = state.pending_commands.read().await;
     let cmds = pending.get(&10).cloned().unwrap_or_default();
     assert!(
@@ -133,11 +131,19 @@ async fn test_drained_node_skipped_by_scheduler() {
         "drained node should not receive deploy commands, got {cmds:?}"
     );
 
-    // The service name should still appear as deployed because
-    // reconcile_service falls through to local deploy when no
-    // remote target is found.
+    // A pin to a drained node refuses loudly (#124's refuse-don't-guess
+    // rule) — it must NOT fall through to a local deploy on the master,
+    // which is a mis-placement, not a fallback.
     assert!(
-        deployed.contains(&"drain-test-svc".to_string()),
-        "service should still be deployed locally"
+        !deployed.contains(&"drain-test-svc".to_string()),
+        "service pinned to a drained node must not deploy anywhere"
+    );
+    let err = errors
+        .iter()
+        .find(|e| e.contains("drain-test-svc"))
+        .expect("refusal must surface as a reconcile error");
+    assert!(
+        err.contains("drained"),
+        "error should tell the operator the node is drained, got: {err}"
     );
 }


### PR DESCRIPTION
## Summary

Fixes the split-brain scheduling bug from the 2026-07-16 breakpilot incident: `placement.node` was matched with `node.address.contains(pin)`, so `node = "ubuntu"` matched both `ubuntu` and `ubuntu-16gb-fsn1-1` — all 10 pinned services ran duplicated on both machines (two independent `kitchenasty-db` Postgres instances included), with deploy targeting decided by HashMap iteration order.

**Commit 1 — exact matching (the issue's suggested fix):**

1. **Shared resolver** (`crates/orca-control/src/placement.rs`): a pin matches only on exact node ID, full `ip:port` address, the address's **host portion** (bare-IP pins like the prod workaround `node = "217.154.26.121"` keep working), or the `hostname` label. Never a substring.
2. **Refuse on ambiguity**: a pin matching multiple nodes fails the deploy with a loud error instead of picking an arbitrary winner.
3. **Deploy and reconcile agree by construction**: `find_target_node` and `send_reconcile`'s expected-services filter call the same resolver; ambiguous pins resolve to no node on reconcile, so agents are never told to run what deploy refused. Also drops the `now_or_never` lock hack and releases both read guards before the WS send.

**Commit 2 — the NoMatch fall-through is gone too:**

Previously a pin naming a vanished/mistyped/drained node fell through to a **silent local deploy on the master**. Now:

- A pin explicitly naming the master (`master`, `localhost`, `127.0.0.1`, or the master's hostname) still deploys locally — the master isn't in `registered_nodes`; prod has such pins.
- A pin matching **only drained node(s)** errors with "undrain the node or repin the service".
- A pin matching **nothing** errors listing the registered nodes.
- `master_hostname()` consolidated into `placement.rs` from its two ops-handler copies.

**Prod config audit** (orca-infra): all 49 existing pins resolve correctly under the new rules — 38× `ubuntu-16gb-fsn1-1` (hostname), 10× `217.154.26.121` (bare IP → host-portion match), 1× `master` (master-pin path). Nothing to migrate.

Behavior note: a pin to a *temporarily desynced* agent (#84) now errors loudly until the node re-registers instead of mis-deploying onto the master — deliberate.

## Test plan

- 8 unit tests in `placement.rs` incl. the literal incident topology (`ubuntu`/`ubuntu-16gb-fsn1-1`), IP-vs-`ip:port`, ambiguity, drain, and master-pin recognition
- `cluster_test::test_drained_node_skipped_by_scheduler` updated: asserts the refusal (old assertion codified the master mis-deploy)
- Full `orca-control` suite (52 targets) green; `cargo fmt --check` + `cargo clippy -- -D warnings` green

Fixes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)
