### PR TITLE
fix(tests): nightly E2E repair — serve all test harnesses with connect_info

### DIFF
--- a/crates/orca-control/src/ws_handler/mod.rs
+++ b/crates/orca-control/src/ws_handler/mod.rs
@@ -85,7 +85,12 @@ pub async fn ws_agent_handler(
     let address = query.address;
     info!("WebSocket upgrade accepted for node {node_id}");
 
-    ws.on_upgrade(move |socket| handle_agent_ws(socket, state, node_id, address, peer.ip()))
+    // NOTE: requires the server to be built with
+    // `into_make_service_with_connect_info::<SocketAddr>()` — axum rejects
+    // the upgrade with a 500 otherwise. All production and test serve
+    // paths do; keep it that way when adding harnesses.
+    let peer_ip = Some(peer.ip());
+    ws.on_upgrade(move |socket| handle_agent_ws(socket, state, node_id, address, peer_ip))
         .into_response()
 }
 
@@ -95,7 +100,7 @@ async fn handle_agent_ws(
     state: Arc<AppState>,
     node_id: u64,
     agent_address: Option<String>,
-    peer_ip: std::net::IpAddr,
+    peer_ip: Option<std::net::IpAddr>,
 ) {
     let (mut ws_tx, mut ws_rx) = socket.split();
 
@@ -147,10 +152,11 @@ async fn handle_agent_ws(
             });
         node.last_heartbeat = chrono::Utc::now();
         node.address = addr;
-        node.peer_ip = Some(peer_ip.to_string());
+        node.peer_ip = peer_ip.map(|ip| ip.to_string());
         info!(
-            "Node {node_id} registered at {} (peer {peer_ip})",
-            node.address
+            "Node {node_id} registered at {} (peer {})",
+            node.address,
+            node.peer_ip.as_deref().unwrap_or("unknown")
         );
     }
 

--- a/crates/orca-control/tests/concurrent_deploy_test.rs
+++ b/crates/orca-control/tests/concurrent_deploy_test.rs
@@ -37,7 +37,14 @@ async fn test_concurrent_deploys_no_panic() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
     let app = router(state.clone());
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let client = reqwest::Client::new();

--- a/crates/orca-control/tests/e2e_auth_test.rs
+++ b/crates/orca-control/tests/e2e_auth_test.rs
@@ -42,7 +42,14 @@ async fn start_authed_server() -> (u16, Arc<AppState>) {
         Arc::new(RwLock::new(Vec::new())),
     ));
     let app = orca_control::api::router(state.clone());
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     tokio::time::sleep(Duration::from_millis(100)).await;
     (port, state)
 }

--- a/crates/orca-control/tests/e2e_cluster_backups_with_agent_test.rs
+++ b/crates/orca-control/tests/e2e_cluster_backups_with_agent_test.rs
@@ -53,7 +53,14 @@ async fn start_authed_server() -> u16 {
         Arc::new(RwLock::new(Vec::new())),
     ));
     let app = orca_control::api::router(state);
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     tokio::time::sleep(Duration::from_millis(100)).await;
     port
 }

--- a/crates/orca-control/tests/e2e_cluster_networks_with_agent_test.rs
+++ b/crates/orca-control/tests/e2e_cluster_networks_with_agent_test.rs
@@ -53,7 +53,14 @@ async fn start_authed_server() -> u16 {
         Arc::new(RwLock::new(Vec::new())),
     ));
     let app = orca_control::api::router(state);
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     tokio::time::sleep(Duration::from_millis(100)).await;
     port
 }

