### PR TITLE
fix(tls): provision certs on every reconcile path + fast-retry failed ACME orders

### DIFF
--- a/crates/orca-cli/src/handlers/join.rs
+++ b/crates/orca-cli/src/handlers/join.rs
@@ -162,7 +162,8 @@ pub async fn handle_join(
             routes.insert(domain.clone(), vec![target]);
             drop(routes);
 
-            // Hot-provision TLS cert for the new domain
+            // Register for renewal/fast-retry, then hot-provision the cert
+            acme.add_domain(&domain).await;
             if let Some(res) = &resolver
                 && !res.has_cert(&domain)
             {
@@ -261,6 +262,12 @@ async fn spawn_local_proxy(
 
     let resolver_out = resolver_for_refresh.clone();
 
+    // Renew expiring certs and fast-retry failed provisions. Previously only
+    // the master ran this, so agent-served certs were never renewed.
+    if let Some(resolver) = &resolver_for_refresh {
+        orca_proxy::acme::renewal::spawn_renewal_task(acme.clone(), resolver.clone());
+    }
+
     // Background route refresher: rescans docker every 5s and rebuilds the
     // route table from `orca.domain` / `orca.port` labels. New domains get
     // their TLS cert hot-provisioned immediately.
@@ -305,6 +312,7 @@ async fn spawn_local_proxy(
             // New domains discovered since last refresh — hot-provision TLS certs.
             for d in current.difference(&known_domains) {
                 info!("Discovered new domain on this node: {d}");
+                acme_for_refresh.add_domain(d).await;
                 if let Some(resolver) = &resolver_for_refresh
                     && !resolver.has_cert(d)
                 {

--- a/crates/orca-cli/src/handlers/server.rs
+++ b/crates/orca-cli/src/handlers/server.rs
@@ -76,6 +76,14 @@ pub async fn handle_server(config: &str, proxy_port: u16) -> anyhow::Result<()> 
         s.service
             .iter()
             .filter(|svc| is_master_placed(svc, &master_node))
+            // BYO-cert services provide their own certificate (tls_cert/tls_key);
+            // ACME must never provision or renew for them. Excluding them here
+            // keeps their domains out of the manager's registered set, so the
+            // 24h sweep and the fast-retry loop never fire an unsolicited Let's
+            // Encrypt order that could overwrite the operator's certificate.
+            // Their cert is loaded into the resolver by the reconciler
+            // (provision_service_certs), which already skips ACME for BYO.
+            .filter(|svc| svc.tls_cert.is_none() && svc.tls_key.is_none())
             .flat_map(|svc| svc.all_domains())
             .collect()
     };

--- a/crates/orca-cli/src/handlers/server.rs
+++ b/crates/orca-cli/src/handlers/server.rs
@@ -103,12 +103,15 @@ pub async fn handle_server(config: &str, proxy_port: u16) -> anyhow::Result<()> 
     // always win). Configurable via `[security_headers]` in cluster.toml.
     orca_proxy::init_security_headers(cluster_config.security_headers.clone());
 
-    // Start proxy and get ACME components for hot cert provisioning
+    // Start proxy and get ACME components for hot cert provisioning.
+    // Brought up whenever acme_email is configured, even with zero initial
+    // domains — otherwise the first service deployed with a domain after
+    // startup has no HTTPS listener, no resolver, and no ACME manager, and
+    // certs can't be provisioned until a restart (mirrors the joined-node
+    // proxy in join.rs, which always starts HTTP+HTTPS).
     let proxy_routes = route_table.clone();
     let proxy_triggers = wasm_triggers.clone();
-    let (acme_for_control, resolver_for_control) = if !domains.is_empty()
-        && let Some(email) = acme_email
-    {
+    let (acme_for_control, resolver_for_control) = if let Some(email) = acme_email {
         let cache = std::env::var("HOME")
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|_| ".".into())

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -55,5 +55,9 @@ futures-util = "0.3"
 [dev-dependencies.tempfile]
 version = "3"
 
+[dev-dependencies.tokio]
+workspace = true
+features = ["test-util"]
+
 [dev-dependencies.rcgen]
 version = "0.13"

--- a/crates/orca-control/src/certs.rs
+++ b/crates/orca-control/src/certs.rs
@@ -1,0 +1,62 @@
+//! TLS certificate provisioning for reconciled services — BYO cert loading
+//! and ACME registration/hot-provisioning.
+
+use orca_core::config::ServiceConfig;
+
+use crate::state::AppState;
+
+/// Load a BYO TLS certificate and key from PEM files.
+pub fn load_byo_cert(
+    cert_path: &str,
+    key_path: &str,
+) -> anyhow::Result<rustls::sign::CertifiedKey> {
+    let cert_pem = std::fs::read(cert_path)?;
+    let key_pem = std::fs::read(key_path)?;
+    let certs: Vec<_> =
+        rustls_pemfile::certs(&mut cert_pem.as_slice()).collect::<Result<Vec<_>, _>>()?;
+    let key = rustls_pemfile::private_key(&mut key_pem.as_slice())?
+        .ok_or_else(|| anyhow::anyhow!("no private key in {key_path}"))?;
+    let signing_key = rustls::crypto::aws_lc_rs::sign::any_supported_type(&key)?;
+    Ok(rustls::sign::CertifiedKey::new(certs, signing_key))
+}
+
+/// TLS cert provisioning — one cert per domain (apex + www, dual-TLD, etc.).
+/// BYO cert/key, when provided, applies to every listed domain.
+///
+/// Must run on EVERY local reconcile path — fresh scale-up, rolling/canary
+/// update, and the same-spec fast path. A domain change on a running service
+/// takes the rolling-update path, and skipping certs there shipped an HTTPS
+/// outage: the route existed but no cert was ever provisioned until restart.
+/// Failures are logged, not fatal — registration alone is enough for the
+/// renewal task's fast-retry loop to pick the domain up.
+pub(crate) async fn provision_service_certs(state: &AppState, config: &ServiceConfig) {
+    let Some(resolver) = &state.cert_resolver else {
+        return;
+    };
+    for domain in config.all_domains() {
+        if let (Some(cert_path), Some(key_path)) = (&config.tls_cert, &config.tls_key) {
+            if resolver.has_cert(&domain) {
+                continue;
+            }
+            // BYO cert: load from file
+            match load_byo_cert(cert_path, key_path) {
+                Ok(key) => {
+                    resolver.add_cert(&domain, std::sync::Arc::new(key));
+                    tracing::info!(domain, "BYO TLS certificate loaded");
+                }
+                Err(e) => tracing::error!(domain, "Failed to load BYO cert: {e}"),
+            }
+        } else if let Some(acme) = &state.acme_manager {
+            // Register even when a cert already exists: the renewal task can
+            // only renew (and fast-retry) domains it knows about.
+            acme.add_domain(&domain).await;
+            if resolver.has_cert(&domain) {
+                continue;
+            }
+            // ACME auto-provisioning
+            if let Err(e) = acme.ensure_cert_for_resolver(&domain, resolver).await {
+                tracing::error!(domain, "Hot cert provisioning failed: {e}");
+            }
+        }
+    }
+}

--- a/crates/orca-control/src/lib.rs
+++ b/crates/orca-control/src/lib.rs
@@ -4,6 +4,7 @@ pub mod api;
 pub mod auth;
 pub mod backup_scheduler;
 pub(crate) mod canary;
+pub mod certs;
 pub mod cleanup_scheduler;
 pub mod cluster_api;
 pub(crate) mod cluster_handlers;

--- a/crates/orca-control/src/reconciler.rs
+++ b/crates/orca-control/src/reconciler.rs
@@ -8,25 +8,14 @@ use orca_core::config::ServiceConfig;
 use orca_core::runtime::Runtime;
 use orca_core::types::{DeployKind, Replicas, RuntimeKind, WorkloadSpec, WorkloadStatus};
 
+use crate::certs::provision_service_certs;
 use crate::instance::create_and_start_instance;
 use crate::placement::find_target_node;
 use crate::routes::{service_config_to_spec, update_container_routes, update_wasm_triggers};
 use crate::state::{AppState, ServiceState};
 
-/// Load a BYO TLS certificate and key from PEM files.
-pub fn load_byo_cert(
-    cert_path: &str,
-    key_path: &str,
-) -> anyhow::Result<rustls::sign::CertifiedKey> {
-    let cert_pem = std::fs::read(cert_path)?;
-    let key_pem = std::fs::read(key_path)?;
-    let certs: Vec<_> =
-        rustls_pemfile::certs(&mut cert_pem.as_slice()).collect::<Result<Vec<_>, _>>()?;
-    let key = rustls_pemfile::private_key(&mut key_pem.as_slice())?
-        .ok_or_else(|| anyhow::anyhow!("no private key in {key_path}"))?;
-    let signing_key = rustls::crypto::aws_lc_rs::sign::any_supported_type(&key)?;
-    Ok(rustls::sign::CertifiedKey::new(certs, signing_key))
-}
+// Re-exported so external `use` paths survive the split into `certs.rs`.
+pub use crate::certs::load_byo_cert;
 
 /// Reconcile all services: make reality match the desired config.
 ///
@@ -233,6 +222,7 @@ pub(crate) async fn reconcile_service(
             RuntimeKind::Container => update_container_routes(state, config).await,
             RuntimeKind::Wasm => update_wasm_triggers(state, config).await,
         }
+        provision_service_certs(state, config).await;
         return Ok(());
     }
 
@@ -251,6 +241,7 @@ pub(crate) async fn reconcile_service(
             info!("Rolling update for {name} ({desired} replicas)");
             crate::operations::rolling_update(state, runtime, config, &spec, desired).await?;
         }
+        provision_service_certs(state, config).await;
         return Ok(());
     }
 
@@ -354,30 +345,7 @@ pub(crate) async fn reconcile_service(
         RuntimeKind::Wasm => update_wasm_triggers(state, config).await,
     }
 
-    // TLS cert provisioning — one cert per domain (apex + www, dual-TLD, etc.).
-    // BYO cert/key, when provided, applies to every listed domain.
-    if let Some(resolver) = &state.cert_resolver {
-        for domain in config.all_domains() {
-            if resolver.has_cert(&domain) {
-                continue;
-            }
-            if let (Some(cert_path), Some(key_path)) = (&config.tls_cert, &config.tls_key) {
-                // BYO cert: load from file
-                match load_byo_cert(cert_path, key_path) {
-                    Ok(key) => {
-                        resolver.add_cert(&domain, std::sync::Arc::new(key));
-                        tracing::info!(domain, "BYO TLS certificate loaded");
-                    }
-                    Err(e) => tracing::error!(domain, "Failed to load BYO cert: {e}"),
-                }
-            } else if let Some(acme) = &state.acme_manager {
-                // ACME auto-provisioning
-                if let Err(e) = acme.ensure_cert_for_resolver(&domain, resolver).await {
-                    tracing::error!(domain, "Hot cert provisioning failed: {e}");
-                }
-            }
-        }
-    }
+    provision_service_certs(state, config).await;
 
     Ok(())
 }

--- a/crates/orca-control/tests/cert_provisioning_test.rs
+++ b/crates/orca-control/tests/cert_provisioning_test.rs
@@ -1,0 +1,175 @@
+//! TLS cert provisioning must run on every local reconcile path.
+//!
+//! Regression tests for the production incident where `orca deploy` of a
+//! service with a new `domain` added the HTTP route but never registered the
+//! domain for ACME or the SNI resolver — HTTPS failed until an agent restart.
+//!
+//! Tests seed the resolver with self-signed certs so `ensure_cert_for_resolver`
+//! short-circuits on `has_cert` and no real ACME order is attempted. The
+//! observable is `AcmeManager::domains()`: registration proves the cert
+//! provisioning block ran on that reconcile path (and is what the renewal
+//! task's sweep + fast-retry loop iterate).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use orca_control::reconciler::{load_byo_cert, reconcile};
+use orca_control::state::AppState;
+use orca_core::config::{ClusterConfig, ServiceConfig};
+use orca_core::testing::MockRuntime;
+use orca_proxy::acme::{AcmeManager, DynCertResolver};
+
+fn svc(name: &str, domain: &str) -> ServiceConfig {
+    serde_json::from_value(serde_json::json!({
+        "name": name,
+        "image": "nginx:latest",
+        "replicas": 1,
+        "port": 8080,
+        "domain": domain,
+    }))
+    .expect("valid service config")
+}
+
+fn state_with_acme(
+    certs_dir: &std::path::Path,
+) -> (Arc<AppState>, AcmeManager, Arc<DynCertResolver>) {
+    let acme = AcmeManager::new("ops@example.com", certs_dir);
+    let resolver = Arc::new(DynCertResolver::new());
+    let state = AppState::new(
+        ClusterConfig::default(),
+        Arc::new(MockRuntime::new()),
+        None,
+        Arc::new(RwLock::new(HashMap::new())),
+        Arc::new(RwLock::new(Vec::new())),
+    )
+    .with_acme(acme.clone(), resolver.clone());
+    (Arc::new(state), acme, resolver)
+}
+
+/// Add a self-signed cert for `domain` so no real ACME order is attempted.
+fn seed_cert(resolver: &DynCertResolver, domain: &str) {
+    let dir = tempfile::tempdir().unwrap();
+    let c = rcgen::generate_simple_self_signed(vec![domain.to_string()]).unwrap();
+    let cert_path = dir.path().join("cert.pem");
+    let key_path = dir.path().join("key.pem");
+    std::fs::write(&cert_path, c.cert.pem()).unwrap();
+    std::fs::write(&key_path, c.key_pair.serialize_pem()).unwrap();
+    let key = load_byo_cert(cert_path.to_str().unwrap(), key_path.to_str().unwrap()).unwrap();
+    resolver.add_cert(domain, Arc::new(key));
+}
+
+/// Fresh deploy of a service with a domain must register that domain with the
+/// ACME manager — otherwise the renewal task never sees it and the cert
+/// silently expires at day ~90.
+#[tokio::test]
+async fn fresh_deploy_registers_domain_for_renewal() {
+    let dir = tempfile::tempdir().unwrap();
+    let (state, acme, resolver) = state_with_acme(dir.path());
+    seed_cert(&resolver, "app.example.com");
+
+    let (deployed, errors) = reconcile(&state, &[svc("web", "app.example.com")]).await;
+    assert_eq!(deployed, vec!["web".to_string()]);
+    assert!(errors.is_empty(), "deploy errors: {errors:?}");
+
+    assert!(
+        acme.domains()
+            .await
+            .contains(&"app.example.com".to_string()),
+        "fresh deploy must register the domain for renewal/retry"
+    );
+}
+
+/// The incident path: a *running* service gets a new domain. That reconcile
+/// takes the rolling-update branch, which returned before the cert
+/// provisioning block — route added, no cert, HTTPS down until restart.
+#[tokio::test(start_paused = true)]
+async fn domain_change_on_running_service_provisions_cert() {
+    let dir = tempfile::tempdir().unwrap();
+    let (state, acme, resolver) = state_with_acme(dir.path());
+    seed_cert(&resolver, "old.example.com");
+    seed_cert(&resolver, "new.example.com");
+
+    let (_, errors) = reconcile(&state, &[svc("web", "old.example.com")]).await;
+    assert!(errors.is_empty(), "initial deploy errors: {errors:?}");
+
+    // Same service, changed domain → rolling update path.
+    let (_, errors) = reconcile(&state, &[svc("web", "new.example.com")]).await;
+    assert!(errors.is_empty(), "rolling update errors: {errors:?}");
+
+    assert!(
+        acme.domains()
+            .await
+            .contains(&"new.example.com".to_string()),
+        "a domain added to a running service must be registered for ACME"
+    );
+}
+
+/// The same-spec fast path must also run cert provisioning: if the initial
+/// provision failed (e.g. DNS not yet propagated), a redeploy of the identical
+/// spec is the operator's natural retry — it must not skip certs.
+#[tokio::test]
+async fn same_spec_reconcile_registers_domain() {
+    let dir = tempfile::tempdir().unwrap();
+    let (state, acme, resolver) = state_with_acme(dir.path());
+    seed_cert(&resolver, "a.example.com");
+    seed_cert(&resolver, "b.example.com");
+
+    let (_, errors) = reconcile(&state, &[svc("web", "a.example.com")]).await;
+    assert!(errors.is_empty(), "initial deploy errors: {errors:?}");
+
+    // Force the stored config to match the incoming one so the reconcile
+    // below takes the same-spec early-return path, with a domain the ACME
+    // manager has not seen yet.
+    state
+        .services
+        .write()
+        .await
+        .get_mut("web")
+        .expect("service exists")
+        .config
+        .domain = Some("b.example.com".to_string());
+
+    let (_, errors) = reconcile(&state, &[svc("web", "b.example.com")]).await;
+    assert!(errors.is_empty(), "same-spec reconcile errors: {errors:?}");
+
+    assert!(
+        acme.domains().await.contains(&"b.example.com".to_string()),
+        "same-spec reconcile must still register domains for renewal/retry"
+    );
+}
+
+/// BYO-cert services must load their cert into the resolver but never be
+/// registered with the ACME manager — no Let's Encrypt orders for domains
+/// the operator provides certs for.
+#[tokio::test]
+async fn byo_service_not_registered_for_acme() {
+    let dir = tempfile::tempdir().unwrap();
+    let (state, acme, resolver) = state_with_acme(dir.path());
+
+    let c = rcgen::generate_simple_self_signed(vec!["byo.example.com".into()]).unwrap();
+    let cert_path = dir.path().join("byo.cert.pem");
+    let key_path = dir.path().join("byo.key.pem");
+    std::fs::write(&cert_path, c.cert.pem()).unwrap();
+    std::fs::write(&key_path, c.key_pair.serialize_pem()).unwrap();
+
+    let mut config = svc("byo", "byo.example.com");
+    config.tls_cert = Some(cert_path.to_str().unwrap().to_string());
+    config.tls_key = Some(key_path.to_str().unwrap().to_string());
+
+    let (_, errors) = reconcile(&state, &[config]).await;
+    assert!(errors.is_empty(), "deploy errors: {errors:?}");
+
+    assert!(
+        resolver.has_cert("byo.example.com"),
+        "BYO cert must be loaded into the resolver"
+    );
+    assert!(
+        !acme
+            .domains()
+            .await
+            .contains(&"byo.example.com".to_string()),
+        "BYO domains must not be registered for ACME"
+    );
+}

--- a/crates/orca-proxy/src/acme/provider.rs
+++ b/crates/orca-proxy/src/acme/provider.rs
@@ -127,6 +127,15 @@ impl AcmeProvider {
 
         info!(email = %self.email, "Creating new ACME account");
         let contact = format!("mailto:{}", self.email);
+        // ORCA_ACME_DIRECTORY overrides the ACME directory URL — point it at
+        // Let's Encrypt staging (https://acme-staging-v02.api.letsencrypt.org/directory)
+        // for migration rehearsals so failed cutover attempts never burn
+        // production rate limits. Only consulted at account creation; cached
+        // credentials pin the directory they were created against, so switch
+        // directories by removing ~/.orca/acme-account.json.
+        let directory = std::env::var("ORCA_ACME_DIRECTORY")
+            .unwrap_or_else(|_| LetsEncrypt::Production.url().to_owned());
+        info!(directory = %directory, "Using ACME directory");
         let (account, credentials) = Account::builder()?
             .create(
                 &NewAccount {
@@ -134,7 +143,7 @@ impl AcmeProvider {
                     terms_of_service_agreed: true,
                     only_return_existing: false,
                 },
-                LetsEncrypt::Production.url().to_owned(),
+                directory,
                 None,
             )
             .await?;

--- a/crates/orca-proxy/src/acme/renewal.rs
+++ b/crates/orca-proxy/src/acme/renewal.rs
@@ -1,28 +1,103 @@
 //! Background task for automatic ACME certificate renewal.
 //!
-//! Runs every 24 hours, checks all cached certificates for expiry,
-//! and re-provisions via ACME if a cert expires within 30 days.
+//! A single loop ticks every 60 seconds. Each tick fast-retries registered
+//! domains that have no certificate in the resolver (a failed or
+//! never-attempted provision) on a short backoff — one minute, then five,
+//! then fifteen. Every 24 hours a full sweep re-provisions certificates
+//! expiring within 30 days.
 
+use std::collections::HashMap;
 use std::time::Duration;
 
+use tokio::time::Instant;
 use tracing::{error, info, warn};
 
 use super::AcmeManager;
 use crate::SharedCertResolver;
 
-/// Spawn a background task that periodically checks and renews expiring certs.
+/// Interval between fast-retry ticks (also the resolution of the 24h sweep).
+const RETRY_TICK: Duration = Duration::from_secs(60);
+/// Interval between full renewal sweeps.
+const SWEEP_INTERVAL: Duration = Duration::from_secs(24 * 3600);
+
+/// Per-domain retry bookkeeping: consecutive failures and next attempt time.
+struct RetryState {
+    failures: u32,
+    next_attempt: Instant,
+}
+
+/// Backoff before retrying a failed provision: 1 min, then 5, then 15 (cap).
 ///
-/// Runs every 24 hours. For each domain registered with the ACME manager,
-/// checks if the certificate needs renewal (expires within 30 days) and
-/// re-provisions it via Let's Encrypt if needed.
+/// 15 min steady-state stays under Let's Encrypt's failed-validation rate
+/// limit (5 per hostname per hour) while turning a bad cutover — domain
+/// registered, initial order failed because DNS hadn't propagated — into a
+/// self-healing delay instead of a wait-for-tomorrow outage.
+fn retry_delay(failures: u32) -> Duration {
+    match failures {
+        0 | 1 => Duration::from_secs(60),
+        2 => Duration::from_secs(5 * 60),
+        _ => Duration::from_secs(15 * 60),
+    }
+}
+
+/// Spawn the background renewal task: fast retry for missing certs every
+/// minute (with per-domain backoff) and a full expiry sweep every 24 hours.
 pub fn spawn_renewal_task(manager: AcmeManager, resolver: SharedCertResolver) {
     tokio::spawn(async move {
-        info!("ACME renewal task started (24h interval)");
+        info!("ACME renewal task started (24h sweep + fast retry for missing certs)");
+        let mut retries: HashMap<String, RetryState> = HashMap::new();
+        let mut last_sweep = Instant::now();
         loop {
-            tokio::time::sleep(Duration::from_secs(24 * 3600)).await;
-            check_and_renew(&manager, &resolver).await;
+            tokio::time::sleep(RETRY_TICK).await;
+            retry_missing_certs(&manager, &resolver, &mut retries).await;
+            if last_sweep.elapsed() >= SWEEP_INTERVAL {
+                last_sweep = Instant::now();
+                check_and_renew(&manager, &resolver).await;
+            }
         }
     });
+}
+
+/// Provision certs for registered domains that have none in the resolver.
+async fn retry_missing_certs(
+    manager: &AcmeManager,
+    resolver: &SharedCertResolver,
+    retries: &mut HashMap<String, RetryState>,
+) {
+    let now = Instant::now();
+    for domain in manager.domains().await {
+        if resolver.has_cert(&domain) {
+            retries.remove(&domain);
+            continue;
+        }
+        if retries.get(&domain).is_some_and(|r| now < r.next_attempt) {
+            continue;
+        }
+        info!(domain = %domain, "Provisioning missing certificate");
+        match manager.ensure_cert_for_resolver(&domain, resolver).await {
+            Ok(()) => {
+                retries.remove(&domain);
+                info!(domain = %domain, "Certificate provisioned");
+            }
+            Err(e) => {
+                let failures = retries.get(&domain).map_or(1, |r| r.failures + 1);
+                let delay = retry_delay(failures);
+                warn!(
+                    domain = %domain,
+                    error = %e,
+                    retry_in_secs = delay.as_secs(),
+                    "Certificate provisioning failed, will retry"
+                );
+                retries.insert(
+                    domain,
+                    RetryState {
+                        failures,
+                        next_attempt: now + delay,
+                    },
+                );
+            }
+        }
+    }
 }
 
 /// Check all registered domains and renew expiring certificates.
@@ -90,6 +165,14 @@ mod tests {
     use std::fs;
     use std::time::{Duration, SystemTime};
     use tempfile::TempDir;
+
+    #[test]
+    fn test_retry_backoff_is_one_five_fifteen_capped() {
+        assert_eq!(retry_delay(1), Duration::from_secs(60));
+        assert_eq!(retry_delay(2), Duration::from_secs(300));
+        assert_eq!(retry_delay(3), Duration::from_secs(900));
+        assert_eq!(retry_delay(100), Duration::from_secs(900));
+    }
 
     #[test]
     fn test_cert_needs_renewal_when_old() {

--- a/crates/orca-proxy/src/acme/renewal.rs
+++ b/crates/orca-proxy/src/acme/renewal.rs
@@ -19,6 +19,12 @@ use crate::SharedCertResolver;
 const RETRY_TICK: Duration = Duration::from_secs(60);
 /// Interval between full renewal sweeps.
 const SWEEP_INTERVAL: Duration = Duration::from_secs(24 * 3600);
+/// Per-domain cap on a single provision attempt. A domain whose HTTP-01
+/// challenge hangs (DNS misdirected, port 80 firewalled, a stalled LE
+/// endpoint) must not block the retry of every other registered domain — or
+/// the 24h sweep — since they share this one task. Mirrors the startup loop's
+/// `PER_DOMAIN_PROVISION_TIMEOUT`.
+const PROVISION_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Per-domain retry bookkeeping: consecutive failures and next attempt time.
 struct RetryState {
@@ -74,28 +80,35 @@ async fn retry_missing_certs(
             continue;
         }
         info!(domain = %domain, "Provisioning missing certificate");
-        match manager.ensure_cert_for_resolver(&domain, resolver).await {
-            Ok(()) => {
+        let provision = manager.ensure_cert_for_resolver(&domain, resolver);
+        let failure = match tokio::time::timeout(PROVISION_TIMEOUT, provision).await {
+            Ok(Ok(())) => {
                 retries.remove(&domain);
                 info!(domain = %domain, "Certificate provisioned");
+                None
             }
-            Err(e) => {
-                let failures = retries.get(&domain).map_or(1, |r| r.failures + 1);
-                let delay = retry_delay(failures);
-                warn!(
-                    domain = %domain,
-                    error = %e,
-                    retry_in_secs = delay.as_secs(),
-                    "Certificate provisioning failed, will retry"
-                );
-                retries.insert(
-                    domain,
-                    RetryState {
-                        failures,
-                        next_attempt: now + delay,
-                    },
-                );
-            }
+            Ok(Err(e)) => Some(e.to_string()),
+            Err(_) => Some(format!(
+                "timed out after {}s",
+                PROVISION_TIMEOUT.as_secs()
+            )),
+        };
+        if let Some(reason) = failure {
+            let failures = retries.get(&domain).map_or(1, |r| r.failures + 1);
+            let delay = retry_delay(failures);
+            warn!(
+                domain = %domain,
+                error = %reason,
+                retry_in_secs = delay.as_secs(),
+                "Certificate provisioning did not succeed, will retry"
+            );
+            retries.insert(
+                domain,
+                RetryState {
+                    failures,
+                    next_attempt: now + delay,
+                },
+            );
         }
     }
 }

--- a/crates/orca-proxy/src/lib.rs
+++ b/crates/orca-proxy/src/lib.rs
@@ -226,6 +226,11 @@ pub async fn run_proxy_with_acme_and_fallback(
         const PER_DOMAIN_PROVISION_TIMEOUT: std::time::Duration =
             std::time::Duration::from_secs(60);
         for domain in &domains {
+            // Register with the manager first: the renewal task's 24h sweep
+            // and fast-retry loop only iterate registered domains, so a
+            // failed or timed-out provision here is retried instead of
+            // staying broken until the next restart.
+            acme_mgr.add_domain(domain).await;
             let fut = acme_mgr.ensure_cert_for_resolver(domain, &resolver_clone);
             match tokio::time::timeout(PER_DOMAIN_PROVISION_TIMEOUT, fut).await {
                 Ok(Ok(())) => {}


### PR DESCRIPTION
Fixes #152.

## What

1. **Cert provisioning runs on every local reconcile path.** Extracted the reconciler's TLS block into `provision_service_certs()` (new `orca-control/src/certs.rs`, keeps `reconciler::load_byo_cert` re-exported) and call it from the same-spec fast path, the rolling/canary path, and the scale-up fall-through. A domain change on a running service now provisions immediately.

2. **Domains are registered for renewal.** `add_domain` is now called from the reconciler, the proxy's startup provisioning loop, and both agent discovery paths (WS notification + 5s label refresh) — so the renewal sweep iterates a real set instead of an empty one. BYO-cert domains are deliberately not registered (no ACME orders for operator-provided certs).

3. **Failed provisions fast-retry.** The renewal task now ticks every 60s: registered domains with no cert in the resolver are retried on a 1m → 5m → 15m backoff (15m steady state stays under LE's failed-validation rate limit). The 24h expiry sweep is unchanged, minus the initial 24h sleep.

4. **ACME stack starts with zero domains.** `orca server` now brings up the ACME manager/resolver/HTTPS listener whenever `acme_email` is configured, matching the joined-node proxy. Joined nodes also spawn the renewal task now.

5. **`ORCA_ACME_DIRECTORY` env override** for the ACME directory URL — lets migration rehearsals run against LE staging without burning production rate limits.

## Tests

- New `cert_provisioning_test.rs`: 4 integration tests over `reconcile()` with `MockRuntime` + a resolver seeded with rcgen self-signed certs (no network). Three of them fail on `main` — one per broken path (fresh deploy registration, rolling-update domain change, same-spec pass). The fourth pins BYO domains staying out of ACME.
- Unit test for the retry backoff schedule.
- `cargo fmt`, `clippy -D warnings`, full `cargo test` pass; all touched files under the CI size limit.

## Verified against a live binary

Ran the release build with LE **staging**: server started with 0 domains (ACME stack up), deploy after startup registered the domain and fired an order immediately, failed validation retried at 60s then backed off to 300s, and a domain change on the running service (rolling path — the incident case) provisioned immediately after `Rolling update complete`. In a subsequent real migration, an apex domain whose first orders failed (DNS still on old infra) was recovered automatically by the retry loop after the DNS cutover — previously a restart-and-wait outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)