### PR TITLE
feat(secrets): age/SOPS-encrypted secrets — in-process decrypt, committed to git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -29,7 +29,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -44,6 +44,49 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+]
+
+[[package]]
+name = "age"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "047a482d1843edf1ce76ada63183698144030fe1191bd5ddba6e41e164e0bc43"
+dependencies = [
+ "age-core",
+ "base64 0.21.7",
+ "bech32",
+ "chacha20poly1305",
+ "cookie-factory",
+ "hmac",
+ "i18n-embed",
+ "i18n-embed-fl",
+ "lazy_static",
+ "nom 7.1.3",
+ "pin-project",
+ "rand 0.8.5",
+ "rust-embed",
+ "scrypt",
+ "sha2 0.10.9",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "age-core"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99"
+dependencies = [
+ "base64 0.21.7",
+ "chacha20poly1305",
+ "cookie-factory",
+ "hkdf",
+ "io_tee",
+ "nom 7.1.3",
+ "rand 0.8.5",
+ "secrecy",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -178,6 +221,15 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "arrayvec"
@@ -338,6 +390,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +429,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -620,6 +696,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,8 +739,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -755,6 +856,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
+dependencies = [
+ "futures",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +909,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -825,7 +959,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "log",
  "regalloc2",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -977,12 +1111,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1064,7 +1233,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl 2.1.1",
 ]
 
 [[package]]
@@ -1075,6 +1253,20 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
  "syn 2.0.117",
  "unicode-xid",
 ]
@@ -1091,9 +1283,29 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -1280,6 +1492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1506,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "libredox",
+]
+
+[[package]]
+name = "find-crate"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+dependencies = [
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -1301,6 +1528,50 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "fluent"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash 1.1.0",
+ "self_cell 0.10.3",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "fnv"
@@ -1595,12 +1866,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1658,6 +1938,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1765,6 +2054,72 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "i18n-config"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef"
+dependencies = [
+ "basic-toml",
+ "log",
+ "serde",
+ "serde_derive",
+ "thiserror 1.0.69",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669ffc2c93f97e6ddf06ddbe999fcd6782e3342978bb85f7d3c087c7978404c4"
+dependencies = [
+ "arc-swap",
+ "fluent",
+ "fluent-langneg",
+ "fluent-syntax",
+ "i18n-embed-impl",
+ "intl-memoizer",
+ "log",
+ "parking_lot",
+ "rust-embed",
+ "thiserror 1.0.69",
+ "unic-langid",
+ "walkdir",
+]
+
+[[package]]
+name = "i18n-embed-fl"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04b2969d0b3fc6143776c535184c19722032b43e6a642d710fa3f88faec53c2d"
+dependencies = [
+ "find-crate",
+ "fluent",
+ "fluent-syntax",
+ "i18n-config",
+ "i18n-embed",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed-impl"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2"
+dependencies = [
+ "find-crate",
+ "i18n-config",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1906,6 +2261,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-tools"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae314a99afb5821e2fda288387546d4a04aace674551e854e6216b892ec3208"
+dependencies = [
+ "autocfg",
+ "impl-tools-lib",
+ "proc-macro-error2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "impl-tools-lib"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab699036df31c1f7d3561bfa6e9cb9bc3bb0fd2e2cd9bf121c31cb961d049ddf"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,6 +2365,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "intl-memoizer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
 name = "io-extras"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,6 +2398,12 @@ name = "io-lifetimes"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io_tee"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304"
 
 [[package]]
 name = "ipnet"
@@ -2288,7 +2692,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite 0.29.0",
- "toml",
+ "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
  "urlencoding",
@@ -2341,6 +2745,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2514,7 +2928,7 @@ dependencies = [
  "byte-unit",
  "chrono",
  "clap",
- "derive_more",
+ "derive_more 1.0.0",
  "futures",
  "maplit",
  "openraft-macros",
@@ -2632,7 +3046,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2651,17 +3065,19 @@ name = "orca-core"
 version = "0.2.11"
 dependencies = [
  "aes-gcm",
+ "age",
  "anyhow",
  "async-trait",
  "chrono",
  "reqwest",
+ "rops",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "tracing",
  "uuid",
 ]
@@ -2752,6 +3168,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,13 +3248,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2886,6 +3323,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit 0.25.8+spec-1.1.0",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3002,7 +3461,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -3022,7 +3481,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3153,7 +3612,7 @@ dependencies = [
  "itertools 0.13.0",
  "lru",
  "paste",
- "strum",
+ "strum 0.26.3",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
@@ -3285,7 +3744,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.15.5",
  "log",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "smallvec",
 ]
 
@@ -3412,6 +3871,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "rops"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4beb52a5d008a707436d388c05e9fee9ae81039cce62813ee750918a13c0aaf"
+dependencies = [
+ "aes-gcm",
+ "age",
+ "anyhow",
+ "base64 0.22.1",
+ "chrono",
+ "derive_more 2.1.1",
+ "directories",
+ "generic-array",
+ "hex",
+ "impl-tools",
+ "indexmap 2.13.0",
+ "rand 0.9.2",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "serde_with",
+ "serde_yaml",
+ "sha2 0.10.9",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+ "walkdir",
+ "zeroize",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "sha2 0.11.0",
+ "walkdir",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,9 +3961,24 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rusticata-macros"
@@ -3584,6 +4124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3632,10 +4181,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -3659,6 +4228,21 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
+dependencies = [
+ "self_cell 1.3.0",
+]
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -3706,6 +4290,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -3722,6 +4307,16 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
+dependencies = [
+ "regex",
+ "serde",
 ]
 
 [[package]]
@@ -3771,7 +4366,20 @@ dependencies = [
  "schemars 1.2.1",
  "serde_core",
  "serde_json",
+ "serde_with_macros",
  "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3794,8 +4402,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3805,8 +4413,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3945,7 +4564,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -3958,6 +4586,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -4160,6 +4800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -4282,6 +4923,15 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4605,6 +5255,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4615,6 +5274,31 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "serde",
+ "tinystr",
+]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -4678,7 +5362,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -5056,8 +5740,8 @@ dependencies = [
  "rustix 0.38.44",
  "serde",
  "serde_derive",
- "sha2",
- "toml",
+ "sha2 0.10.9",
+ "toml 0.8.23",
  "windows-sys 0.59.0",
  "zstd",
 ]
@@ -5866,6 +6550,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5961,6 +6657,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -5979,6 +6689,7 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/crates/orca-cli/src/handlers/db.rs
+++ b/crates/orca-cli/src/handlers/db.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use anyhow::{Result, bail};
 use orca_core::config::ServiceConfig;
-use orca_core::secrets::SecretStore;
 use orca_core::types::VolumeSpec;
 
 use crate::client::OrcaClient;
@@ -104,12 +103,10 @@ async fn handle_create(
         backup: None,
     };
 
-    // Store password as a secret
-    let secrets_path = dirs_next::data_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
-        .join("orca")
-        .join("secrets.json");
-    let mut store = SecretStore::open(&secrets_path)?;
+    // Store password as a secret. Uses the configured backend — this
+    // previously wrote to a divergent `data_dir()/orca/secrets.json` path
+    // that neither the server nor `orca secrets` ever read.
+    let mut store = orca_core::secrets::open_configured()?;
     let secret_key = format!("{name}_password");
     store.set(&secret_key, &password)?;
 

--- a/crates/orca-cli/src/handlers/mod.rs
+++ b/crates/orca-cli/src/handlers/mod.rs
@@ -12,6 +12,7 @@ pub mod join;
 pub mod ops;
 mod port;
 pub mod reload;
+pub mod secrets;
 pub mod server;
 pub mod status;
 pub mod token;

--- a/crates/orca-cli/src/handlers/ops.rs
+++ b/crates/orca-cli/src/handlers/ops.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use crate::client::OrcaClient;
-use crate::commands::{AlertsAction, SecretsAction, WebhookAction};
+use crate::commands::{AlertsAction, WebhookAction};
 
 /// Find the orca project directory by walking up from `base` looking for
 /// `cluster.toml` or `services/`. Falls back to `~/.orca/`.
@@ -241,71 +241,6 @@ fn truncate(s: &str, max: usize) -> String {
         s.to_string()
     } else {
         format!("{}…", &s[..max.saturating_sub(1)])
-    }
-}
-
-fn open_secrets() -> orca_core::secrets::SecretStore {
-    orca_core::secrets::SecretStore::open(orca_core::secrets::default_path()).unwrap_or_else(|e| {
-        tracing::error!("Failed to open secrets store: {e}");
-        std::process::exit(1);
-    })
-}
-
-pub fn handle_secrets(action: SecretsAction) {
-    match action {
-        SecretsAction::Set { key, value } => {
-            let mut store = open_secrets();
-            store.set(&key, &value).expect("failed to set secret");
-            println!("Secret '{key}' set.");
-        }
-        SecretsAction::Get { key } => {
-            let store = open_secrets();
-            match store.get(&key) {
-                Some(value) => println!("{value}"),
-                None => {
-                    eprintln!("Secret '{key}' not found.");
-                    std::process::exit(1);
-                }
-            }
-        }
-        SecretsAction::Remove { key } => {
-            let mut store = open_secrets();
-            match store.remove(&key) {
-                Ok(true) => println!("Secret '{key}' removed."),
-                Ok(false) => println!("Secret '{key}' not found."),
-                Err(e) => tracing::error!("Failed to remove: {e}"),
-            }
-        }
-        SecretsAction::List => {
-            let store = open_secrets();
-            let keys = store.list();
-            if keys.is_empty() {
-                println!("No secrets configured.");
-            } else {
-                for key in keys {
-                    println!("  {key}");
-                }
-            }
-        }
-        SecretsAction::Import { file } => {
-            let mut store = open_secrets();
-            let content = std::fs::read_to_string(&file).unwrap_or_else(|e| {
-                tracing::error!("Failed to read '{file}': {e}");
-                std::process::exit(1);
-            });
-            let mut count = 0u32;
-            for line in content.lines() {
-                let line = line.trim();
-                if line.is_empty() || line.starts_with('#') {
-                    continue;
-                }
-                if let Some((key, value)) = line.split_once('=') {
-                    store.set(key.trim(), value.trim()).expect("failed to set");
-                    count += 1;
-                }
-            }
-            println!("Imported {count} secrets from {file}.");
-        }
     }
 }
 

--- a/crates/orca-cli/src/handlers/secrets.rs
+++ b/crates/orca-cli/src/handlers/secrets.rs
@@ -1,0 +1,110 @@
+//! `orca secrets` — CLI surface over the configured secret store
+//! (legacy machine-local AES file, or the [secrets] SOPS/age-encrypted
+//! file when cluster.toml configures one — #109).
+
+use crate::commands::SecretsAction;
+
+fn open_secrets() -> orca_core::secrets::SecretStore {
+    orca_core::secrets::open_configured().unwrap_or_else(|e| {
+        tracing::error!("Failed to open secrets store: {e}");
+        std::process::exit(1);
+    })
+}
+
+pub fn handle_secrets(action: SecretsAction) {
+    // Best-effort cluster.toml load so a configured [secrets] section
+    // switches this CLI to the encrypted backend (#109). Without one the
+    // legacy machine-local store is used — which doubles as the offline
+    // recovery path when run next to the config repo.
+    let cluster_toml = std::path::Path::new("cluster.toml");
+    if cluster_toml.exists() {
+        let _ = orca_core::config::ClusterConfig::load(cluster_toml);
+    }
+    match action {
+        SecretsAction::Set { key, value } => {
+            let mut store = open_secrets();
+            store.set(&key, &value).expect("failed to set secret");
+            println!("Secret '{key}' set.");
+        }
+        SecretsAction::Get { key } => {
+            let store = open_secrets();
+            match store.get(&key) {
+                Some(value) => println!("{value}"),
+                None => {
+                    eprintln!("Secret '{key}' not found.");
+                    std::process::exit(1);
+                }
+            }
+        }
+        SecretsAction::Remove { key } => {
+            let mut store = open_secrets();
+            match store.remove(&key) {
+                Ok(true) => println!("Secret '{key}' removed."),
+                Ok(false) => println!("Secret '{key}' not found."),
+                Err(e) => tracing::error!("Failed to remove: {e}"),
+            }
+        }
+        SecretsAction::List => {
+            let store = open_secrets();
+            let keys = store.list();
+            if keys.is_empty() {
+                println!("No secrets configured.");
+            } else {
+                for key in keys {
+                    println!("  {key}");
+                }
+            }
+        }
+        SecretsAction::Import { file } => {
+            let mut store = open_secrets();
+            let content = std::fs::read_to_string(&file).unwrap_or_else(|e| {
+                tracing::error!("Failed to read '{file}': {e}");
+                std::process::exit(1);
+            });
+            let mut count = 0u32;
+            for line in content.lines() {
+                let line = line.trim();
+                if line.is_empty() || line.starts_with('#') {
+                    continue;
+                }
+                if let Some((key, value)) = line.split_once('=') {
+                    store.set(key.trim(), value.trim()).expect("failed to set");
+                    count += 1;
+                }
+            }
+            println!("Imported {count} secrets from {file}.");
+        }
+        SecretsAction::Migrate => {
+            if !orca_core::secrets::sops_configured() {
+                eprintln!(
+                    "No [secrets] section configured — add encrypted_file/age_recipients \
+                     to cluster.toml (run from the directory containing it) first."
+                );
+                std::process::exit(1);
+            }
+            let legacy_path = orca_core::secrets::default_path();
+            let legacy = orca_core::secrets::SecretStore::open(&legacy_path).unwrap_or_else(|e| {
+                tracing::error!("Failed to open legacy store: {e}");
+                std::process::exit(1);
+            });
+            let mut store = open_secrets();
+            let count = store.import_from(&legacy).unwrap_or_else(|e| {
+                tracing::error!("Migration failed: {e}");
+                std::process::exit(1);
+            });
+            let backup = legacy_path.with_extension("json.bak");
+            match std::fs::rename(&legacy_path, &backup) {
+                Ok(()) => println!(
+                    "Migrated {count} secret(s) into the encrypted store. \
+                     Legacy store moved to {}.",
+                    backup.display()
+                ),
+                Err(e) => println!(
+                    "Migrated {count} secret(s), but could not move the legacy store aside: {e}. \
+                     Remove {} manually.",
+                    legacy_path.display()
+                ),
+            }
+        }
+    }
+}

--- a/crates/orca-cli/src/main.rs
+++ b/crates/orca-cli/src/main.rs
@@ -95,7 +95,7 @@ async fn main() -> anyhow::Result<()> {
         Command::Ask { question } => handlers::ai_ops::handle_ask(question, cli.api).await?,
         Command::Generate { description } => handlers::ai_ops::handle_generate(description).await?,
         Command::Alerts { action } => handlers::ops::handle_alerts(action, cli.api).await?,
-        Command::Secrets { action } => handlers::ops::handle_secrets(action),
+        Command::Secrets { action } => handlers::secrets::handle_secrets(action),
         Command::Import { source } => handlers::import::handle_import(source),
         Command::Webhooks { action } => handlers::ops::handle_webhooks(action, cli.api).await?,
         Command::Nodes { gpus } => handlers::ops::handle_nodes(gpus, cli.api).await?,

--- a/crates/orca-cli/src/subcommands.rs
+++ b/crates/orca-cli/src/subcommands.rs
@@ -42,6 +42,9 @@ pub enum SecretsAction {
         #[arg(short, long)]
         file: String,
     },
+    /// Move all secrets from the legacy machine-local store into the
+    /// [secrets] encrypted file (#109). Requires [secrets] in cluster.toml.
+    Migrate,
 }
 
 #[derive(Subcommand)]

--- a/crates/orca-control/src/api/handlers/secrets.rs
+++ b/crates/orca-control/src/api/handlers/secrets.rs
@@ -14,7 +14,7 @@ use axum::response::IntoResponse;
 use serde::Deserialize;
 
 use orca_core::api_types::{SecretRef, SecretUsage, SecretsUsageResponse};
-use orca_core::secrets::{SecretStore, default_path, extract_refs};
+use orca_core::secrets::extract_refs;
 
 use crate::state::AppState;
 
@@ -25,7 +25,7 @@ pub struct SetSecretRequest {
 
 /// `GET /api/v1/secrets` — return the list of secret keys (never values).
 pub async fn list_secrets() -> impl IntoResponse {
-    match SecretStore::open(default_path()) {
+    match orca_core::secrets::open_configured() {
         Ok(store) => {
             let keys: Vec<String> = store.list().into_iter().collect();
             (StatusCode::OK, Json(serde_json::json!({ "keys": keys }))).into_response()
@@ -43,7 +43,7 @@ pub async fn set_secret(
     Path(key): Path<String>,
     Json(body): Json<SetSecretRequest>,
 ) -> impl IntoResponse {
-    let mut store = match SecretStore::open(default_path()) {
+    let mut store = match orca_core::secrets::open_configured() {
         Ok(s) => s,
         Err(e) => {
             return (
@@ -73,7 +73,7 @@ pub async fn set_secret(
 /// key that isn't in the store — so the operator sees broken templates,
 /// not just stored keys.
 pub async fn secrets_usage(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let store = match SecretStore::open(default_path()) {
+    let store = match orca_core::secrets::open_configured() {
         Ok(s) => s,
         Err(e) => {
             return (
@@ -137,7 +137,7 @@ pub async fn secrets_usage(State(state): State<Arc<AppState>>) -> impl IntoRespo
 
 /// `DELETE /api/v1/secrets/{key}` — remove a secret.
 pub async fn remove_secret(Path(key): Path<String>) -> impl IntoResponse {
-    let mut store = match SecretStore::open(default_path()) {
+    let mut store = match orca_core::secrets::open_configured() {
         Ok(s) => s,
         Err(e) => {
             return (

--- a/crates/orca-control/src/routes.rs
+++ b/crates/orca-control/src/routes.rs
@@ -9,7 +9,7 @@ use orca_core::types::{DeployKind, HealthState, WorkloadSpec, WorkloadStatus};
 
 /// Resolve `${secrets.KEY}` patterns in env vars using the local secrets store.
 fn resolve_secrets(env: &HashMap<String, String>) -> HashMap<String, String> {
-    match orca_core::secrets::SecretStore::open(orca_core::secrets::default_path()) {
+    match orca_core::secrets::open_configured() {
         Ok(store) => store.resolve_env(env),
         Err(_) => env.clone(),
     }

--- a/crates/orca-core/Cargo.toml
+++ b/crates/orca-core/Cargo.toml
@@ -21,6 +21,8 @@ tracing = { workspace = true }
 reqwest = { workspace = true }
 serde_yaml = "0.9"
 aes-gcm = "0.10"
+rops = { version = "0.1", default-features = false, features = ["aes-gcm", "age", "json", "sha2"] }
 
 [dev-dependencies]
+age = "0.11"
 tempfile = "3"

--- a/crates/orca-core/src/config/cluster.rs
+++ b/crates/orca-core/src/config/cluster.rs
@@ -29,6 +29,11 @@ pub struct ClusterConfig {
     /// Mesh networking configuration (NetBird).
     #[serde(default)]
     pub network: Option<NetworkConfig>,
+    /// Encrypted-secrets store (#109). When present, secrets come from a
+    /// SOPS/age-encrypted file committed to the config repo instead of the
+    /// machine-local AES store.
+    #[serde(default)]
+    pub secrets: Option<SecretsConfig>,
     /// Fallback proxy for unmatched requests (e.g., point to coolify-proxy).
     #[serde(default)]
     pub fallback: Option<FallbackConfig>,
@@ -194,6 +199,39 @@ pub struct FallbackConfig {
     pub http: Option<String>,
     /// HTTPS/TLS fallback target for SNI passthrough (e.g., "127.0.0.1:8443").
     pub tls: Option<String>,
+}
+
+/// SOPS/age-encrypted secrets store configuration (#109).
+///
+/// The master decrypts the file in-process at load with a local age
+/// identity and re-encrypts on every mutation. Standard `sops`/`age`
+/// tooling can always decrypt the file without orca — recovery is
+/// "have the repo + the key."
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SecretsConfig {
+    /// SOPS-encrypted JSON secrets file. Relative paths resolve against
+    /// the directory containing cluster.toml, so the file lives in the
+    /// same git repo the declarative reconciler converges on.
+    pub encrypted_file: String,
+    /// age identity file (one `AGE-SECRET-KEY-…` per line) used for
+    /// in-process decryption. Optional when the `ROPS_AGE` /
+    /// `ROPS_AGE_KEY_FILE` environment variables are set instead.
+    #[serde(default)]
+    pub age_key_file: Option<String>,
+    /// age public keys (`age1…`) the file is encrypted to — the master's
+    /// key plus the operator's offline key. Required when orca creates
+    /// the file; an existing file's recipient set is reused as-is.
+    #[serde(default)]
+    pub age_recipients: Vec<String>,
+    /// Commit and push the encrypted file after each mutation so the
+    /// config repo stays the source of truth (best-effort: failures are
+    /// logged loudly, never lose the local write). Default: true.
+    #[serde(default = "default_secrets_git_autocommit")]
+    pub git_autocommit: bool,
+}
+
+fn default_secrets_git_autocommit() -> bool {
+    true
 }
 
 /// Mesh networking configuration.

--- a/crates/orca-core/src/config/mod.rs
+++ b/crates/orca-core/src/config/mod.rs
@@ -17,7 +17,7 @@ pub use cluster::NetworkConfig;
 pub use cluster::{
     AlertChannelConfig, ApiToken, CleanupConfig, ClusterConfig, ClusterMeta, DeployConfig,
     FallbackConfig, NodeConfig, NodeGpuConfig, ObservabilityConfig, ReconcileConfig, Role,
-    SecurityHeadersConfig,
+    SecretsConfig, SecurityHeadersConfig,
 };
 pub use service::{BuildConfig, ProbeConfig, ServiceConfig, ServicesConfig};
 
@@ -29,13 +29,20 @@ impl ClusterConfig {
             .map_err(|e| OrcaError::Config(format!("failed to read {}: {e}", path.display())))?;
         let mut config: Self = toml::from_str(&content)
             .map_err(|e| OrcaError::Config(format!("failed to parse {}: {e}", path.display())))?;
+        // Install the encrypted-secrets backend BEFORE resolving
+        // `${secrets.X}` fields below, so they resolve against the store
+        // `[secrets]` selects (#109).
+        if let Some(secrets_cfg) = &config.secrets {
+            let base_dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+            crate::secrets::configure(secrets_cfg, base_dir);
+        }
         config.resolve_secrets();
         Ok(config)
     }
 
     /// Resolve `${secrets.X}` patterns in config fields that may contain secrets.
     fn resolve_secrets(&mut self) {
-        let store = match crate::secrets::SecretStore::open(crate::secrets::default_path()) {
+        let store = match crate::secrets::open_configured() {
             Ok(s) => s,
             Err(_) => return,
         };

--- a/crates/orca-core/src/config/tests_parse.rs
+++ b/crates/orca-core/src/config/tests_parse.rs
@@ -168,3 +168,28 @@ scale_on_pressure = false
     assert_eq!(ai.alerts.as_ref().unwrap().analysis_interval_secs, 30);
     assert!(ai.auto_remediate.as_ref().unwrap().restart_crashed);
 }
+
+#[test]
+fn parse_secrets_config() {
+    let toml = r#"
+[cluster]
+name = "test"
+
+[secrets]
+encrypted_file = "secrets.enc.json"
+age_key_file = "/home/op/.config/orca/age.key"
+age_recipients = [
+    "age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+    "age1zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+]
+"#;
+    let config: ClusterConfig = toml::from_str(toml).unwrap();
+    let secrets = config.secrets.as_ref().unwrap();
+    assert_eq!(secrets.encrypted_file, "secrets.enc.json");
+    assert_eq!(secrets.age_recipients.len(), 2);
+    assert!(secrets.git_autocommit, "git_autocommit defaults to true");
+
+    // Section absent → no encrypted backend selected.
+    let bare: ClusterConfig = toml::from_str("[cluster]\nname = \"t\"\n").unwrap();
+    assert!(bare.secrets.is_none());
+}

--- a/crates/orca-core/src/secrets/git_sync.rs
+++ b/crates/orca-core/src/secrets/git_sync.rs
@@ -1,0 +1,87 @@
+//! Best-effort git write-back for the encrypted secrets file (#109).
+//!
+//! The encrypted store lives in the config repo, so a mutation that stays
+//! uncommitted drifts from git and a later pull could silently revert it.
+//! After each save we commit and push. Every step is best-effort: the
+//! secret is already persisted locally, so failures warn loudly instead of
+//! failing the mutation.
+
+use std::path::Path;
+use std::process::Command;
+
+use tracing::{debug, info, warn};
+
+/// Commit `file` in its containing repo and push. No-op outside a git
+/// work tree or when the file is unchanged.
+pub(crate) fn autocommit_and_push(file: &Path) {
+    let Some(dir) = file.parent() else {
+        return;
+    };
+    if !run(dir, &["rev-parse", "--is-inside-work-tree"]) {
+        debug!(
+            ?file,
+            "secrets file not in a git work tree — skipping write-back"
+        );
+        return;
+    }
+    let Some(name) = file.file_name().map(|n| n.to_string_lossy().into_owned()) else {
+        return;
+    };
+    if !run(dir, &["add", "--", &name]) {
+        warn!(?file, "git add failed — secrets change is NOT committed");
+        return;
+    }
+    // `diff --cached --quiet` exits 0 when nothing is staged.
+    if run(dir, &["diff", "--cached", "--quiet", "--", &name]) {
+        debug!(?file, "secrets file unchanged — nothing to commit");
+        return;
+    }
+    if !run(dir, &["commit", "-m", "orca: secrets update"]) {
+        warn!(?file, "git commit failed — secrets change is NOT committed");
+        return;
+    }
+    let has_remote = output(dir, &["remote"]).is_some_and(|o| !o.trim().is_empty());
+    if !has_remote {
+        info!(
+            ?file,
+            "secrets change committed (no remote configured — not pushed)"
+        );
+        return;
+    }
+    if run(dir, &["push"]) {
+        info!(?file, "secrets change committed and pushed");
+        return;
+    }
+    warn!("git push rejected — retrying after pull --rebase");
+    if run(dir, &["pull", "--rebase"]) && run(dir, &["push"]) {
+        info!(?file, "secrets change pushed after rebase");
+        return;
+    }
+    warn!(
+        ?file,
+        "secrets change committed locally but NOT pushed — the config repo \
+         has drifted; push manually before the next git pull/reconcile"
+    );
+}
+
+fn run(dir: &Path, args: &[&str]) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn output(dir: &Path, args: &[&str]) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).into_owned())
+}

--- a/crates/orca-core/src/secrets/mod.rs
+++ b/crates/orca-core/src/secrets/mod.rs
@@ -1,10 +1,25 @@
+mod git_sync;
 mod refs;
+mod sops_store;
+#[cfg(test)]
+#[path = "sops_store_tests.rs"]
+mod sops_store_tests;
 mod store;
 
 pub use refs::{SecretReference, extract_refs};
 pub use store::SecretStore;
 
-/// Canonical on-disk location for the secrets store: `~/.orca/secrets.json`.
+use std::path::Path;
+use std::sync::RwLock;
+
+use sops_store::SopsBackend;
+
+/// Backend selected by `[secrets]` in cluster.toml, installed at config
+/// load. `RwLock` (not `OnceLock`) so `orca reload` can re-configure.
+static SOPS: RwLock<Option<SopsBackend>> = RwLock::new(None);
+
+/// Canonical on-disk location for the legacy secrets store:
+/// `~/.orca/secrets.json`.
 ///
 /// Falls back to `./secrets.json` only if `$HOME` is unset (test/CI fallback).
 /// All CLI and server code should resolve secrets via this path so that
@@ -18,5 +33,73 @@ pub fn default_path() -> std::path::PathBuf {
             dir.join("secrets.json")
         }
         Err(_) => std::path::PathBuf::from("secrets.json"),
+    }
+}
+
+/// Install the SOPS/age backend from `[secrets]` in cluster.toml (#109).
+/// `base_dir` is the directory containing cluster.toml — relative
+/// `encrypted_file` paths resolve against it, keeping the store inside the
+/// config repo. Called by `ClusterConfig::load`; callers then get the
+/// encrypted backend from [`open_configured`].
+pub fn configure(cfg: &crate::config::SecretsConfig, base_dir: &Path) {
+    let path = {
+        let p = Path::new(&cfg.encrypted_file);
+        if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            base_dir.join(p)
+        }
+    };
+
+    // Bridge [secrets].age_key_file to the env var rops actually reads.
+    // rops looks for ROPS_AGE / ROPS_AGE_KEY_FILE — not the SOPS_AGE_*
+    // names — and offers no API to pass an identity explicitly.
+    if let Some(key_file) = &cfg.age_key_file
+        && std::env::var("ROPS_AGE").is_err()
+    {
+        match std::fs::read_to_string(key_file) {
+            Ok(contents) => {
+                let identities: Vec<&str> = contents
+                    .lines()
+                    .map(str::trim)
+                    .filter(|l| l.starts_with("AGE-SECRET-KEY-"))
+                    .collect();
+                if identities.is_empty() {
+                    tracing::error!(
+                        key_file,
+                        "no age identities found in [secrets].age_key_file"
+                    );
+                } else {
+                    // SAFETY: configure() runs during startup config load
+                    // (single-threaded, before the async runtime spawns
+                    // worker threads that might read the environment).
+                    unsafe { std::env::set_var("ROPS_AGE", identities.join(",")) };
+                }
+            }
+            Err(e) => {
+                tracing::error!(key_file, "failed to read [secrets].age_key_file: {e}");
+            }
+        }
+    }
+
+    let backend = SopsBackend::new(path, cfg.age_recipients.clone(), cfg.git_autocommit);
+    *SOPS.write().expect("secrets backend lock poisoned") = Some(backend);
+}
+
+/// Whether the SOPS/age backend is active (i.e. `[secrets]` was configured).
+pub fn sops_configured() -> bool {
+    SOPS.read()
+        .expect("secrets backend lock poisoned")
+        .is_some()
+}
+
+/// Open the configured secrets backend: the SOPS/age store when `[secrets]`
+/// is set in cluster.toml, the legacy machine-local AES store otherwise.
+/// This is the entry point every production caller should use.
+pub fn open_configured() -> anyhow::Result<SecretStore> {
+    let backend = SOPS.read().expect("secrets backend lock poisoned").clone();
+    match backend {
+        Some(b) => SecretStore::open_sops(b),
+        None => SecretStore::open(default_path()),
     }
 }

--- a/crates/orca-core/src/secrets/sops_store.rs
+++ b/crates/orca-core/src/secrets/sops_store.rs
@@ -1,0 +1,140 @@
+//! SOPS/age-encrypted secrets backend (#109).
+//!
+//! Secrets live as a SOPS-format JSON file in the config repo: keys stay
+//! plaintext (readable `git diff`), values are AES-256-GCM encrypted with a
+//! data key wrapped for each age recipient. Decryption happens in-process
+//! via the `rops` crate — no external `sops`/`age` binary at runtime.
+//!
+//! Saves reuse the file's existing data key and per-value nonces
+//! (`encrypt_with_saved_parameters`), so untouched values stay
+//! byte-identical across mutations and diffs show only what changed.
+//!
+//! The age identity is supplied through the environment: `rops` reads
+//! `ROPS_AGE` (comma-separated identities) or `ROPS_AGE_KEY_FILE` — note
+//! these are NOT the `SOPS_AGE_*` names. `secrets::configure` bridges the
+//! `[secrets].age_key_file` setting to `ROPS_AGE` at startup.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use anyhow::{Context, Result};
+use rops::cryptography::cipher::AES256GCM;
+use rops::cryptography::hasher::SHA512;
+use rops::file::RopsFile;
+use rops::file::builder::RopsFileBuilder;
+use rops::file::format::{JsonFileFormat, RopsFileFormatMap};
+use rops::file::state::{DecryptedFile, EncryptedFile};
+use rops::integration::{AgeIntegration, Integration};
+
+type EncryptedRops = RopsFile<EncryptedFile<AES256GCM, SHA512>, JsonFileFormat>;
+type DecryptedRops = RopsFile<DecryptedFile<SHA512>, JsonFileFormat>;
+
+/// File-level backend: load-and-decrypt / re-encrypt-and-save a flat
+/// `KEY → value` map. The in-memory model stays `SecretStore`'s plain
+/// `HashMap`; this type only owns the on-disk envelope.
+#[derive(Debug, Clone)]
+pub(crate) struct SopsBackend {
+    pub(crate) path: PathBuf,
+    recipients: Vec<String>,
+    git_autocommit: bool,
+}
+
+impl SopsBackend {
+    pub(crate) fn new(path: PathBuf, recipients: Vec<String>, git_autocommit: bool) -> Self {
+        Self {
+            path,
+            recipients,
+            git_autocommit,
+        }
+    }
+
+    /// Decrypt the file into a flat map. A missing file is an empty store
+    /// (created on first mutation).
+    pub(crate) fn load(&self) -> Result<HashMap<String, String>> {
+        if !self.path.exists() {
+            return Ok(HashMap::new());
+        }
+        let raw = std::fs::read_to_string(&self.path)
+            .with_context(|| format!("failed to read {}", self.path.display()))?;
+        let encrypted = EncryptedRops::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("failed to parse {}: {e}", self.path.display()))?;
+        let decrypted: DecryptedRops = encrypted.decrypt::<JsonFileFormat>().map_err(|e| {
+            anyhow::anyhow!(
+                "failed to decrypt {}: {e} — is a matching age identity available \
+                 ([secrets].age_key_file, ROPS_AGE, or ROPS_AGE_KEY_FILE)?",
+                self.path.display()
+            )
+        })?;
+        Ok(decrypted
+            .into_inner_map()
+            .into_iter()
+            .map(|(k, v)| {
+                let val = match v {
+                    serde_json::Value::String(s) => s,
+                    other => other.to_string(),
+                };
+                (k, val)
+            })
+            .collect())
+    }
+
+    /// Re-encrypt the full map and write it back. Reuses the existing data
+    /// key + nonces when the file exists (stable diffs); creates a fresh
+    /// file encrypted to the configured recipients otherwise.
+    pub(crate) fn save(&self, secrets: &HashMap<String, String>) -> Result<()> {
+        // Sort keys so the serialized file is deterministic — diffs must
+        // reflect value changes, never map-iteration order.
+        let sorted: BTreeMap<&String, &String> = secrets.iter().collect();
+        let mut json_map = serde_json::Map::new();
+        for (k, v) in sorted {
+            json_map.insert(k.clone(), serde_json::Value::String(v.clone()));
+        }
+
+        let serialized = if self.path.exists() {
+            let raw = std::fs::read_to_string(&self.path)
+                .with_context(|| format!("failed to read {}", self.path.display()))?;
+            let encrypted = EncryptedRops::from_str(&raw)
+                .map_err(|e| anyhow::anyhow!("failed to parse {}: {e}", self.path.display()))?;
+            let (decrypted, saved_params) = encrypted
+                .decrypt_and_save_parameters::<JsonFileFormat>()
+                .map_err(|e| anyhow::anyhow!("failed to decrypt for update: {e}"))?;
+            let updated = decrypted
+                .set_map(RopsFileFormatMap::from_inner_map(json_map))
+                .map_err(|e| anyhow::anyhow!("failed to apply secrets update: {e}"))?;
+            updated
+                .encrypt_with_saved_parameters::<AES256GCM, JsonFileFormat>(saved_params)
+                .map_err(|e| anyhow::anyhow!("failed to re-encrypt secrets: {e}"))?
+                .to_string()
+        } else {
+            anyhow::ensure!(
+                !self.recipients.is_empty(),
+                "cannot create {}: no [secrets].age_recipients configured — \
+                 add at least the master's age public key",
+                self.path.display()
+            );
+            let mut builder = RopsFileBuilder::<JsonFileFormat>::from_map(json_map);
+            for recipient in &self.recipients {
+                let key_id = AgeIntegration::parse_key_id(recipient).map_err(|e| {
+                    anyhow::anyhow!("invalid age recipient {recipient:?} in [secrets]: {e}")
+                })?;
+                builder = builder.add_integration_key::<AgeIntegration>(key_id);
+            }
+            builder
+                .encrypt::<AES256GCM, SHA512>()
+                .map_err(|e| anyhow::anyhow!("failed to encrypt new secrets file: {e}"))?
+                .to_string()
+        };
+
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent).context("failed to create secrets directory")?;
+        }
+        std::fs::write(&self.path, &serialized)
+            .with_context(|| format!("failed to write {}", self.path.display()))?;
+
+        if self.git_autocommit {
+            super::git_sync::autocommit_and_push(&self.path);
+        }
+        Ok(())
+    }
+}

--- a/crates/orca-core/src/secrets/sops_store_tests.rs
+++ b/crates/orca-core/src/secrets/sops_store_tests.rs
@@ -1,0 +1,89 @@
+use std::collections::HashMap;
+
+use super::sops_store::SopsBackend;
+
+/// One combined scenario instead of several tests: the age identity is
+/// supplied via the process-global `ROPS_AGE` env var, and parallel tests
+/// mutating the environment would race.
+#[test]
+fn sops_backend_round_trip_edit_and_diff_stability() {
+    let identity = age::x25519::Identity::generate();
+    let recipient = identity.to_public().to_string();
+    // SAFETY: this is the only test in the binary touching ROPS_AGE, and
+    // it sets the var before any rops call reads it.
+    unsafe {
+        std::env::set_var(
+            "ROPS_AGE",
+            age::secrecy::ExposeSecret::expose_secret(&identity.to_string()),
+        )
+    };
+
+    let dir = std::env::temp_dir().join(format!("orca-sops-test-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("secrets.enc.json");
+
+    // git_autocommit=false: the scratch dir is intentionally not a repo,
+    // and the write-back is exercised as a no-op via the missing-repo path.
+    let backend = SopsBackend::new(path.clone(), vec![recipient], false);
+
+    // Missing file loads as empty.
+    assert_eq!(backend.load().unwrap(), HashMap::new());
+
+    // Create: first save encrypts to the configured recipient.
+    let mut secrets = HashMap::from([
+        ("db_password".to_string(), "hunter2".to_string()),
+        ("api_token".to_string(), "tok-123".to_string()),
+    ]);
+    backend.save(&secrets).unwrap();
+
+    let raw = std::fs::read_to_string(&path).unwrap();
+    let on_disk: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    // SOPS format: keys plaintext, values ENC[...], metadata present.
+    assert!(on_disk.get("sops").is_some(), "sops metadata section");
+    let db_cipher = on_disk["db_password"].as_str().unwrap().to_string();
+    assert!(db_cipher.starts_with("ENC["), "value must be encrypted");
+    assert!(!raw.contains("hunter2"), "plaintext must not hit disk");
+
+    // Round trip.
+    assert_eq!(backend.load().unwrap(), secrets);
+
+    // Edit: change one key, add one, remove one.
+    secrets.insert("api_token".to_string(), "tok-456".to_string());
+    secrets.insert("new_key".to_string(), "fresh".to_string());
+    secrets.remove("db_password");
+    backend.save(&secrets).unwrap();
+    assert_eq!(backend.load().unwrap(), secrets);
+
+    // Diff stability: an untouched value keeps its exact ciphertext across
+    // an unrelated mutation (saved data key + nonces are reused), so git
+    // diffs show only the keys that actually changed.
+    let raw2 = std::fs::read_to_string(&path).unwrap();
+    let on_disk2: serde_json::Value = serde_json::from_str(&raw2).unwrap();
+    secrets.insert("another".to_string(), "x".to_string());
+    backend.save(&secrets).unwrap();
+    let on_disk3: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(
+        on_disk2["new_key"], on_disk3["new_key"],
+        "untouched value must stay byte-identical across saves"
+    );
+
+    // A fresh file with no recipients configured must refuse, not panic.
+    let empty = SopsBackend::new(dir.join("other.enc.json"), vec![], false);
+    let err = empty.save(&secrets).unwrap_err().to_string();
+    assert!(err.contains("age_recipients"), "got: {err}");
+
+    // Missing identity: with no matching age key available, decryption
+    // must fail with a hint pointing at the key configuration. (Last in
+    // this test — it clears the process-global ROPS_AGE.)
+    // SAFETY: same single-test env discipline as the set_var above.
+    unsafe { std::env::remove_var("ROPS_AGE") };
+    let err = backend.load().unwrap_err().to_string();
+    assert!(
+        err.contains("age identity") || err.contains("age_key_file"),
+        "missing-identity error should point at key config, got: {err}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/orca-core/src/secrets/store.rs
+++ b/crates/orca-core/src/secrets/store.rs
@@ -125,12 +125,44 @@ pub struct SecretStore {
     #[serde(skip)]
     master_key: Vec<u8>,
     secrets: HashMap<String, String>,
+    /// When set, this store reads/writes the SOPS/age-encrypted file
+    /// (#109) instead of the legacy AES file. The in-memory model and the
+    /// public API are identical either way.
+    #[serde(skip)]
+    sops: Option<super::sops_store::SopsBackend>,
 }
 
 impl SecretStore {
     /// Open an existing secrets file or create a new empty one.
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         Self::open_with_key(path, &default_master_key_path())
+    }
+
+    /// Open the SOPS/age-encrypted backend (#109). Prefer
+    /// [`super::open_configured`], which picks the backend from cluster.toml.
+    pub(super) fn open_sops(backend: super::sops_store::SopsBackend) -> Result<Self> {
+        let secrets = backend.load()?;
+        Ok(SecretStore {
+            path: backend.path.clone(),
+            master_key: Vec::new(),
+            secrets,
+            sops: Some(backend),
+        })
+    }
+
+    /// Copy every secret from `other` into this store with a single save —
+    /// the migration path from the legacy AES store into the encrypted
+    /// file (one commit, not one per key).
+    pub fn import_from(&mut self, other: &SecretStore) -> Result<usize> {
+        let mut count = 0;
+        for key in other.list() {
+            if let Some(value) = other.get(&key) {
+                self.secrets.insert(key, value.to_string());
+                count += 1;
+            }
+        }
+        self.save()?;
+        Ok(count)
     }
 
     /// Open with a specific master key path (useful for testing).
@@ -165,6 +197,7 @@ impl SecretStore {
                 path,
                 master_key,
                 secrets: HashMap::new(),
+                sops: None,
             };
             store.save()?;
             Ok(store)
@@ -207,6 +240,9 @@ impl SecretStore {
 
     /// Persist secrets to disk with restrictive permissions.
     fn save(&self) -> Result<()> {
+        if let Some(backend) = &self.sops {
+            return backend.save(&self.secrets);
+        }
         if let Some(parent) = self.path.parent() {
             std::fs::create_dir_all(parent).context("failed to create secrets directory")?;
         }

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -174,14 +174,43 @@ API_KEY = "${secrets.edge_key}"
 
 ## Secrets
 
-Secrets are encrypted and stored in the cluster state (redb). Reference them in
-config with `${secrets.KEY}`.
+Secrets are stored encrypted and referenced in config with `${secrets.KEY}`.
+Two backends exist:
+
+- **Default:** a machine-local AES-256-GCM store (`~/.orca/secrets.json`,
+  key at `~/.orca/master.key`). Simple, but tied to one machine.
+- **Recommended — `[secrets]` in cluster.toml:** an age/SOPS-encrypted file
+  committed to your config repo. Keys stay plaintext (readable `git diff`),
+  values are encrypted to your age recipients. The master decrypts
+  in-process; recovery never needs orca — `sops -d` / `age -d` with the key
+  is enough.
+
+```toml
+[secrets]
+encrypted_file = "secrets.enc.json"            # relative to cluster.toml
+age_key_file   = "/root/.config/orca/age.key"  # master's age identity (keep OUT of git)
+age_recipients = [                             # encrypt to master + operator
+  "age1masterkey…",
+  "age1operatorkey…",
+]
+# git_autocommit = true   # commit+push after each mutation (default)
+```
+
+Generate keys with `age-keygen`. Because the file is encrypted to *both*
+recipients, the operator can always decrypt locally, independent of the
+master. With `git_autocommit` (default), every `orca secrets set/remove`
+commits and pushes `secrets.enc.json` so the repo stays the source of truth;
+push failures are logged loudly but never lose the local write.
 
 ```bash
 orca secrets set DB_PASS "s3cret"
 orca secrets list
 orca secrets import -f .env           # Bulk import
+orca secrets migrate                  # move legacy local store → encrypted file
 ```
+
+The CLI uses the encrypted backend when run from the directory containing
+cluster.toml (offline/recovery access included — no running master needed).
 
 `${secrets.X}` is resolved both in `service.toml` (any string field, including
 `env` values) and in selected `cluster.toml` fields:
@@ -189,7 +218,7 @@ orca secrets import -f .env           # Bulk import
 | File | Resolved fields |
 |------|-----------------|
 | `service.toml` | All string fields, including `env`, `image`, `domain`, `aliases` |
-| `cluster.toml` | `ai.api_key`, `ai.endpoint`, `network.setup_key` |
+| `cluster.toml` | `ai.api_key`, `ai.endpoint`, SMTP password, `network.setup_key`, named token values, S3 backup credentials |
 
 This means cluster-level config can be safely committed to git -- credentials
 live in the encrypted secret store, not in the TOML.


### PR DESCRIPTION
## Summary

Implements #109: secrets move from the machine-local AES store to a **SOPS-format JSON file in the config repo** — keys plaintext (readable `git diff`), values encrypted to age recipients, decrypted **in-process** via the `rops` crate (no `sops`/`age` binary at runtime). Recovery never needs orca: `sops -d` / `age` with the key decrypts the file.

Enabled by a new `[secrets]` section in cluster.toml (without it, behavior is unchanged — legacy store):

```toml
[secrets]
encrypted_file = "secrets.enc.json"            # relative to cluster.toml → lives in the config repo
age_key_file   = "/root/.config/orca/age.key"  # master identity, OUT of git
age_recipients = ["age1master…", "age1operator…"]  # multi-recipient: operator can always decrypt offline
# git_autocommit = true                        # default
```

## Design decisions

- **One seam:** the backend swap is entirely inside `SecretStore` — `secrets::open_configured()` picks the backend and all production callers (CLI, HTTP API, deploy-time env resolution, cluster.toml fields) now use it. CLI/API surfaces unchanged.
- **Clean diffs:** saves reuse the file's data key + per-value nonces, so untouched values stay byte-identical; keys sorted for deterministic output. Verified by test.
- **Git write-back (decided on the issue):** each mutation commits ("orca: secrets update") and pushes, one `pull --rebase` retry; failures warn loudly, never lose the local write; no-repo/no-remote are quiet no-ops.
- **`orca secrets migrate`** moves the legacy store into the encrypted file (single save/commit), renames the old file `.bak`.
- **Offline mode:** the CLI reads the encrypted file directly when run beside cluster.toml — no running master needed (covers the issue's `--local` criterion).
- **rops quirk:** it reads `ROPS_AGE`/`ROPS_AGE_KEY_FILE`, not `SOPS_AGE_*` — `[secrets].age_key_file` bridges at config load.

## Drive-by fixes

- `orca db create` wrote its password to a divergent `data_dir()/orca/secrets.json` nothing ever read — now uses the configured store.
- CLI secrets handling split into `handlers/secrets.rs` (file-size cap).
- Docs: secrets section rewritten (also removed a stale claim that secrets live in redb).

## Test plan

- New: SOPS round-trip (create/read/edit/remove), diff byte-stability, no-recipients refusal, missing-identity error hint, `[secrets]` TOML parse
- Full workspace tests, `cargo fmt --check`, `clippy -- -D warnings`, 500-line gate: all green
- **Follow-up (not in this PR):** interop fixture generated with the real `sops` CLI in nightly CI — `rops` claims full bidirectional compatibility but is pre-1.0 (pinned 0.1.x)

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)