--- a/crates/orca-control/tests/e2e_failures_test.rs
+++ b/crates/orca-control/tests/e2e_failures_test.rs
@@ -86,7 +86,14 @@ async fn e2e_container_exit_nonzero_detected() {
     let port = listener.local_addr().unwrap().port();
     let state = test_state(port);
     let app = orca_control::api::router(state.clone());
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let client = Client::new(port);
@@ -134,7 +141,14 @@ async fn e2e_deploy_invalid_image() {
     let port = listener.local_addr().unwrap().port();
     let state = test_state(port);
     let app = orca_control::api::router(state.clone());
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let client = Client::new(port);
@@ -179,7 +193,14 @@ async fn e2e_container_manually_removed() {
     let state = test_state(port);
 
     let app = orca_control::api::router(state.clone());
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     orca_control::watchdog::spawn_watchdog(state.clone());
     tokio::time::sleep(Duration::from_millis(100)).await;
 

--- a/crates/orca-control/tests/e2e_health_unhealthy_test.rs
+++ b/crates/orca-control/tests/e2e_health_unhealthy_test.rs
@@ -66,7 +66,14 @@ async fn e2e_health_checker_marks_unhealthy() {
     let state = test_state(port);
 
     let app = orca_control::api::router(state.clone());
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Deploy with a liveness probe path that will always 404. Explicit

--- a/crates/orca-control/tests/e2e_helpers.rs
+++ b/crates/orca-control/tests/e2e_helpers.rs
@@ -40,7 +40,12 @@ pub async fn start_server() -> (u16, Arc<AppState>, tokio::task::JoinHandle<()>)
     let app = orca_control::api::router(state.clone());
 
     let handle = tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap();
     });
 
     // Wait for server to be ready

--- a/crates/orca-control/tests/e2e_network_test.rs
+++ b/crates/orca-control/tests/e2e_network_test.rs
@@ -35,7 +35,14 @@ async fn start_server() -> (u16, Arc<AppState>) {
     let port = listener.local_addr().unwrap().port();
     let state = test_state(port);
     let app = orca_control::api::router(state.clone());
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     tokio::time::sleep(Duration::from_millis(100)).await;
     (port, state)
 }

--- a/crates/orca-control/tests/e2e_proxy_test.rs
+++ b/crates/orca-control/tests/e2e_proxy_test.rs
@@ -43,7 +43,12 @@ async fn start_server() -> (u16, Arc<AppState>, tokio::task::JoinHandle<()>) {
     let app = orca_control::api::router(state.clone());
 
     let handle = tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap();
     });
 
     tokio::time::sleep(Duration::from_millis(100)).await;

--- a/crates/orca-control/tests/e2e_rbac_test.rs
+++ b/crates/orca-control/tests/e2e_rbac_test.rs
@@ -68,7 +68,14 @@ async fn start_rbac_server() -> u16 {
         Arc::new(RwLock::new(Vec::new())),
     ));
     let app = orca_control::api::router(state);
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     tokio::time::sleep(Duration::from_millis(100)).await;
     port
 }

--- a/crates/orca-control/tests/e2e_resources_test.rs
+++ b/crates/orca-control/tests/e2e_resources_test.rs
@@ -65,7 +65,12 @@ async fn e2e_deploy_with_resource_limits() {
     let app = orca_control::api::router(state.clone());
 
     let _handle = tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap();
     });
     tokio::time::sleep(Duration::from_millis(100)).await;
 

--- a/crates/orca-control/tests/e2e_rolling_multi_test.rs
+++ b/crates/orca-control/tests/e2e_rolling_multi_test.rs
@@ -64,7 +64,14 @@ async fn e2e_rolling_update_multi_replica() {
     let state = test_state(port);
 
     let app = orca_control::api::router(state.clone());
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let client = reqwest::Client::new();

--- a/crates/orca-control/tests/e2e_selfheal_helpers.rs
+++ b/crates/orca-control/tests/e2e_selfheal_helpers.rs
@@ -35,7 +35,14 @@ pub async fn start_server_with_watchdog() -> (u16, Arc<AppState>) {
 
     // Spawn API
     let app = orca_control::api::router(state.clone());
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
 
     // Spawn watchdog and health checker
     orca_control::watchdog::spawn_watchdog(state.clone());

--- a/crates/orca-control/tests/state_edge_test.rs
+++ b/crates/orca-control/tests/state_edge_test.rs
@@ -37,7 +37,14 @@ async fn test_concurrent_deploys_same_service() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
     let app = router(state.clone());
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let client = reqwest::Client::new();
@@ -84,7 +91,14 @@ async fn test_stop_nonexistent_service() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
     let app = router(state.clone());
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let client = reqwest::Client::new();
@@ -109,7 +123,14 @@ async fn test_deploy_then_immediately_stop() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
     let app = router(state.clone());
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let client = reqwest::Client::new();
@@ -161,7 +182,14 @@ async fn test_redeploy_with_fewer_replicas() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
     let app = router(state.clone());
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let client = reqwest::Client::new();

--- a/crates/orca-control/tests/ws_integration_test.rs
+++ b/crates/orca-control/tests/ws_integration_test.rs
@@ -420,6 +420,18 @@ async fn half_dead_session_is_closed_by_idle_deadline() {
         state.ws_agents.read().await.contains_key(&77),
         "session must be registered after connect"
     );
+    // #135: the peer IP must be captured when the server is served with
+    // connect_info — guards against the prod serve path losing it.
+    assert_eq!(
+        state
+            .registered_nodes
+            .read()
+            .await
+            .get(&77)
+            .and_then(|n| n.peer_ip.clone()),
+        Some("127.0.0.1".to_string()),
+        "peer IP must be recorded from ConnectInfo"
+    );
 
     // Go silent — no heartbeats, no close frame. The socket stays open,
     // exactly like a half-dead connection. The idle deadline must fire.


### PR DESCRIPTION
The #135 `ConnectInfo` requirement 500s the WS upgrade on servers built without `into_make_service_with_connect_info`. The two agent-connecting E2E harnesses weren't converted, and being `#[ignore]`d they only run in the nightly — which failed Jul 18 + 19 while PR CI stayed green.

- All 14 control-plane test harnesses now serve with connect_info uniformly.
- `ws_integration_test` asserts `peer_ip` is captured (guards the prod serve path).
- Handler comment documents the serve requirement.
- Verified: the complete `--ignored` nightly suite passes locally — the gate that was missing from the pre-push pipeline both times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)