### PR TITLE
feat(secrets): project-scoped secrets via prefix keys

### DIFF
--- a/crates/orca-cli/src/handlers/secrets.rs
+++ b/crates/orca-cli/src/handlers/secrets.rs
@@ -4,6 +4,15 @@
 
 use crate::commands::SecretsAction;
 
+/// Build the stored key for an optionally project-scoped secret (#68):
+/// `<project>.<key>` when scoped, the bare key otherwise.
+fn scoped_key(key: &str, project: Option<&str>) -> String {
+    match project {
+        Some(p) => format!("{p}.{key}"),
+        None => key.to_string(),
+    }
+}
+
 fn open_secrets() -> orca_core::secrets::SecretStore {
     orca_core::secrets::open_configured().unwrap_or_else(|e| {
         tracing::error!("Failed to open secrets store: {e}");
@@ -21,14 +30,26 @@ pub fn handle_secrets(action: SecretsAction) {
         let _ = orca_core::config::ClusterConfig::load(cluster_toml);
     }
     match action {
-        SecretsAction::Set { key, value } => {
+        SecretsAction::Set {
+            key,
+            value,
+            project,
+        } => {
+            let key = scoped_key(&key, project.as_deref());
             let mut store = open_secrets();
             store.set(&key, &value).expect("failed to set secret");
             println!("Secret '{key}' set.");
         }
-        SecretsAction::Get { key } => {
+        SecretsAction::Get { key, project } => {
             let store = open_secrets();
-            match store.get(&key) {
+            // Project-first lookup mirrors deploy-time resolution: the
+            // scoped variant wins, the bare key is the fallback.
+            let scoped = project.as_deref().map(|p| format!("{p}.{key}"));
+            let hit = scoped
+                .as_deref()
+                .and_then(|k| store.get(k))
+                .or_else(|| store.get(&key));
+            match hit {
                 Some(value) => println!("{value}"),
                 None => {
                     eprintln!("Secret '{key}' not found.");
@@ -36,7 +57,8 @@ pub fn handle_secrets(action: SecretsAction) {
                 }
             }
         }
-        SecretsAction::Remove { key } => {
+        SecretsAction::Remove { key, project } => {
+            let key = scoped_key(&key, project.as_deref());
             let mut store = open_secrets();
             match store.remove(&key) {
                 Ok(true) => println!("Secret '{key}' removed."),
@@ -49,10 +71,33 @@ pub fn handle_secrets(action: SecretsAction) {
             let keys = store.list();
             if keys.is_empty() {
                 println!("No secrets configured.");
-            } else {
-                for key in keys {
+                return;
+            }
+            // Group by scope prefix: `<project>.<key>` under its project,
+            // everything else under (global). Purely cosmetic — the store
+            // is flat and dots in legacy global keys just group oddly.
+            let (mut global, mut scoped): (Vec<&String>, Vec<&String>) = (vec![], vec![]);
+            for k in &keys {
+                if k.contains('.') {
+                    scoped.push(k);
+                } else {
+                    global.push(k);
+                }
+            }
+            if !global.is_empty() {
+                println!("(global)");
+                for key in global {
                     println!("  {key}");
                 }
+            }
+            let mut last_scope = "";
+            for key in scoped {
+                let (scope, name) = key.split_once('.').expect("filtered on '.'");
+                if scope != last_scope {
+                    println!("{scope}:");
+                    last_scope = scope;
+                }
+                println!("  {name}");
             }
         }
         SecretsAction::Import { file } => {

--- a/crates/orca-cli/src/subcommands.rs
+++ b/crates/orca-cli/src/subcommands.rs
@@ -29,13 +29,22 @@ pub enum SecretsAction {
     Set {
         key: String,
         value: String,
+        /// Scope the secret to a project (stored as `<project>.<key>`, #68).
+        #[arg(short, long)]
+        project: Option<String>,
     },
     /// Print a secret value to stdout.
     Get {
         key: String,
+        /// Look the key up in a project scope first.
+        #[arg(short, long)]
+        project: Option<String>,
     },
     Remove {
         key: String,
+        /// Remove the project-scoped variant (`<project>.<key>`).
+        #[arg(short, long)]
+        project: Option<String>,
     },
     List,
     Import {

--- a/crates/orca-control/src/routes.rs
+++ b/crates/orca-control/src/routes.rs
@@ -7,10 +7,15 @@ use tracing::info;
 use orca_core::config::ServiceConfig;
 use orca_core::types::{DeployKind, HealthState, WorkloadSpec, WorkloadStatus};
 
-/// Resolve `${secrets.KEY}` patterns in env vars using the local secrets store.
-fn resolve_secrets(env: &HashMap<String, String>) -> HashMap<String, String> {
+/// Resolve `${secrets.KEY}` patterns in env vars using the configured
+/// secrets store. Project-scoped keys (`<project>.KEY`, #68) win over
+/// bare global keys for services that belong to a project.
+fn resolve_secrets(
+    env: &HashMap<String, String>,
+    project: Option<&str>,
+) -> HashMap<String, String> {
     match orca_core::secrets::open_configured() {
-        Ok(store) => store.resolve_env(env),
+        Ok(store) => store.resolve_env_scoped(env, project),
         Err(_) => env.clone(),
     }
 }
@@ -173,7 +178,7 @@ pub(crate) fn service_config_to_spec(config: &ServiceConfig) -> anyhow::Result<W
         health: config.health.clone(),
         readiness: config.readiness.clone(),
         liveness: config.liveness.clone(),
-        env: resolve_secrets(&config.env),
+        env: resolve_secrets(&config.env, config.project.as_deref()),
         resources: config.resources.clone(),
         volume: config.volume.clone(),
         deploy: config.deploy.clone(),

--- a/crates/orca-core/src/secrets/store.rs
+++ b/crates/orca-core/src/secrets/store.rs
@@ -233,9 +233,32 @@ impl SecretStore {
 
     /// Replace `${secrets.KEY}` patterns in env-var values with actual secret values.
     pub fn resolve_env(&self, env: &HashMap<String, String>) -> HashMap<String, String> {
+        self.resolve_env_scoped(env, None)
+    }
+
+    /// Like [`Self::resolve_env`], but with project-first resolution (#68):
+    /// for a service in project `p`, `${secrets.KEY}` resolves `p.KEY`
+    /// before falling back to the bare `KEY`. Explicit cross-project refs
+    /// (`${secrets.other.KEY}`) keep working — the prefixed form is looked
+    /// up as written after the project-qualified attempt misses.
+    pub fn resolve_env_scoped(
+        &self,
+        env: &HashMap<String, String>,
+        project: Option<&str>,
+    ) -> HashMap<String, String> {
         env.iter()
-            .map(|(k, v)| (k.clone(), self.resolve_value(v)))
+            .map(|(k, v)| (k.clone(), self.resolve_value(v, project)))
             .collect()
+    }
+
+    /// Look a reference key up project-first, then bare.
+    fn lookup_scoped(&self, key: &str, project: Option<&str>) -> Option<&String> {
+        if let Some(p) = project
+            && let Some(v) = self.secrets.get(&format!("{p}.{key}"))
+        {
+            return Some(v);
+        }
+        self.secrets.get(key)
     }
 
     /// Persist secrets to disk with restrictive permissions.
@@ -269,7 +292,7 @@ impl SecretStore {
     }
 
     /// Resolve `${secrets.KEY}` patterns in a single string value.
-    fn resolve_value(&self, value: &str) -> String {
+    fn resolve_value(&self, value: &str, project: Option<&str>) -> String {
         let mut result = value.to_string();
         let mut search_from = 0;
         while let Some(start) = result[search_from..].find("${secrets.") {
@@ -279,7 +302,7 @@ impl SecretStore {
                 break;
             };
             let key = result[after_prefix..after_prefix + end].to_string();
-            if let Some(secret_value) = self.secrets.get(&key) {
+            if let Some(secret_value) = self.lookup_scoped(&key, project) {
                 result = format!(
                     "{}{}{}",
                     &result[..abs_start],

--- a/crates/orca-core/src/secrets/store_tests.rs
+++ b/crates/orca-core/src/secrets/store_tests.rs
@@ -143,3 +143,46 @@ fn test_xor_migration() {
     let store2 = SecretStore::open_with_key(&path, &key_path).unwrap();
     assert_eq!(store2.get("OLD_KEY"), Some("my-legacy-secret"));
 }
+
+/// Project-scoped resolution (#68): `<project>.KEY` wins over bare `KEY`
+/// for services in that project; everything else falls back to global.
+#[test]
+fn project_scoped_resolution_order() {
+    let (mut store, _dir) = temp_store();
+    store.set("db_url", "global-url").unwrap();
+    store.set("inka.db_url", "inka-url").unwrap();
+    store.set("only_global", "shared").unwrap();
+    store.set("kitchenasty.only_scoped", "ka-secret").unwrap();
+
+    let env = std::collections::HashMap::from([
+        ("URL".to_string(), "${secrets.db_url}".to_string()),
+        ("SHARED".to_string(), "${secrets.only_global}".to_string()),
+    ]);
+
+    // In project `inka`, the scoped variant wins; globals still resolve.
+    let inka = store.resolve_env_scoped(&env, Some("inka"));
+    assert_eq!(inka["URL"], "inka-url");
+    assert_eq!(inka["SHARED"], "shared");
+
+    // A project without a scoped variant falls back to the global key.
+    let other = store.resolve_env_scoped(&env, Some("kitchenasty"));
+    assert_eq!(other["URL"], "global-url");
+
+    // No project context (cluster.toml fields): bare keys only.
+    let none = store.resolve_env_scoped(&env, None);
+    assert_eq!(none["URL"], "global-url");
+
+    // Explicit cross-project refs keep working as written.
+    let cross = std::collections::HashMap::from([(
+        "X".to_string(),
+        "${secrets.kitchenasty.only_scoped}".to_string(),
+    )]);
+    let resolved = store.resolve_env_scoped(&cross, Some("inka"));
+    assert_eq!(resolved["X"], "ka-secret");
+
+    // A scoped-only key does NOT leak into the bare form.
+    let bare =
+        std::collections::HashMap::from([("X".to_string(), "${secrets.only_scoped}".to_string())]);
+    let unresolved = store.resolve_env_scoped(&bare, None);
+    assert_eq!(unresolved["X"], "${secrets.only_scoped}");
+}

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -212,6 +212,21 @@ orca secrets migrate                  # move legacy local store → encrypted fi
 The CLI uses the encrypted backend when run from the directory containing
 cluster.toml (offline/recovery access included — no running master needed).
 
+### Project-scoped secrets
+
+Secrets can be scoped to a project with a `<project>.<key>` prefix. For a
+service in project `p`, `${secrets.KEY}` resolves `p.KEY` first and falls
+back to the bare global `KEY` — so a project can override a shared default
+without leaking its value to other projects. Explicit cross-project
+references (`${secrets.other.KEY}`) resolve as written.
+
+```bash
+orca secrets set --project inka db_password "s3cret"   # stored as inka.db_password
+orca secrets get --project inka db_password            # scoped first, global fallback
+orca secrets remove --project inka db_password
+orca secrets list                                      # grouped by scope
+```
+
 `${secrets.X}` is resolved both in `service.toml` (any string field, including
 `env` values) and in selected `cluster.toml` fields:
 


### PR DESCRIPTION
## Summary

Implements #68's prefix-key scheme on top of the #109 encrypted store: `<project>.KEY` scopes a secret to a project. For a service in project `p`, `${secrets.KEY}` resolves `p.KEY` first, then falls back to the bare global `KEY` — projects override shared defaults without widening blast radius. Explicit cross-project refs (`${secrets.other.KEY}`) resolve as written; cluster.toml fields (no project context) only ever see bare keys, so scoped values can't leak into global resolution.

- **Store**: one new seam — `resolve_env_scoped(env, project)`; `resolve_env` delegates with `None`, so existing behavior is untouched.
- **Deploy path**: `service_config_to_spec` passes `config.project` (covers container + Wasm env).
- **CLI**: `--project` on `set`/`get`/`remove`; `list` groups by scope.
- **Backend-agnostic**: prefix keys are plain flat keys — identical on the legacy AES store and the SOPS/age file (where they keep per-key readable diffs).

Sequencing note: #69 (TUI secrets organizer a/e/x) builds on this and is the remaining v0.2.12 TUI item.

## Test plan

- New `project_scoped_resolution_order` test: scoped-wins, global-fallback, no-project-context, explicit cross-project, and scoped-doesn't-leak-into-bare.
- Full workspace tests + fmt + `clippy -- -D warnings` + 500-line gate: green.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)