### PR TITLE
chore: portable dev-profile build tuning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,20 @@ authors = ["Sharang <sharang@meghsakha.com>"]
 keywords = ["orchestrator", "container", "wasm", "docker", "kubernetes"]
 categories = ["command-line-utilities"]
 
+# Portable build tuning (machine/infra-specific settings — jobs, mold linker,
+# the Kellnr registry mirror, RUSTC_WRAPPER=sccache — stay in each dev's local
+# ~/.cargo/config.toml, not here).
+[profile.dev]
+# Full debuginfo makes each debug test binary ~400MB; one `cargo test
+# --workspace` regenerates 30-40GB. Line tables keep file:line backtraces at
+# ~1/10th the size.
+debug = "line-tables-only"
+# sccache cannot cache incremental compilation and silently passes through
+# when it's on. Off = sccache actually caches every crate build (so rebuilds
+# after a `cargo clean` are mostly cache hits) and no multi-GB
+# target/debug/incremental dir. CI already builds with CARGO_INCREMENTAL=0.
+incremental = false
+
 [workspace.dependencies]
 # Shared across crates
 orca-core = { path = "crates/orca-core", version = "0.2.12-rc.4" }


### PR DESCRIPTION
Adds `[profile.dev]` to the workspace `Cargo.toml` with the two build settings worth sharing repo-wide:

- `debug = "line-tables-only"` — ~10x smaller debug binaries (a full `cargo test --workspace` was regenerating 30-40GB), backtraces intact.
- `incremental = false` — sccache can't cache incremental compilation and silently passes through; off makes `RUSTC_WRAPPER=sccache` actually cache, so post-`cargo clean` rebuilds are mostly cache hits. CI already runs `CARGO_INCREMENTAL=0`.

**Not** committed (machine/infra-specific — belong in each dev's `~/.cargo/config.toml`): `jobs`, the mold linker, the private Kellnr registry mirror, and `RUSTC_WRAPPER=sccache`. Committing the Kellnr mirror especially would break CI/other builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)