### PR TITLE
feat(tui): secrets organizer inline a/e/x + project scope filter

### DIFF
--- a/crates/orca-control/src/api/handlers/secrets.rs
+++ b/crates/orca-control/src/api/handlers/secrets.rs
@@ -84,21 +84,33 @@ pub async fn secrets_usage(State(state): State<Arc<AppState>>) -> impl IntoRespo
         }
     };
     let stored_keys: Vec<String> = store.list();
+    let stored: std::collections::HashSet<&str> = stored_keys.iter().map(|s| s.as_str()).collect();
 
-    // Build key → unique (service, project) set. Using BTreeMap so the
-    // response order is stable for the dashboard.
-    let mut refs_by_key: BTreeMap<(Option<String>, String), Vec<SecretRef>> = BTreeMap::new();
+    // Join references to the STORED key they actually resolve to, mirroring
+    // deploy-time resolution (#68): an implicit `${secrets.X}` from a
+    // service in project `p` resolves to `p.X` when that scoped key exists,
+    // the bare `X` otherwise; an explicit `${secrets.s.X}` targets `s.X` as
+    // written. BTreeMap keeps the response order stable for the dashboard.
+    let mut refs_by_target: BTreeMap<String, Vec<SecretRef>> = BTreeMap::new();
     {
         let services = state.services.read().await;
         for svc in services.values() {
             let project = svc.config.project.clone();
-            let mut seen_for_service: std::collections::HashSet<(Option<String>, String)> =
+            let mut seen_for_service: std::collections::HashSet<String> =
                 std::collections::HashSet::new();
             for value in svc.config.env.values() {
                 for r in extract_refs(value) {
-                    let map_key = (r.scope.clone(), r.key.clone());
-                    if seen_for_service.insert(map_key.clone()) {
-                        refs_by_key.entry(map_key).or_default().push(SecretRef {
+                    let target = match &r.scope {
+                        Some(s) => format!("{s}.{}", r.key),
+                        None => match &project {
+                            Some(p) if stored.contains(format!("{p}.{}", r.key).as_str()) => {
+                                format!("{p}.{}", r.key)
+                            }
+                            _ => r.key.clone(),
+                        },
+                    };
+                    if seen_for_service.insert(target.clone()) {
+                        refs_by_target.entry(target).or_default().push(SecretRef {
                             service_name: svc.config.name.clone(),
                             project: project.clone(),
                         });
@@ -109,24 +121,25 @@ pub async fn secrets_usage(State(state): State<Arc<AppState>>) -> impl IntoRespo
     }
 
     // Emit stored keys first (preserving alphabetical order from the store),
-    // then any referenced-but-unstored keys as "broken" entries.
+    // then any referenced-but-unstored keys as "broken" entries. `key` is
+    // always the FULL stored key (delete/set target); `scope` is the
+    // grouping hint — the prefix for project-scoped keys.
     let mut out: Vec<SecretUsage> = stored_keys
         .iter()
         .map(|k| {
-            let map_key = (None, k.clone());
-            let refs = refs_by_key.remove(&map_key).unwrap_or_default();
+            let refs = refs_by_target.remove(k).unwrap_or_default();
             SecretUsage {
                 key: k.clone(),
-                scope: None,
+                scope: k.split_once('.').map(|(s, _)| s.to_string()),
                 refs,
                 in_store: true,
             }
         })
         .collect();
-    for ((scope, key), refs) in refs_by_key {
+    for (target, refs) in refs_by_target {
         out.push(SecretUsage {
-            key,
-            scope,
+            scope: target.split_once('.').map(|(s, _)| s.to_string()),
+            key: target,
             refs,
             in_store: false,
         });

--- a/crates/orca-tui/src/commands.rs
+++ b/crates/orca-tui/src/commands.rs
@@ -193,7 +193,10 @@ async fn cmd_secret_rm(state: &mut AppState, client: &ApiClient, parts: &[&str])
             crate::refresh_secrets_usage(client, state).await;
             // After the row drops out, clamp selection back into the
             // selectable range (skip past group headers).
-            let rows = crate::ui::secrets::flatten(&state.secrets_usage);
+            let rows = crate::ui::secrets::flatten(
+                &state.secrets_usage,
+                state.secrets_scope_filter.as_deref(),
+            );
             let sel = crate::ui::secrets::selectable_indices(&rows);
             if !sel.contains(&state.selected_secret) {
                 state.selected_secret = sel.last().copied().unwrap_or(0);

--- a/crates/orca-tui/src/input_keys.rs
+++ b/crates/orca-tui/src/input_keys.rs
@@ -1,0 +1,54 @@
+//! Key handling for the non-normal input modes: the `/` filter line and
+//! the `:` command bar. Normal-mode dispatch lives in `keys.rs`.
+
+use crossterm::event::KeyCode;
+
+use crate::api::ApiClient;
+use crate::state::{AppState, InputMode};
+
+pub fn handle_filter_key(state: &mut AppState, code: KeyCode) {
+    match code {
+        KeyCode::Esc => {
+            state.filter.clear();
+            state.input_mode = InputMode::Normal;
+            state.selected_service = 0;
+        }
+        KeyCode::Enter => {
+            state.input_mode = InputMode::Normal;
+        }
+        KeyCode::Backspace => {
+            state.filter.pop();
+            state.selected_service = 0;
+        }
+        KeyCode::Char(c) => {
+            state.filter.push(c);
+            state.selected_service = 0;
+        }
+        _ => {}
+    }
+}
+
+pub async fn handle_command_key(state: &mut AppState, client: &ApiClient, code: KeyCode) {
+    match code {
+        KeyCode::Esc => {
+            state.command_input.clear();
+            state.input_mode = InputMode::Normal;
+        }
+        KeyCode::Enter => {
+            let cmd = state.command_input.trim().to_string();
+            state.command_input.clear();
+            state.input_mode = InputMode::Normal;
+            crate::commands::execute_command(state, client, &cmd).await;
+        }
+        KeyCode::Backspace => {
+            state.command_input.pop();
+            if state.command_input.is_empty() {
+                state.input_mode = InputMode::Normal;
+            }
+        }
+        KeyCode::Char(c) => {
+            state.command_input.push(c);
+        }
+        _ => {}
+    }
+}

--- a/crates/orca-tui/src/keys.rs
+++ b/crates/orca-tui/src/keys.rs
@@ -5,52 +5,7 @@ use crossterm::event::KeyCode;
 use crate::api::ApiClient;
 use crate::state::{AppState, InputMode, View};
 
-pub fn handle_filter_key(state: &mut AppState, code: KeyCode) {
-    match code {
-        KeyCode::Esc => {
-            state.filter.clear();
-            state.input_mode = InputMode::Normal;
-            state.selected_service = 0;
-        }
-        KeyCode::Enter => {
-            state.input_mode = InputMode::Normal;
-        }
-        KeyCode::Backspace => {
-            state.filter.pop();
-            state.selected_service = 0;
-        }
-        KeyCode::Char(c) => {
-            state.filter.push(c);
-            state.selected_service = 0;
-        }
-        _ => {}
-    }
-}
-
-pub async fn handle_command_key(state: &mut AppState, client: &ApiClient, code: KeyCode) {
-    match code {
-        KeyCode::Esc => {
-            state.command_input.clear();
-            state.input_mode = InputMode::Normal;
-        }
-        KeyCode::Enter => {
-            let cmd = state.command_input.trim().to_string();
-            state.command_input.clear();
-            state.input_mode = InputMode::Normal;
-            crate::commands::execute_command(state, client, &cmd).await;
-        }
-        KeyCode::Backspace => {
-            state.command_input.pop();
-            if state.command_input.is_empty() {
-                state.input_mode = InputMode::Normal;
-            }
-        }
-        KeyCode::Char(c) => {
-            state.command_input.push(c);
-        }
-        _ => {}
-    }
-}
+pub use crate::input_keys::{handle_command_key, handle_filter_key};
 
 pub async fn handle_normal_key(
     state: &mut AppState,
@@ -60,6 +15,17 @@ pub async fn handle_normal_key(
 ) {
     if matches!(state.view, View::Chat) {
         crate::chat_input::handle_chat_key(state, client, code).await;
+        return;
+    }
+    // Pending delete confirmation (#69): the next keypress resolves it —
+    // `y` deletes, anything else cancels. Intercepted before normal
+    // dispatch so no other binding can fire mid-confirmation.
+    if let Some(key) = state.pending_secret_delete.take() {
+        if matches!(code, KeyCode::Char('y') | KeyCode::Char('Y')) {
+            crate::secrets_actions::delete_secret(client, state, &key).await;
+        } else {
+            state.flash("Delete cancelled".into());
+        }
         return;
     }
     match code {
@@ -78,7 +44,7 @@ pub async fn handle_normal_key(
 
         // Navigation
         KeyCode::Char('j') | KeyCode::Down => match state.view {
-            View::Secrets => secret_nav_next(state),
+            View::Secrets => crate::secrets_actions::secret_nav_next(state),
             View::Backups => {
                 let len = state.backups.as_ref().map(|b| b.nodes.len()).unwrap_or(0);
                 if len > 0 && state.selected_backup_node + 1 < len {
@@ -108,7 +74,7 @@ pub async fn handle_normal_key(
             _ => state.next_service(),
         },
         KeyCode::Char('k') | KeyCode::Up => match state.view {
-            View::Secrets => secret_nav_prev(state),
+            View::Secrets => crate::secrets_actions::secret_nav_prev(state),
             View::Backups => {
                 if state.selected_backup_node > 0 {
                     state.selected_backup_node -= 1;
@@ -136,7 +102,7 @@ pub async fn handle_normal_key(
             _ => state.prev_service(),
         },
         KeyCode::Char('g') => match state.view {
-            View::Secrets => secret_nav_first(state),
+            View::Secrets => crate::secrets_actions::secret_nav_first(state),
             View::Backups => state.selected_backup_node = 0,
             View::BackupSnapshots { .. } => state.selected_backup_snapshot = 0,
             View::Webhooks => state.selected_webhook = 0,
@@ -146,7 +112,7 @@ pub async fn handle_normal_key(
             _ => state.selected_service = 0,
         },
         KeyCode::Char('G') => match state.view {
-            View::Secrets => secret_nav_last(state),
+            View::Secrets => crate::secrets_actions::secret_nav_last(state),
             View::Backups => {
                 let len = state.backups.as_ref().map(|b| b.nodes.len()).unwrap_or(0);
                 if len > 0 {
@@ -242,7 +208,7 @@ pub async fn handle_normal_key(
         KeyCode::Char('2') | KeyCode::Char('n') => {}
         KeyCode::Char('3') if !matches!(state.view, View::Secrets) => {
             super::refresh_secrets_usage(client, state).await;
-            secret_nav_first(state);
+            crate::secrets_actions::secret_nav_first(state);
             state.push_view(View::Secrets);
         }
         KeyCode::Char('3') => {}
@@ -302,6 +268,13 @@ pub async fn handle_normal_key(
             state.input_mode = InputMode::Command;
             state.command_input = "webhook-add ".into();
         }
+        // `a` adds a secret: opens the command bar pre-filled with `:set`.
+        // Project-scoped keys use the `<project>.KEY` prefix form (#68).
+        KeyCode::Char('a') if matches!(state.view, View::Secrets) => {
+            state.input_mode = InputMode::Command;
+            state.command_input = "set ".into();
+            state.flash("Enter KEY <value> — or <project>.KEY <value> to scope".into());
+        }
         // `e` edits — opens command mode pre-filled with the current row's
         // identity so the user only types the changed field(s).
         KeyCode::Char('e') if matches!(state.view, View::Webhooks) => {
@@ -309,6 +282,16 @@ pub async fn handle_normal_key(
                 state.input_mode = InputMode::Command;
                 state.command_input =
                     format!("webhook-edit {} {} {} ", w.repo, w.branch, w.service_name);
+            }
+        }
+        // `e` edits the selected secret: `:set` pre-filled with the full
+        // stored key. Values are never readable back, so the flow always
+        // takes a fresh value (same as `:set` today).
+        KeyCode::Char('e') if matches!(state.view, View::Secrets) => {
+            if let Some(u) = crate::ui::secrets::selected_key(state) {
+                let key = u.key.clone();
+                state.input_mode = InputMode::Command;
+                state.command_input = format!("set {key} ");
             }
         }
         // `b` triggers a manual backup on the selected node when in the
@@ -325,8 +308,25 @@ pub async fn handle_normal_key(
         KeyCode::Char('x') if matches!(state.view, View::Webhooks) => {
             super::delete_selected_webhook(client, state).await;
         }
+        // `x` on a secret arms a y/N confirmation instead of deleting
+        // immediately — a mistyped delete here loses a credential, unlike
+        // stopping a service which is reversible.
+        KeyCode::Char('x') if matches!(state.view, View::Secrets) => {
+            if let Some(u) = crate::ui::secrets::selected_key(state) {
+                if u.in_store {
+                    state.pending_secret_delete = Some(u.key.clone());
+                } else {
+                    state.flash("Not in store (broken ref) — nothing to delete".into());
+                }
+            }
+        }
         KeyCode::Char('x') => super::handle_stop(client, state).await,
         KeyCode::Char('s') => handle_scale_prompt(state),
+        // `p` in the secrets view cycles the scope filter (#69); everywhere
+        // else it keeps its services-project-filter meaning.
+        KeyCode::Char('p') if matches!(state.view, View::Secrets) => {
+            crate::secrets_actions::cycle_scope_filter(state);
+        }
         KeyCode::Char('p') => handle_project_filter(state),
         KeyCode::Char('w') => {
             if matches!(state.view, View::Logs { .. } | View::Detail { .. }) {
@@ -367,40 +367,6 @@ fn handle_esc(state: &mut AppState) {
         state.flash("Project filter cleared".into());
     } else {
         state.pop_view();
-    }
-}
-
-/// Navigation helpers for the secrets organizer. The view is a flat list of
-/// group-headers interleaved with key rows, but selection should only land on
-/// key rows. Going through `selectable_indices` keeps the contract in one
-/// place (see `ui::secrets::flatten`).
-fn secret_nav_first(state: &mut AppState) {
-    let rows = crate::ui::secrets::flatten(&state.secrets_usage);
-    if let Some(&i) = crate::ui::secrets::selectable_indices(&rows).first() {
-        state.selected_secret = i;
-    }
-}
-
-fn secret_nav_last(state: &mut AppState) {
-    let rows = crate::ui::secrets::flatten(&state.secrets_usage);
-    if let Some(&i) = crate::ui::secrets::selectable_indices(&rows).last() {
-        state.selected_secret = i;
-    }
-}
-
-fn secret_nav_next(state: &mut AppState) {
-    let rows = crate::ui::secrets::flatten(&state.secrets_usage);
-    let sel = crate::ui::secrets::selectable_indices(&rows);
-    if let Some(next) = sel.iter().find(|&&i| i > state.selected_secret) {
-        state.selected_secret = *next;
-    }
-}
-
-fn secret_nav_prev(state: &mut AppState) {
-    let rows = crate::ui::secrets::flatten(&state.secrets_usage);
-    let sel = crate::ui::secrets::selectable_indices(&rows);
-    if let Some(prev) = sel.iter().rev().find(|&&i| i < state.selected_secret) {
-        state.selected_secret = *prev;
     }
 }
 

--- a/crates/orca-tui/src/lib.rs
+++ b/crates/orca-tui/src/lib.rs
@@ -4,9 +4,11 @@ mod chat_input;
 mod commands;
 
 pub(crate) use chat_dispatch::{drain_chat_result, send_chat_message};
+mod input_keys;
 mod keys;
 mod metrics;
 mod persist;
+mod secrets_actions;
 pub mod state;
 pub mod ui;
 mod webhook_actions;

--- a/crates/orca-tui/src/secrets_actions.rs
+++ b/crates/orca-tui/src/secrets_actions.rs
@@ -1,0 +1,94 @@
+//! Inline actions for the secrets organizer (#69): delete with y/N
+//! confirmation and the `p` scope-filter cycle. The add/edit flows reuse the
+//! command bar (`:set`) — see the `a`/`e` arms in `keys.rs`.
+
+use crate::api::ApiClient;
+use crate::state::AppState;
+
+/// Confirmed delete: remove the key on the master, refresh, and clamp the
+/// selection back onto a selectable row (mirrors `:rm`).
+pub(crate) async fn delete_secret(client: &ApiClient, state: &mut AppState, key: &str) {
+    match client.remove_secret(key).await {
+        Ok(()) => {
+            state.flash(format!("Secret {key} removed"));
+            crate::refresh_secrets_usage(client, state).await;
+            clamp_secret_selection(state);
+        }
+        Err(e) => state.error = Some(format!("Remove secret failed: {e}")),
+    }
+}
+
+/// Cycle the scope filter: all groups → each group label in display order →
+/// all. Selection resets to the first selectable row so the cursor never
+/// points at a row the filter just hid.
+pub(crate) fn cycle_scope_filter(state: &mut AppState) {
+    let labels = crate::ui::secrets::group_labels(&state.secrets_usage);
+    if labels.is_empty() {
+        return;
+    }
+    state.secrets_scope_filter = match &state.secrets_scope_filter {
+        None => Some(labels[0].clone()),
+        Some(current) => labels
+            .iter()
+            .position(|l| l == current)
+            .and_then(|i| labels.get(i + 1))
+            .cloned(),
+    };
+    let shown = state
+        .secrets_scope_filter
+        .as_deref()
+        .unwrap_or("all scopes");
+    state.flash(format!("Secrets filter: {shown}"));
+    let rows =
+        crate::ui::secrets::flatten(&state.secrets_usage, state.secrets_scope_filter.as_deref());
+    state.selected_secret = crate::ui::secrets::selectable_indices(&rows)
+        .first()
+        .copied()
+        .unwrap_or(0);
+}
+
+/// Clamp `selected_secret` into the current selectable set.
+pub(crate) fn clamp_secret_selection(state: &mut AppState) {
+    let rows =
+        crate::ui::secrets::flatten(&state.secrets_usage, state.secrets_scope_filter.as_deref());
+    let sel = crate::ui::secrets::selectable_indices(&rows);
+    if !sel.contains(&state.selected_secret) {
+        state.selected_secret = sel.last().copied().unwrap_or(0);
+    }
+}
+
+/// j/k/g/G navigation over the flattened secrets list — skips group
+/// headers, honors the active scope filter.
+pub(crate) fn secret_nav_first(state: &mut AppState) {
+    let rows =
+        crate::ui::secrets::flatten(&state.secrets_usage, state.secrets_scope_filter.as_deref());
+    if let Some(&i) = crate::ui::secrets::selectable_indices(&rows).first() {
+        state.selected_secret = i;
+    }
+}
+
+pub(crate) fn secret_nav_last(state: &mut AppState) {
+    let rows =
+        crate::ui::secrets::flatten(&state.secrets_usage, state.secrets_scope_filter.as_deref());
+    if let Some(&i) = crate::ui::secrets::selectable_indices(&rows).last() {
+        state.selected_secret = i;
+    }
+}
+
+pub(crate) fn secret_nav_next(state: &mut AppState) {
+    let rows =
+        crate::ui::secrets::flatten(&state.secrets_usage, state.secrets_scope_filter.as_deref());
+    let sel = crate::ui::secrets::selectable_indices(&rows);
+    if let Some(next) = sel.iter().find(|&&i| i > state.selected_secret) {
+        state.selected_secret = *next;
+    }
+}
+
+pub(crate) fn secret_nav_prev(state: &mut AppState) {
+    let rows =
+        crate::ui::secrets::flatten(&state.secrets_usage, state.secrets_scope_filter.as_deref());
+    let sel = crate::ui::secrets::selectable_indices(&rows);
+    if let Some(prev) = sel.iter().rev().find(|&&i| i < state.selected_secret) {
+        state.selected_secret = *prev;
+    }
+}

--- a/crates/orca-tui/src/state.rs
+++ b/crates/orca-tui/src/state.rs
@@ -116,6 +116,14 @@ pub struct AppState {
     /// so use `ui::secrets::selectable_indices` when navigating to skip
     /// non-selectable header rows.
     pub selected_secret: usize,
+    /// Pending y/N confirmation for deleting a secret (#69). Holds the full
+    /// stored key. Rendered in the footer; consumed by the next keypress
+    /// (`y` confirms, anything else cancels).
+    pub pending_secret_delete: Option<String>,
+    /// Scope filter for the secrets view (#69): `None` shows every group,
+    /// `Some(label)` shows only that group (`global`, a project name, or
+    /// `broken refs`). Cycled with `p`.
+    pub secrets_scope_filter: Option<String>,
     /// Cached cluster-backups response; refreshed when entering the view or
     /// on explicit `r` keypress. `None` means we haven't fetched yet this
     /// session — the view shows a "loading" placeholder.
@@ -231,6 +239,8 @@ impl AppState {
             cluster_version: None,
             cluster_commit: None,
             selected_secret: 0,
+            pending_secret_delete: None,
+            secrets_scope_filter: None,
             backups: None,
             selected_backup_node: 0,
             selected_backup_snapshot: 0,

--- a/crates/orca-tui/src/ui.rs
+++ b/crates/orca-tui/src/ui.rs
@@ -276,6 +276,16 @@ fn draw_footer(f: &mut Frame, area: Rect, state: &AppState) {
 
     // Separator + key hints
     spans.push(Span::styled(" | ", dim));
+    // A pending delete confirmation replaces the key hints — the next
+    // keypress answers it, so nothing else is actionable right now.
+    if let Some(key) = &state.pending_secret_delete {
+        spans.push(Span::styled(
+            format!("Delete secret '{key}'? y:confirm  any other key:cancel"),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ));
+        f.render_widget(Paragraph::new(Line::from(spans)), area);
+        return;
+    }
     let keys = match &state.view {
         // Services: 1 services, 2 nodes, 3 secrets. `c` collapses the
         // project of the currently selected row (was SPC, but space
@@ -285,7 +295,9 @@ fn draw_footer(f: &mut Frame, area: Rect, state: &AppState) {
         View::Logs { .. } => "Esc:back w:wrap PgUp/PgDn:scroll ?:help",
         View::Detail { .. } => "Esc:back s:scale x:stop l:logs ?:help",
         View::Help => "Esc:back",
-        View::Secrets => "Esc:back j/k:select ↵:refs r:refresh :set/:rm ?:help",
+        View::Secrets => {
+            "Esc:back j/k:select ↵:refs a:add e:edit x:delete p:scope r:refresh ?:help"
+        }
         View::SecretRefs { .. } => "Esc:back r:refresh ?:help",
         View::Networks => "Esc:back r:refresh ?:help",
         View::Backups => "Esc:back j/k:select ↵:snapshots r:refresh b:trigger ?:help",

--- a/crates/orca-tui/src/ui/help.rs
+++ b/crates/orca-tui/src/ui/help.rs
@@ -50,6 +50,14 @@ pub fn draw_help(f: &mut Frame, area: Rect, state: &AppState) {
         ("2 / n", "Nodes view (CPU/Mem/Disk/Net sparklines)"),
         ("3", "Secrets view (grouped by inferred scope + ref counts)"),
         (
+            "a / e / x (secrets)",
+            "Add (:set prefill), edit selected key, delete with y/N confirm",
+        ),
+        (
+            "p (secrets)",
+            "Cycle scope filter: all -> global -> per-project -> broken refs",
+        ),
+        (
             "↵ on a secret row",
             "Drill into the list of services referencing that key",
         ),

--- a/crates/orca-tui/src/ui/secrets.rs
+++ b/crates/orca-tui/src/ui/secrets.rs
@@ -31,7 +31,7 @@ pub fn draw_secrets(f: &mut Frame, area: Rect, state: &AppState) {
         return;
     }
 
-    let rows_data = flatten(&state.secrets_usage);
+    let rows_data = flatten(&state.secrets_usage, state.secrets_scope_filter.as_deref());
     let total_keys = rows_data
         .iter()
         .filter(|r| matches!(r, FlatRow::Key { .. }))
@@ -59,14 +59,19 @@ pub fn draw_secrets(f: &mut Frame, area: Rect, state: &AppState) {
 
     let widths = [Constraint::Min(40), Constraint::Length(14)];
 
+    let filter_tag = state
+        .secrets_scope_filter
+        .as_deref()
+        .map(|fltr| format!(" ⛉ {fltr}"))
+        .unwrap_or_default();
     let title = if rows_data.len() > visible_rows {
         format!(
-            " Secrets ({total_keys}) [{}/{}] ",
+            " Secrets ({total_keys}){filter_tag} [{}/{}] ",
             (scroll + 1).min(rows_data.len()),
             rows_data.len()
         )
     } else {
-        format!(" Secrets ({total_keys}) ")
+        format!(" Secrets ({total_keys}){filter_tag} ")
     };
 
     let block = Block::default()
@@ -102,14 +107,31 @@ pub enum FlatRow<'a> {
     Key { usage: &'a SecretUsage },
 }
 
-pub fn flatten(usage: &[SecretUsage]) -> Vec<FlatRow<'_>> {
+/// Group labels present in the usage list, in display order — the cycle
+/// ring for the `p` scope filter.
+pub fn group_labels(usage: &[SecretUsage]) -> Vec<String> {
+    let mut labels: Vec<String> = usage
+        .iter()
+        .map(infer_group)
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    labels.sort_by_key(|s| (sort_rank(s), s.clone()));
+    labels
+}
+
+pub fn flatten<'a>(usage: &'a [SecretUsage], filter: Option<&str>) -> Vec<FlatRow<'a>> {
     use std::collections::BTreeMap;
 
     // Bucket each usage into a group. The infer_group rule lives in one place
     // so the test suite can pin the contract.
     let mut groups: BTreeMap<String, Vec<&SecretUsage>> = BTreeMap::new();
     for u in usage {
-        groups.entry(infer_group(u)).or_default().push(u);
+        let group = infer_group(u);
+        if filter.is_some_and(|f| f != group) {
+            continue;
+        }
+        groups.entry(group).or_default().push(u);
     }
 
     let mut out: Vec<FlatRow<'_>> = Vec::new();
@@ -198,8 +220,13 @@ fn render_row<'a>(r: &FlatRow<'a>, selected: bool) -> Row<'a> {
             } else {
                 Style::default()
             };
+            let display = usage
+                .scope
+                .as_deref()
+                .and_then(|s| usage.key.strip_prefix(s).and_then(|k| k.strip_prefix('.')))
+                .unwrap_or(&usage.key);
             Row::new(vec![
-                Span::raw(format!("    {}", usage.key)),
+                Span::raw(format!("    {display}")),
                 Span::styled(count_text, Style::default().fg(count_color)),
             ])
             .style(row_style)
@@ -219,7 +246,7 @@ fn group_color(name: &str) -> Color {
 /// Used by the event-loop drill-down handler so it can stay decoupled from
 /// the rendering structure.
 pub fn selected_key(state: &AppState) -> Option<&SecretUsage> {
-    let rows = flatten(&state.secrets_usage);
+    let rows = flatten(&state.secrets_usage, state.secrets_scope_filter.as_deref());
     match rows.get(state.selected_secret) {
         Some(FlatRow::Key { usage }) => Some(usage),
         _ => None,
@@ -297,7 +324,7 @@ mod tests {
             usage("B", true, &[]),
             usage("C", false, &[("svc", None)]),
         ];
-        let rows = flatten(&usages);
+        let rows = flatten(&usages, None);
         // Sequence: global header, B, alpha header, A, broken refs header, C
         match &rows[0] {
             FlatRow::Group { label, .. } => assert_eq!(label, "global"),
@@ -321,11 +348,55 @@ mod tests {
             usage("A", true, &[("svc", Some("alpha"))]),
             usage("B", true, &[]),
         ];
-        let rows = flatten(&usages);
+        let rows = flatten(&usages, None);
         let sel = selectable_indices(&rows);
         for i in &sel {
             assert!(matches!(rows[*i], FlatRow::Key { .. }));
         }
         assert_eq!(sel.len(), 2);
+    }
+    /// A stored `<project>.KEY` (scope populated by the usage endpoint since
+    /// #68) groups under its project regardless of who references it.
+    #[test]
+    fn stored_scoped_key_groups_under_its_scope() {
+        let mut u = usage("inka.db_password", true, &[("web", Some("other"))]);
+        u.scope = Some("inka".into());
+        assert_eq!(infer_group(&u), "inka");
+    }
+
+    /// The scope filter hides every other group — rows and headers.
+    #[test]
+    fn flatten_filter_shows_only_matching_group() {
+        let usages = vec![
+            usage("A", true, &[("svc", Some("alpha"))]),
+            usage("B", true, &[]),
+            usage("C", false, &[("svc", None)]),
+        ];
+        let rows = flatten(&usages, Some("alpha"));
+        assert_eq!(rows.len(), 2, "one header + one key row");
+        match &rows[0] {
+            FlatRow::Group { label, .. } => assert_eq!(label, "alpha"),
+            _ => panic!("expected group header"),
+        }
+        match &rows[1] {
+            FlatRow::Key { usage } => assert_eq!(usage.key, "A"),
+            _ => panic!("expected key row"),
+        }
+        // A filter matching nothing yields an empty list, not a panic.
+        assert!(flatten(&usages, Some("nope")).is_empty());
+    }
+
+    /// Cycle ring for the `p` filter: display order, every group once.
+    #[test]
+    fn group_labels_follow_display_order() {
+        let usages = vec![
+            usage("A", true, &[("svc", Some("alpha"))]),
+            usage("B", true, &[]),
+            usage("C", false, &[("svc", None)]),
+        ];
+        assert_eq!(
+            group_labels(&usages),
+            vec!["global", "alpha", "broken refs"]
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implements #69 — the last v0.2.12 TUI item, building on the #68 prefix-key scheme:

| Key | Action |
|---|---|
| `a` | Add: command bar pre-filled with `:set ` (scope via `<project>.KEY`) |
| `e` | Edit: `:set <full stored key> ` pre-filled (values are never readable back, so edit takes a fresh value — same as `:set`) |
| `x` | Delete with a **y/N confirmation** rendered in the footer; broken-ref rows refuse with a hint |
| `p` | Cycle the scope filter: all → global → each project → broken refs (shown in the view title) |

Design notes:
- `a`/`e` reuse the existing command-bar machinery (mirrors the webhooks view) — no new input widgets.
- The delete confirm is the TUI's first y/N flow: `pending_secret_delete` on state, intercepted before normal key dispatch, footer prompt replaces key hints while armed.
- The filter lives inside `flatten()` so every consumer (render, j/k/g/G nav, selection clamp, `selected_key`) shares one view of the list — the cursor can never point at a hidden row.
- **Master-side fix**: the `secrets_usage` join predated #68 — a stored `inka.db_password` showed as an orphan while implicit refs from project `inka` counted against the global key. The join now mirrors deploy-time resolution exactly (implicit refs target the scoped key when stored, bare otherwise; explicit refs as written). Scoped keys group under their project and render their bare name.
- `keys.rs` split to stay under the 500-line gate: nav helpers → `secrets_actions.rs`, input-mode handlers → `input_keys.rs` (re-exported; call sites unchanged).

## Test plan

- New tests: filter shows only the matching group (and empty-filter safety), group-label cycle order, stored-scoped-key grouping; all existing flatten/infer_group tests updated for the two-arg `flatten`.
- Full workspace tests + fmt + `clippy -- -D warnings` + 500-line gate: green.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)