### PR TITLE
fix(control,agent): WS session liveness — half-dead sessions can't masquerade as healthy nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "mallorca"
-version = "0.2.11"
+version = "0.2.12-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2968,7 +2968,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orca-agent"
-version = "0.2.11"
+version = "0.2.12-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2995,7 +2995,7 @@ dependencies = [
 
 [[package]]
 name = "orca-ai"
-version = "0.2.11"
+version = "0.2.12-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "orca-control"
-version = "0.2.11"
+version = "0.2.12-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "orca-core"
-version = "0.2.11"
+version = "0.2.12-rc.1"
 dependencies = [
  "aes-gcm",
  "age",
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "orca-proxy"
-version = "0.2.11"
+version = "0.2.12-rc.1"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "orca-tui"
-version = "0.2.11"
+version = "0.2.12-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "orca-web"
-version = "0.2.11"
+version = "0.2.12-rc.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/wasm-hello"]
 
 [workspace.package]
-version = "0.2.11"
+version = "0.2.12-rc.1"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mighty840/orca"
@@ -24,9 +24,9 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Shared across crates
-orca-core = { path = "crates/orca-core", version = "0.2.11" }
-orca-ai = { path = "crates/orca-ai", version = "0.2.11" }
-orca-proxy = { path = "crates/orca-proxy", version = "0.2.11" }
+orca-core = { path = "crates/orca-core", version = "0.2.12-rc.1" }
+orca-ai = { path = "crates/orca-ai", version = "0.2.12-rc.1" }
+orca-proxy = { path = "crates/orca-proxy", version = "0.2.12-rc.1" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/orca-agent/src/ws_client/mod.rs
+++ b/crates/orca-agent/src/ws_client/mod.rs
@@ -1,7 +1,13 @@
 //! WebSocket client for agent→master streaming communication.
 //!
-//! Replaces the HTTP heartbeat polling with a persistent WS connection.
-//! Falls back to HTTP heartbeat if WS connection fails.
+//! The persistent WS connection is the agent's ONLY control/heartbeat
+//! channel (there is no HTTP fallback). The session read loop runs under a
+//! read-idle deadline (#131): the master sends `StatusPing` every 30s, so
+//! prolonged silence means the socket is half-open — the loop tears the
+//! session down and the outer reconnect loop re-establishes it with
+//! backoff. Without this, a half-open socket blocked the read forever
+//! while heartbeats buffered into a dead kernel send buffer, and the
+//! agent believed it was connected for days.
 
 mod adoption;
 mod backup;
@@ -129,7 +135,22 @@ async fn handle_ws_session(
     });
 
     // Process incoming master messages, passing out_tx for async responses.
