### PR TITLE
fix(control): restore disk/net node metrics in cluster/info (TUI regression)

### DIFF
--- a/crates/orca-control/src/cluster_handlers.rs
+++ b/crates/orca-control/src/cluster_handlers.rs
@@ -47,16 +47,18 @@ pub async fn cluster_info(State(state): State<Arc<AppState>>) -> impl IntoRespon
                 .find(|d| d.address == n.address || host(&d.address) == host(&n.address))
                 .map(|d| d.gpus.clone())
                 .unwrap_or_default();
-            serde_json::json!({
-                "node_id": n.node_id,
-                "address": n.address,
-                "labels": n.labels,
-                "last_heartbeat": n.last_heartbeat,
-                "cpu_percent": n.cpu_percent,
-                "memory_bytes": n.memory_bytes,
-                "memory_total": n.memory_total,
-                "gpus": gpus,
-            })
+            // Serialize the WHOLE node, then enrich with GPUs. Hand-listing
+            // fields (as this did between #135 and now) silently dropped
+            // disk_used/disk_total/net_rx/net_tx — they're `#[serde(default)]`
+            // on the TUI side, so they read as 0 (blank) rather than erroring.
+            let mut obj = serde_json::to_value(n).unwrap_or_else(|_| serde_json::json!({}));
+            if let Some(map) = obj.as_object_mut() {
+                map.insert(
+                    "gpus".to_string(),
+                    serde_json::to_value(&gpus).unwrap_or_default(),
+                );
+            }
+            obj
         })
         .collect();
     Json(serde_json::json!({

--- a/crates/orca-control/tests/cluster_info_test.rs
+++ b/crates/orca-control/tests/cluster_info_test.rs
@@ -56,14 +56,14 @@ async fn start() -> u16 {
             address: "gpu-box:6881".into(),
             labels: HashMap::new(),
             last_heartbeat: chrono::Utc::now(),
-            drain: false,
-            cpu_percent: 0.0,
-            memory_bytes: 0,
-            memory_total: 0,
-            disk_used: 0,
-            disk_total: 0,
-            net_rx: 0,
-            net_tx: 0,
+            drain: true,
+            cpu_percent: 42.5,
+            memory_bytes: 100,
+            memory_total: 200,
+            disk_used: 300,
+            disk_total: 400,
+            net_rx: 500,
+            net_tx: 600,
         },
     );
     let app = orca_control::api::router(state);
@@ -104,4 +104,19 @@ async fn cluster_info_requires_auth_and_surfaces_gpus() {
     assert_eq!(node["node_id"], 7);
     assert_eq!(node["gpus"][0]["model"], "A100");
     assert_eq!(node["gpus"][0]["count"], 2);
+
+    // Regression guard (#143 rc.4 dropped these when cluster_info switched to
+    // hand-built JSON — the TUI Disk/Net columns went blank because the
+    // fields default to 0). Every heartbeat-reported metric must survive.
+    assert_eq!(node["cpu_percent"], 42.5, "cpu missing");
+    assert_eq!(node["memory_bytes"], 100, "mem missing");
+    assert_eq!(node["memory_total"], 200);
+    assert_eq!(
+        node["disk_used"], 300,
+        "disk_used missing (the reported bug)"
+    );
+    assert_eq!(node["disk_total"], 400, "disk_total missing");
+    assert_eq!(node["net_rx"], 500, "net_rx missing (the reported bug)");
+    assert_eq!(node["net_tx"], 600, "net_tx missing");
+    assert_eq!(node["drain"], true, "drain missing");
 }


### PR DESCRIPTION
## Bug
The TUI Nodes view shows CPU/Mem but **Disk and Net are blank** — a regression in **rc.4 (#143)**.

## Cause
#143 rewrote `cluster_info` to hand-build each node's JSON (to enrich with declared GPUs). It listed `cpu_percent`/`memory_*` but omitted `disk_used`, `disk_total`, `net_rx`, `net_tx`. The TUI's `NodeInfo` fields are `#[serde(default)]`, so the missing fields deserialized to `0` (blank) instead of erroring — hence CPU/Mem visible, Disk/Net blank. Before #143 the handler serialized the whole `RegisteredNode`, so every field was present.

## Fix
Serialize the full `RegisteredNode` and inject `gpus`, rather than re-listing fields — a field can never be silently dropped again. Regression test asserts cpu/mem/disk/net/drain all survive the endpoint.

Fixes the blank Disk/Net columns; ships in the next tag (rc.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)