### PR TITLE
fix(status): report observed container state, not deploy-time state

### DIFF
--- a/crates/orca-agent/src/grpc/client/reporting.rs
+++ b/crates/orca-agent/src/grpc/client/reporting.rs
@@ -39,24 +39,47 @@ async fn read_log_tail(runtime: &dyn Runtime, handle: &WorkloadHandle) -> Option
 
 impl AgentClient {
     /// Collect workload status reports with per-container stats for heartbeat.
+    ///
+    /// Queries the runtime for each workload's OBSERVED state instead of
+    /// trusting the status recorded at deploy time — the map is written once
+    /// on deploy, so without the live check a container that crashed after
+    /// deploy would be reported "running" in every heartbeat forever (the
+    /// `orca status` said running / Docker said `Exited (1)` incident).
+    /// A workload the runtime no longer knows at all reports as failed.
     pub async fn collect_workload_reports(
         &self,
         runtime: &dyn Runtime,
     ) -> Vec<orca_core::ws_types::WorkloadReport> {
-        let workloads = self.workloads.read().await;
-        let mut reports = Vec::with_capacity(workloads.len());
+        // Snapshot ids under the read lock, then query the runtime without
+        // holding it (status/stats/log calls can be slow).
+        let snapshot: Vec<(String, String)> = self
+            .workloads
+            .read()
+            .await
+            .iter()
+            .map(|(id, info)| (id.clone(), info.service_name.clone()))
+            .collect();
 
-        for (id, info) in workloads.iter() {
+        let mut reports = Vec::with_capacity(snapshot.len());
+        let mut observed: Vec<(String, WorkloadStatus)> = Vec::with_capacity(snapshot.len());
+
+        for (id, service_name) in snapshot {
             let handle = WorkloadHandle {
                 runtime_id: id.clone(),
-                name: format!("orca-{}", info.service_name),
+                name: format!("orca-{service_name}"),
                 metadata: Default::default(),
             };
+            let status = runtime
+                .status(&handle)
+                .await
+                .unwrap_or(WorkloadStatus::Failed);
+            observed.push((id.clone(), status));
+
             // Running: collect live stats. Not running: collect crash detail
             // (exit code, restart count, log tail) so the master can explain
             // *why* without a separate fetch.
             let (cpu, mem, exit_code, restart_count, last_logs) =
-                if info.status == WorkloadStatus::Running {
+                if status == WorkloadStatus::Running {
                     let (cpu, mem) = match runtime.stats(&handle).await {
                         Ok(rs) => (rs.cpu_percent, rs.memory_bytes),
                         Err(_) => (0.0, 0),
@@ -69,8 +92,8 @@ impl AgentClient {
                 };
 
             reports.push(orca_core::ws_types::WorkloadReport {
-                service_name: info.service_name.clone(),
-                status: match info.status {
+                service_name,
+                status: match status {
                     WorkloadStatus::Running => "running",
                     WorkloadStatus::Stopped | WorkloadStatus::Completed => "stopped",
                     WorkloadStatus::Failed => "failed",
@@ -78,13 +101,21 @@ impl AgentClient {
                     WorkloadStatus::Stopping => "stopping",
                 }
                 .into(),
-                container_id: Some(id.clone()),
+                container_id: Some(id),
                 cpu_percent: cpu,
                 memory_bytes: mem,
                 exit_code,
                 restart_count,
                 last_logs,
             });
+        }
+
+        // Converge the cache to what was observed.
+        let mut workloads = self.workloads.write().await;
+        for (id, status) in observed {
+            if let Some(info) = workloads.get_mut(&id) {
+                info.status = status;
+            }
         }
 
         reports

--- a/crates/orca-agent/tests/workload_report_test.rs
+++ b/crates/orca-agent/tests/workload_report_test.rs
@@ -1,0 +1,93 @@
+//! Heartbeat reports must reflect the observed container state, not the
+//! status cached at deploy time.
+//!
+//! Regression tests for the incident where `orca status` said `running` for
+//! services whose containers Docker showed as `Exited (1)`: the agent's
+//! workload map is written once at deploy time and was never re-checked
+//! against the runtime, so heartbeats reported stale state forever.
+
+use std::time::Duration;
+
+use orca_agent::grpc::AgentClient;
+use orca_core::runtime::Runtime;
+use orca_core::testing::MockRuntime;
+use orca_core::types::{WorkloadSpec, WorkloadStatus};
+
+fn spec(name: &str) -> WorkloadSpec {
+    serde_json::from_value(serde_json::json!({
+        "name": name,
+        "runtime": "container",
+        "image": "nginx:alpine",
+        "replicas": 1,
+        "routes": [],
+        "env": {},
+        "aliases": [],
+        "mounts": [],
+        "triggers": [],
+        "internal": false,
+    }))
+    .expect("valid workload spec")
+}
+
+fn agent() -> AgentClient {
+    AgentClient::new("http://127.0.0.1:1".into(), 1)
+}
+
+/// A container that exits after deploy must be reported with its observed
+/// state ("stopped"), not the "running" recorded when it was deployed.
+#[tokio::test]
+async fn report_reflects_observed_state_not_deploy_time_cache() {
+    let runtime = MockRuntime::new();
+    let handle = runtime.create(&spec("web")).await.unwrap();
+    runtime.start(&handle).await.unwrap();
+    // Container dies after deploy — the runtime now observes Stopped.
+    runtime.stop(&handle, Duration::from_secs(1)).await.unwrap();
+
+    let agent = agent();
+    // Deploy-time cache still says Running.
+    agent
+        .update_workload_status(&handle.runtime_id, "web", WorkloadStatus::Running)
+        .await;
+
+    let reports = agent.collect_workload_reports(&runtime).await;
+    assert_eq!(reports.len(), 1);
+    assert_eq!(
+        reports[0].status, "stopped",
+        "heartbeat must report the observed container state"
+    );
+}
+
+/// A container that no longer exists at all must be reported "failed" —
+/// not silently kept at whatever status the map last recorded.
+#[tokio::test]
+async fn report_marks_vanished_container_failed() {
+    let runtime = MockRuntime::new();
+    let agent = agent();
+    agent
+        .update_workload_status("vanished-123", "web", WorkloadStatus::Running)
+        .await;
+
+    let reports = agent.collect_workload_reports(&runtime).await;
+    assert_eq!(reports.len(), 1);
+    assert_eq!(
+        reports[0].status, "failed",
+        "a vanished container must surface as failed"
+    );
+}
+
+/// Sanity: a genuinely running container still reports "running".
+#[tokio::test]
+async fn report_keeps_running_for_running_container() {
+    let runtime = MockRuntime::new();
+    let handle = runtime.create(&spec("web")).await.unwrap();
+    runtime.start(&handle).await.unwrap();
+
+    let agent = agent();
+    agent
+        .update_workload_status(&handle.runtime_id, "web", WorkloadStatus::Running)
+        .await;
+
+    let reports = agent.collect_workload_reports(&runtime).await;
+    assert_eq!(reports.len(), 1);
+    assert_eq!(reports[0].status, "running");
+}

--- a/crates/orca-control/src/api/handlers/mod.rs
+++ b/crates/orca-control/src/api/handlers/mod.rs
@@ -91,8 +91,21 @@ pub(crate) struct StatusQuery {
 async fn refresh_observed_statuses(state: &AppState) {
     use orca_core::types::WorkloadStatus;
 
-    // Snapshot handles under the read lock, then query without holding it.
-    let handles: Vec<(String, usize, orca_core::runtime::WorkloadHandle, _)> = {
+    /// Per-instance cap on the runtime status query. `GET /status` is polled
+    /// every 1-3s by the TUI/CLI/dashboards; without a bound, a slow or wedged
+    /// Docker daemon — exactly when operators most need status — would hang the
+    /// endpoint for every caller. On timeout we leave the recorded status
+    /// untouched (a slow daemon is not evidence the container is gone).
+    const STATUS_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+    // Snapshot (service name, stable runtime_id, handle, kind) under the read
+    // lock, then query without holding it. The write-back below is keyed by
+    // runtime_id, NOT a positional index: a concurrent reconcile/watchdog can
+    // prune or reorder `svc.instances` between this snapshot and the write-back
+    // (retain/sort/scale all do), and a positional index would then land an
+    // observed status on the wrong — possibly brand-new, healthy — instance,
+    // which routing (Running-only) would act on.
+    let handles: Vec<(String, String, orca_core::runtime::WorkloadHandle, _)> = {
         let services = state.services.read().await;
         services
             .values()
@@ -101,32 +114,38 @@ async fn refresh_observed_statuses(state: &AppState) {
                 let kind = svc.config.runtime;
                 svc.instances
                     .iter()
-                    .enumerate()
-                    .filter(|(_, i)| !i.handle.runtime_id.starts_with("remote-"))
-                    .map(move |(idx, i)| (name.clone(), idx, i.handle.clone(), kind))
+                    .filter(|i| !i.handle.runtime_id.starts_with("remote-"))
+                    .map(move |i| {
+                        (
+                            name.clone(),
+                            i.handle.runtime_id.clone(),
+                            i.handle.clone(),
+                            kind,
+                        )
+                    })
                     .collect::<Vec<_>>()
             })
             .collect()
     };
 
     let mut observed = Vec::with_capacity(handles.len());
-    for (name, idx, handle, kind) in handles {
+    for (name, runtime_id, handle, kind) in handles {
         let Ok(runtime) = crate::reconciler::get_runtime(state, kind) else {
             continue;
         };
-        let status = runtime
-            .status(&handle)
-            .await
-            .unwrap_or(WorkloadStatus::Failed);
-        observed.push((name, idx, status));
+        match tokio::time::timeout(STATUS_QUERY_TIMEOUT, runtime.status(&handle)).await {
+            Ok(res) => observed.push((name, runtime_id, res.unwrap_or(WorkloadStatus::Failed))),
+            Err(_) => continue, // daemon slow — keep the recorded status
+        }
     }
 
     let mut services = state.services.write().await;
-    for (name, idx, status) in observed {
-        if let Some(inst) = services
-            .get_mut(&name)
-            .and_then(|svc| svc.instances.get_mut(idx))
-        {
+    for (name, runtime_id, status) in observed {
+        if let Some(inst) = services.get_mut(&name).and_then(|svc| {
+            svc.instances
+                .iter_mut()
+                .find(|i| i.handle.runtime_id == runtime_id)
+        }) {
             inst.status = status;
         }
     }

--- a/crates/orca-control/src/api/handlers/mod.rs
+++ b/crates/orca-control/src/api/handlers/mod.rs
@@ -80,11 +80,65 @@ pub(crate) struct StatusQuery {
     project: Option<String>,
 }
 
+/// Refresh local instance statuses from the runtime so `status` reports the
+/// OBSERVED container state, not what the deploy path recorded. Instances are
+/// marked Running optimistically on create and only corrected by the 30s
+/// watchdog cycle — inside that window a failed deploy reported `running`
+/// while Docker showed `Exited (1)`. Status is what an operator (or an AI
+/// agent) trusts to decide whether a deploy succeeded, so it must ask the
+/// runtime. Remote placeholders (`remote-*`) are owned by the heartbeat
+/// handler and are skipped here.
+async fn refresh_observed_statuses(state: &AppState) {
+    use orca_core::types::WorkloadStatus;
+
+    // Snapshot handles under the read lock, then query without holding it.
+    let handles: Vec<(String, usize, orca_core::runtime::WorkloadHandle, _)> = {
+        let services = state.services.read().await;
+        services
+            .values()
+            .flat_map(|svc| {
+                let name = svc.config.name.clone();
+                let kind = svc.config.runtime;
+                svc.instances
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, i)| !i.handle.runtime_id.starts_with("remote-"))
+                    .map(move |(idx, i)| (name.clone(), idx, i.handle.clone(), kind))
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    };
+
+    let mut observed = Vec::with_capacity(handles.len());
+    for (name, idx, handle, kind) in handles {
+        let Ok(runtime) = crate::reconciler::get_runtime(state, kind) else {
+            continue;
+        };
+        let status = runtime
+            .status(&handle)
+            .await
+            .unwrap_or(WorkloadStatus::Failed);
+        observed.push((name, idx, status));
+    }
+
+    let mut services = state.services.write().await;
+    for (name, idx, status) in observed {
+        if let Some(inst) = services
+            .get_mut(&name)
+            .and_then(|svc| svc.instances.get_mut(idx))
+        {
+            inst.status = status;
+        }
+    }
+}
+
 /// Get cluster and service status, optionally filtered by project.
 pub(crate) async fn status(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(query): axum::extract::Query<StatusQuery>,
 ) -> impl IntoResponse {
+    refresh_observed_statuses(&state).await;
+
     let services = state.services.read().await;
     let stats_cache = state.container_stats.read().await;
     let failures = state.last_failures.read().await;

--- a/crates/orca-control/tests/status_actual_state_test.rs
+++ b/crates/orca-control/tests/status_actual_state_test.rs
@@ -1,0 +1,118 @@
+//! `GET /api/v1/status` must report observed container state, not the state
+//! recorded at deploy time.
+//!
+//! Regression test for the incident where the API returned `status=running`
+//! for services whose containers Docker showed as `Exited (1)`: the handler
+//! read only the in-memory instance list, which is written optimistically on
+//! deploy and refreshed no faster than the 30s watchdog cycle.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::RwLock;
+
+use orca_control::api::router;
+use orca_control::reconciler::reconcile;
+use orca_control::state::AppState;
+use orca_core::api_types::StatusResponse;
+use orca_core::config::{ClusterConfig, ServiceConfig};
+use orca_core::runtime::Runtime;
+use orca_core::testing::MockRuntime;
+
+fn svc(name: &str) -> ServiceConfig {
+    serde_json::from_value(serde_json::json!({
+        "name": name,
+        "image": "nginx:alpine",
+        "replicas": 1,
+    }))
+    .expect("valid service config")
+}
+
+async fn serve(state: Arc<AppState>) -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let app = router(state);
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    port
+}
+
+/// Deploy a service, then stop its container behind the control plane's back
+/// (as a crash would). `status` must report what the runtime observes.
+#[tokio::test]
+async fn status_reports_observed_state_after_container_dies() {
+    let mock = Arc::new(MockRuntime::new());
+    let state = Arc::new(AppState::new(
+        ClusterConfig::default(),
+        mock.clone(),
+        None,
+        Arc::new(RwLock::new(HashMap::new())),
+        Arc::new(RwLock::new(Vec::new())),
+    ));
+
+    let (deployed, errors) = reconcile(&state, &[svc("web")]).await;
+    assert_eq!(deployed, vec!["web".to_string()]);
+    assert!(errors.is_empty(), "deploy errors: {errors:?}");
+
+    // The container exits behind the control plane's back.
+    let handle = {
+        let services = state.services.read().await;
+        services.get("web").unwrap().instances[0].handle.clone()
+    };
+    mock.stop(&handle, Duration::from_secs(1)).await.unwrap();
+
+    let port = serve(state).await;
+    let resp: StatusResponse = reqwest::get(format!("http://127.0.0.1:{port}/api/v1/status"))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let web = resp.services.iter().find(|s| s.name == "web").unwrap();
+    assert_eq!(
+        web.running_replicas, 0,
+        "a dead container must not count as a running replica"
+    );
+    assert_eq!(
+        web.status, "stopped",
+        "status must reflect the observed container state, got {:?}",
+        web.status
+    );
+}
+
+/// Sanity: a genuinely running service still reports running.
+#[tokio::test]
+async fn status_reports_running_for_live_container() {
+    let mock = Arc::new(MockRuntime::new());
+    let state = Arc::new(AppState::new(
+        ClusterConfig::default(),
+        mock.clone(),
+        None,
+        Arc::new(RwLock::new(HashMap::new())),
+        Arc::new(RwLock::new(Vec::new())),
+    ));
+
+    let (_, errors) = reconcile(&state, &[svc("web")]).await;
+    assert!(errors.is_empty(), "deploy errors: {errors:?}");
+
+    let port = serve(state).await;
+    let resp: StatusResponse = reqwest::get(format!("http://127.0.0.1:{port}/api/v1/status"))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let web = resp.services.iter().find(|s| s.name == "web").unwrap();
+    assert_eq!(web.running_replicas, 1);
+    assert_eq!(web.status, "running");
+}


### PR DESCRIPTION
Fixes #154.

## What

Two changes, one per layer of the stale-status chain:

1. **Agent: heartbeats report observed state.** `collect_workload_reports` now queries `runtime.status()` for every workload instead of trusting the status recorded at deploy time. Vanished containers surface as `failed`. The workload map converges to what was observed. Snapshot/write-back happens outside the runtime calls so no lock is held across Docker I/O.

2. **Master: the status endpoint refreshes before reporting.** A new `refresh_observed_statuses` runs at the start of `GET /api/v1/status`: local instance statuses are re-queried from the runtime (missing container → `Failed`) and written back, so a failed deploy is visible immediately instead of after the next 30s watchdog cycle. Remote `remote-*` placeholders stay owned by the heartbeat handler — which now receives honest data via (1).

The CLI's replica counter already prints `running/desired`; no format change.

## Tests

- `orca-agent/tests/workload_report_test.rs` (3): stale-cache container reports `stopped`, vanished container reports `failed`, running container stays `running`. The first two fail on `main`.
- `orca-control/tests/status_actual_state_test.rs` (2): deploy via `reconcile` with `MockRuntime`, stop the container behind the control plane's back, `GET /api/v1/status` must return `0` running / `stopped`. Fails on `main` (returns `1`/`running`); plus a live-container sanity case.
- `cargo fmt`, `clippy -D warnings`, full `cargo test` pass.

## Verified against a live binary

Release build, real Docker: deployed nginx, `docker kill` behind orca's back — Docker showed `Exited (137)` and `orca status` immediately reported `0/1 stopped` (previously `1/1 running` for up to 30s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)