-    while let Some(msg_result) = ws_rx.next().await {
+    // Read-idle deadline (#131): the master StatusPings every 30s; three
+    // missed intervals means the connection is half-dead — break so the
+    // reconnect loop replaces it. Detection window: ≤90s, no human needed.
+    const READ_IDLE: std::time::Duration = std::time::Duration::from_secs(90);
+    loop {
+        let msg_result = match tokio::time::timeout(READ_IDLE, ws_rx.next()).await {
+            Err(_) => {
+                warn!(
+                    "no traffic from master within {}s — closing half-dead session for reconnect",
+                    READ_IDLE.as_secs()
+                );
+                break;
+            }
+            Ok(None) => break,
+            Ok(Some(r)) => r,
+        };
         let msg = match msg_result {
             Ok(m) => m,
             Err(e) => {

--- a/crates/orca-cli/Cargo.toml
+++ b/crates/orca-cli/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/main.rs"
 [dependencies]
 orca-core = { workspace = true }
 orca-ai = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.11" }
-orca-control = { path = "../orca-control", version = "0.2.11" }
+orca-agent = { path = "../orca-agent", version = "0.2.12-rc.1" }
+orca-control = { path = "../orca-control", version = "0.2.12-rc.1" }
 orca-proxy = { workspace = true }
-orca-tui = { path = "../orca-tui", version = "0.2.11" }
+orca-tui = { path = "../orca-tui", version = "0.2.12-rc.1" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 
 [dependencies]
 orca-core = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.11" }
+orca-agent = { path = "../orca-agent", version = "0.2.12-rc.1" }
 orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }

--- a/crates/orca-control/src/api/handlers/ops/mod.rs
+++ b/crates/orca-control/src/api/handlers/ops/mod.rs
@@ -169,7 +169,11 @@ mod tests {
 
         // Register a fake WS sender for the agent.
         let (agent_tx, mut agent_rx) = tokio::sync::mpsc::channel::<MasterMessage>(4);
-        state.ws_agents.write().await.insert(node_id, agent_tx);
+        state
+            .ws_agents
+            .write()
+            .await
+            .insert(node_id, crate::state::AgentSession::new(agent_tx));
 
         // Spawn a task that simulates the agent responding with log chunks.
         let state_clone = state.clone();

--- a/crates/orca-control/src/backup_scheduler.rs
+++ b/crates/orca-control/src/backup_scheduler.rs
@@ -258,8 +258,8 @@ mod tests {
         let (tx2, mut rx2) = tokio::sync::mpsc::channel::<MasterMessage>(4);
         {
             let mut agents = state.ws_agents.write().await;
-            agents.insert(1, tx1);
-            agents.insert(2, tx2);
+            agents.insert(1, crate::state::AgentSession::new(tx1));
+            agents.insert(2, crate::state::AgentSession::new(tx2));
         }
 
         let config = BackupConfig {

--- a/crates/orca-control/src/lib.rs
+++ b/crates/orca-control/src/lib.rs
@@ -21,6 +21,7 @@ pub mod raft;
 pub mod reconciler;
 pub mod routes;
 pub mod scheduler;
+pub mod session;
 pub mod state;
 pub mod stats;
 pub mod store;

--- a/crates/orca-control/src/reconciler.rs
+++ b/crates/orca-control/src/reconciler.rs
@@ -427,8 +427,16 @@ async fn queue_remote_deploy(
         }
         Err(_) => {
             clear_pending_deploy(state, &spec.name).await;
+            // A missed receipt-ACK is proof the control session is dead
+            // (#131): the agent ACKs instantly when the channel works. Tear
+            // the session down so the node stops looking reachable and
+            // subsequent deploys fail fast with the real story — instead of
+            // every deploy re-timing-out against the same zombie tx for
+            // days. The agent's own idle deadline triggers its reconnect;
+            // a truly-gone node is stale-pruned 60s later.
+            crate::ws_handler::kill_agent_session(state, node_id, "deploy ACK timeout").await;
             anyhow::bail!(
-                "agent {node_id} did not acknowledge deploy of {} within {}s — agent may be unreachable or the WS session is dead",
+                "agent {node_id} did not acknowledge deploy of {} within {}s — control                  session closed; node is unreachable until it rejoins",
                 spec.name,
                 ack_timeout.as_secs()
             );

--- a/crates/orca-control/src/session.rs
+++ b/crates/orca-control/src/session.rs
@@ -1,0 +1,74 @@
+//! Agent control-session lifecycle (#131).
+//!
+//! A session wraps the master→agent sender with a generation id and a kill
+//! switch; presence in `AppState.ws_agents` is the master's definition of
+//! "reachable". The read-idle deadline in `ws_handler` guarantees entries
+//! are live by construction — a session that stops producing traffic is
+//! torn down, taking the node's reachability and placeholders with it.
+
+use std::sync::Arc;
+
+use crate::state::AppState;
+
+/// One agent control session (#131). Wraps the master→agent sender with a
+/// generation id and a kill switch so session lifecycle is explicit:
+///
+/// - `session_id` disambiguates reconnects — a superseded session's cleanup
+///   must never remove its replacement's map entry or placeholders.
+/// - `shutdown` wakes the session's read loop for immediate teardown
+///   (superseded by a reconnect, or killed after a deploy-ACK timeout).
+#[derive(Debug, Clone)]
+pub struct AgentSession {
+    pub tx: crate::ws_handler::AgentSender,
+    pub session_id: u64,
+    pub shutdown: Arc<tokio::sync::Notify>,
+}
+
+impl AgentSession {
+    /// Send a message to the agent over this session's channel. Delegates
+    /// to the inner sender so call sites treat a session like the sender
+    /// they always held.
+    pub async fn send(
+        &self,
+        msg: orca_core::ws_types::MasterMessage,
+    ) -> Result<(), tokio::sync::mpsc::error::SendError<orca_core::ws_types::MasterMessage>> {
+        self.tx.send(msg).await
+    }
+
+    pub fn new(tx: crate::ws_handler::AgentSender) -> Self {
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        AgentSession {
+            tx,
+            session_id: COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            shutdown: Arc::new(tokio::sync::Notify::new()),
+        }
+    }
+}
+
+impl AppState {
+    /// Clone the current control-session sender for a node, if connected.
+    pub async fn agent_tx(&self, node_id: u64) -> Option<crate::ws_handler::AgentSender> {
+        self.ws_agents
+            .read()
+            .await
+            .get(&node_id)
+            .map(|s| s.tx.clone())
+    }
+
+    /// Deregister a session's map entry iff it still owns it (#131).
+    /// Returns whether the caller was the owner — a superseded session
+    /// exiting late gets `false` and must not touch its replacement's
+    /// placeholders.
+    pub async fn deregister_agent_session(&self, node_id: u64, session_id: u64) -> bool {
+        let mut senders = self.ws_agents.write().await;
+        if senders
+            .get(&node_id)
+            .is_some_and(|s| s.session_id == session_id)
+        {
+            senders.remove(&node_id);
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/crates/orca-control/src/state.rs
+++ b/crates/orca-control/src/state.rs
@@ -13,6 +13,7 @@ use orca_core::types::{HealthState, Replicas, WorkloadStatus};
 use crate::stats::ContainerStats;
 use crate::webhook::WebhookStore;
 
+pub use crate::session::AgentSession;
 pub use orca_proxy::{RouteTarget, SharedWasmTriggers, WasmTrigger};
 
 /// Shared route table type, compatible with [`orca_proxy::run_proxy`].
@@ -51,8 +52,11 @@ pub struct AppState {
     pub container_stats: RwLock<HashMap<String, ContainerStats>>,
     /// Persistent cluster store (redb). None in tests without persistence.
     pub store: Option<Arc<crate::store::ClusterStore>>,
-    /// WebSocket senders for connected agent nodes, keyed by node_id.
-    pub ws_agents: RwLock<HashMap<u64, crate::ws_handler::AgentSender>>,
+    /// Control sessions for connected agent nodes, keyed by node_id (#131).
+    /// Presence in this map is the master's definition of "reachable" — a
+    /// session that stops producing traffic is torn down by the read-idle
+    /// deadline in `ws_handler`, so entries here are live by construction.
+    pub ws_agents: RwLock<HashMap<u64, AgentSession>>,
     /// Log stream listeners: request_id → (data, done) sender.
     pub log_listeners: RwLock<HashMap<String, tokio::sync::mpsc::Sender<(String, bool)>>>,
     /// Backup status listeners: request_id → report sender. Used by the

--- a/crates/orca-control/src/ws_handler/mod.rs
+++ b/crates/orca-control/src/ws_handler/mod.rs
@@ -39,6 +39,26 @@ pub struct WsQuery {
 /// Per-node sender so the master can push messages to a connected agent.
 pub type AgentSender = mpsc::Sender<MasterMessage>;
 
+/// Tear down a node's control session immediately (#131): remove it from
+/// the session map (so the node stops looking reachable NOW), wake its
+/// read loop so the task exits, and drop the node's remote placeholders
+/// (so status stops reporting last-known state as current). Used when the
+/// session is proven dead — e.g. a deploy ACK timeout. The agent's own
+/// read-idle deadline triggers its reconnect; a truly-gone node is
+/// stale-pruned 60s later.
+pub(crate) async fn kill_agent_session(state: &AppState, node_id: u64, reason: &str) {
+    let session = state.ws_agents.write().await.remove(&node_id);
+    let Some(session) = session else { return };
+    warn!(
+        node_id,
+        session_id = session.session_id,
+        reason,
+        "killing agent control session"
+    );
+    session.shutdown.notify_waiters();
+    remove_remote_placeholders(state, node_id).await;
+}
+
 /// Handle the WebSocket upgrade request.
 ///
 /// Authenticates via the `token` query param, then upgrades to a
@@ -80,13 +100,26 @@ async fn handle_agent_ws(
     // Channel for master → agent messages (deploy commands, log requests, etc.)
     let (tx, mut rx) = mpsc::channel::<MasterMessage>(64);
 
-    // Register this agent's sender so other parts of the system can push messages.
+    // Register this session. A reconnect from the same node supersedes the
+    // old session (#131): wake its read loop so it tears down immediately —
+    // its generation-guarded cleanup can't touch our fresh entry.
+    let session = crate::state::AgentSession::new(tx.clone());
+    let session_id = session.session_id;
+    let shutdown = session.shutdown.clone();
     {
         let mut senders = state.ws_agents.write().await;
-        senders.insert(node_id, tx.clone());
+        if let Some(old) = senders.insert(node_id, session) {
+            info!(
+                node_id,
+                old_session = old.session_id,
+                new_session = session_id,
+                "agent reconnected — superseding previous control session"
+            );
+            old.shutdown.notify_waiters();
+        }
     }
 
-    info!("Agent {node_id} connected via WebSocket");
+    info!("Agent {node_id} connected via WebSocket (session {session_id})");
 
     // Register/update the node in registered_nodes so the reconciler's
     // find_target_node() can match placement constraints to this agent.
@@ -133,6 +166,9 @@ async fn handle_agent_ws(
     send_reconcile(&state, node_id, &tx).await;
 
     // Spawn task to forward master→agent messages from the channel to the WS.
+    // A send failure is proof the socket is dead — wake the read loop so the
+    // session tears down now instead of waiting out the idle deadline.
+    let send_shutdown = shutdown.clone();
     let send_task = tokio::spawn(async move {
         while let Some(msg) = rx.recv().await {
             let json = match serde_json::to_string(&msg) {
@@ -143,7 +179,8 @@ async fn handle_agent_ws(
                 }
             };
             if ws_tx.send(Message::Text(json.into())).await.is_err() {
-                break; // connection closed
+                send_shutdown.notify_waiters();
+                break;
             }
         }
     });
@@ -161,28 +198,55 @@ async fn handle_agent_ws(
         }
     });
 
-    // Process incoming agent messages.
-    while let Some(Ok(msg)) = ws_rx.next().await {
-        match msg {
-            Message::Text(text) => {
-                if let Err(e) = handle_agent_message(&state, node_id, &text, &tx).await {
-                    warn!("Error handling agent message from {node_id}: {e}");
-                }
+    // Process incoming agent messages under a read-idle deadline (#131).
+    // Healthy agents heartbeat every 5s, so IDLE seconds of silence means
+    // the socket is half-open (peer gone without FIN/RST) — the exact
+    // failure that previously left a zombie session serving stale state
+    // for days. Session liveness IS deploy-channel liveness: no traffic,
+    // no session.
+    let idle = std::time::Duration::from_secs(state.cluster_config.deploy.ws_idle_timeout_secs);
+    loop {
+        tokio::select! {
+            _ = shutdown.notified() => {
+                info!(node_id, session_id, "control session shut down (superseded or killed)");
+                break;
             }
-            Message::Close(_) => break,
-            _ => {} // ignore binary, ping, pong (axum handles pong auto)
+            next = tokio::time::timeout(idle, ws_rx.next()) => match next {
+                Err(_) => {
+                    warn!(
+                        node_id, session_id, idle_secs = idle.as_secs(),
+                        "no traffic from agent within idle deadline — closing half-dead session"
+                    );
+                    break;
+                }
+                Ok(None) => break,
+                Ok(Some(Err(e))) => {
+                    warn!(node_id, session_id, "WebSocket read error: {e}");
+                    break;
+                }
+                Ok(Some(Ok(msg))) => match msg {
+                    Message::Text(text) => {
+                        if let Err(e) = handle_agent_message(&state, node_id, &text, &tx).await {
+                            warn!("Error handling agent message from {node_id}: {e}");
+                        }
+                    }
+                    Message::Close(_) => break,
+                    _ => {} // ignore binary, ping, pong (axum handles pong auto)
+                },
+            }
         }
     }
 
-    // Cleanup on disconnect
+    // Cleanup on disconnect — generation-guarded (#131): only the session
+    // that still owns the map entry may deregister the node and drop its
+    // placeholders. A superseded session exiting late must not tear down
+    // its replacement's state (the old last-writer-cleanup race).
     send_task.abort();
     ping_task.abort();
-    {
-        let mut senders = state.ws_agents.write().await;
-        senders.remove(&node_id);
+    if state.deregister_agent_session(node_id, session_id).await {
+        remove_remote_placeholders(&state, node_id).await;
     }
-    remove_remote_placeholders(&state, node_id).await;
-    info!("Agent {node_id} WebSocket disconnected");
+    info!("Agent {node_id} WebSocket disconnected (session {session_id})");
 }
 
 /// Process a single message from the agent.

--- a/crates/orca-control/tests/declarative_test.rs
+++ b/crates/orca-control/tests/declarative_test.rs
@@ -165,7 +165,11 @@ async fn remote_deploy_without_ack_is_not_redeployed_every_cycle() {
         },
     );
     let (tx, mut rx) = tokio::sync::mpsc::channel::<MasterMessage>(16);
-    state.ws_agents.write().await.insert(7, tx);
+    state
+        .ws_agents
+        .write()
+        .await
+        .insert(7, orca_control::state::AgentSession::new(tx));
 
     let dir = tmp.path().to_str().unwrap();
     // Two reconcile passes — the agent never acks, so each deploy attempt errors,

--- a/crates/orca-control/tests/deploy_timeout_test.rs
+++ b/crates/orca-control/tests/deploy_timeout_test.rs
@@ -104,7 +104,11 @@ async fn ack_timeout_reports_unreachable_distinctly() {
     // Register a WS sender whose receiver we hold open, so the Deploy send
     // succeeds but nothing ever replies with DeployReceived.
     let (tx, _rx) = tokio::sync::mpsc::channel::<MasterMessage>(8);
-    state.ws_agents.write().await.insert(1, tx);
+    state
+        .ws_agents
+        .write()
+        .await
+        .insert(1, orca_control::state::AgentSession::new(tx));
 
     let cfg = config_placed_on("svc", "1");
     let (deployed, errors) = orca_control::reconciler::reconcile(&state, &[cfg]).await;
@@ -124,6 +128,23 @@ async fn ack_timeout_reports_unreachable_distinctly() {
     // Both waiter maps must be cleaned up so they don't leak.
     assert!(state.pending_deploy_acks.read().await.is_empty());
     assert!(state.pending_deploys.read().await.is_empty());
+
+    // #131: a missed ACK is proof the control session is dead — it must be
+    // torn down so the node stops looking reachable and the next deploy
+    // fails fast with the real story instead of re-timing-out forever.
+    assert!(
+        state.ws_agents.read().await.is_empty(),
+        "dead control session must be killed after ACK timeout"
+    );
+    // And the node's remote placeholders must be gone, so status stops
+    // reporting last-known state as current.
+    let services = state.services.read().await;
+    if let Some(svc) = services.get("svc") {
+        assert!(
+            svc.instances.is_empty(),
+            "remote placeholders must be removed with the dead session"
+        );
+    }
 }
 
 /// Once the agent acknowledges receipt, a real deploy failure (e.g. image not
@@ -134,7 +155,11 @@ async fn real_agent_error_propagates_after_ack() {
     register_node(&state, 1).await;
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<MasterMessage>(8);
-    state.ws_agents.write().await.insert(1, tx);
+    state
+        .ws_agents
+        .write()
+        .await
+        .insert(1, orca_control::state::AgentSession::new(tx));
 
     let cfg = config_placed_on("svc", "1");
     let state_c = state.clone();

--- a/crates/orca-control/tests/e2e_drain_test.rs
+++ b/crates/orca-control/tests/e2e_drain_test.rs
@@ -61,7 +61,11 @@ async fn e2e_drain_prevents_remote_dispatch() {
 
     // Wire up a WS sender for node 7 so placement can succeed, then drain it.
     let (tx, mut rx) = tokio::sync::mpsc::channel::<MasterMessage>(8);
-    state.ws_agents.write().await.insert(7, tx);
+    state
+        .ws_agents
+        .write()
+        .await
+        .insert(7, orca_control::state::AgentSession::new(tx));
     state
         .registered_nodes
         .write()
@@ -86,7 +90,11 @@ async fn e2e_undrained_node_receives_dispatch() {
     register_node(&state, 8).await;
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<MasterMessage>(8);
-    state.ws_agents.write().await.insert(8, tx);
+    state
+        .ws_agents
+        .write()
+        .await
+        .insert(8, orca_control::state::AgentSession::new(tx));
 
     let services = services_json("e2e-active-svc", 8);
     orca_control::reconciler::reconcile(&state, &services).await;
@@ -105,7 +113,11 @@ async fn e2e_drain_then_undrain_allows_dispatch() {
     register_node(&state, 9).await;
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<MasterMessage>(8);
-    state.ws_agents.write().await.insert(9, tx);
+    state
+        .ws_agents
+        .write()
+        .await
+        .insert(9, orca_control::state::AgentSession::new(tx));
 
     // Drain — deploy should be skipped.
     state

--- a/crates/orca-control/tests/ws_integration_test.rs
+++ b/crates/orca-control/tests/ws_integration_test.rs
@@ -386,3 +386,82 @@ async fn ws_cleanup_on_disconnect() {
         );
     }
 }
+
+/// #131 regression: a session that stops producing traffic (half-open
+/// socket — peer gone without FIN/RST) must be torn down by the master's
+/// read-idle deadline, removing the node from `ws_agents` without any
+/// close frame or error ever arriving.
+#[tokio::test]
+async fn half_dead_session_is_closed_by_idle_deadline() {
+    let container_runtime = Arc::new(orca_core::testing::MockRuntime::new());
+    let mut cluster_config = ClusterConfig::default();
+    cluster_config.api_tokens = vec!["test-token-123".to_string()];
+    cluster_config.deploy.ws_idle_timeout_secs = 1; // fast test
+    let state = Arc::new(orca_control::state::AppState::new(
+        cluster_config,
+        container_runtime,
+        None,
+        Arc::new(RwLock::new(HashMap::new())),
+        Arc::new(RwLock::new(Vec::new())),
+    ));
+    let addr = start_server(state.clone()).await;
+
+    let url = format!("ws://{addr}/api/v1/ws/agent?token=test-token-123&node_id=77");
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    // Drain the Ack so the connection is fully established.
+    let _ = tokio::time::timeout(Duration::from_secs(2), ws.next()).await;
+    assert!(
+        state.ws_agents.read().await.contains_key(&77),
+        "session must be registered after connect"
+    );
+
+    // Go silent — no heartbeats, no close frame. The socket stays open,
+    // exactly like a half-dead connection. The idle deadline must fire.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if !state.ws_agents.read().await.contains_key(&77) {
+            break; // torn down — pass
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "half-dead session was not torn down within 5s (idle deadline 1s)"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// #131 regression: a reconnect from the same node supersedes the old
+/// session, and the old session's (later) cleanup must NOT remove the new
+/// session's registration — the old last-writer-cleanup race.
+#[tokio::test]
+async fn reconnect_supersedes_without_clobbering_new_session() {
+    let state = test_state();
+    let addr = start_server(state.clone()).await;
+    let url = format!("ws://{addr}/api/v1/ws/agent?token=test-token-123&node_id=88");
+
+    // First connection.
+    let (mut ws1, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(2), ws1.next()).await;
+    let first_id = state.ws_agents.read().await.get(&88).unwrap().session_id;
+
+    // Second connection from the same node — supersedes the first.
+    let (mut ws2, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(2), ws2.next()).await;
+    let second_id = state.ws_agents.read().await.get(&88).unwrap().session_id;
+    assert_ne!(first_id, second_id, "reconnect must install a new session");
+
+    // Close the FIRST (superseded) socket and give its cleanup time to run.
+    ws1.close(None).await.ok();
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // The new session must still be registered — the old session's exit
+    // must not have deregistered node 88.
+    let current = state.ws_agents.read().await.get(&88).map(|s| s.session_id);
+    assert_eq!(
+        current,
+        Some(second_id),
+        "old session's cleanup clobbered the new session"
+    );
+
+    ws2.close(None).await.ok();
+}

--- a/crates/orca-core/src/config/cluster.rs
+++ b/crates/orca-core/src/config/cluster.rs
@@ -162,6 +162,12 @@ pub struct DeployConfig {
     /// Interval in seconds between orphan-adoption scans. Default 30.
     #[serde(default = "default_adopt_interval")]
     pub adopt_interval_secs: u64,
+    /// Read-idle deadline on each agent control session (#131). Healthy
+    /// agents heartbeat every 5s; this many seconds of silence closes the
+    /// session as half-dead, marking the node unreachable until it
+    /// rejoins. Default 30.
+    #[serde(default = "default_ws_idle_timeout")]
+    pub ws_idle_timeout_secs: u64,
 }
 
 impl Default for DeployConfig {
@@ -171,6 +177,7 @@ impl Default for DeployConfig {
             completion_timeout_secs: default_deploy_completion_timeout(),
             adopt_orphans: default_adopt_orphans(),
             adopt_interval_secs: default_adopt_interval(),
+            ws_idle_timeout_secs: default_ws_idle_timeout(),
         }
     }
 }
@@ -185,6 +192,10 @@ fn default_deploy_completion_timeout() -> u64 {
 
 fn default_adopt_orphans() -> bool {
     true
+}
+
+fn default_ws_idle_timeout() -> u64 {
+    30
 }
 
 fn default_adopt_interval() -> u64 {

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -58,6 +58,7 @@ ack_timeout_secs = 10          # agent must acknowledge a deploy within this, el
 completion_timeout_secs = 600  # time for the agent to pull the image + start (covers multi-GB pulls)
 adopt_orphans = true           # adopt orca.managed containers running on an agent but missing from the registry
 adopt_interval_secs = 30       # how often to scan agents for orphans
+ws_idle_timeout_secs = 30      # silence window before an agent control session is declared dead (#131)
 
 # Declarative reconciliation (K8s-style) — opt-in. When set, the master
 # continuously applies a directory of service configs: drop in a service.toml


### PR DESCRIPTION
## Summary

Fixes #131 and the recurring #84/#85/#90 family at its root: **node liveness was tracked separately from the control channel the master dispatches over.** A half-open socket was invisible to both peers — master read loop blocked forever, `ws_agents` entry immortal, the #85 anti-orphan rule kept the node 'healthy' regardless of heartbeat age, deploys re-timed-out against the same dead tx for 10 days, and placeholders served 14-hour-stale `Running`.

**The fix: session liveness = deploy-channel liveness**, built on traffic both sides already send (agent heartbeats 5s, master StatusPings 30s) — zero protocol changes:

| Mechanism | Effect |
|---|---|
| Master read-idle deadline (`[deploy].ws_idle_timeout_secs`, default 30s) | Silent session → torn down: map entry + placeholders removed, node unreachable |
| Agent read-idle deadline (90s = 3 missed StatusPings) | Half-dead socket → session breaks → existing backoff loop reconnects, **no manual restart** |
| ACK timeout kills the session | Next deploy fails fast with `node is unreachable until it rejoins` — never re-times-out against a zombie tx |
| Generation-guarded cleanup (`AgentSession.session_id`) | A superseded session's late exit can no longer clobber its replacement's registration (latent reconnect race, also fixed) |
| Send-failure wakes the read loop | Immediate teardown instead of ~15min TCP retransmit limbo |

Stale-status honesty follows **structurally**: placeholder state only exists while a live session refreshes it every 5s — when the session dies, the placeholders die with it. No timestamps or labels needed; the lie is simply unrepresentable.

New `session.rs` module holds `AgentSession` + lifecycle helpers; `ws_agents` map now stores sessions (call sites unchanged via a delegating `send()`).

## Test plan (the adversarial test previous fixes never had)

- **`half_dead_session_is_closed_by_idle_deadline`**: real WS connect, then total silence with the TCP socket held open → master tears the session down within the idle window. This is the exact prod failure mode.
- **`reconnect_supersedes_without_clobbering_new_session`**: double-connect same node, close the old socket late → new session survives.
- `ack_timeout_reports_unreachable_distinctly` extended: asserts session death + placeholder removal after a missed ACK.
- Full workspace tests + fmt + `clippy -- -D warnings` + size gate: green.

Ships in v0.2.12-rc.1 (tag held for this).

Fixes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)