### PR TITLE
fix(proxy): parse cert expiry from NotAfter instead of file mtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,17 +1501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
-]
-
-[[package]]
 name = "find-crate"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,10 +2601,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -3100,7 +3086,6 @@ version = "0.2.12"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
- "filetime",
  "futures-util",
  "http-body-util",
  "hyper",
@@ -3115,9 +3100,11 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-rustls",
  "tracing",
+ "x509-parser",
 ]
 
 [[package]]
@@ -3168,7 +3155,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -3252,12 +3239,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "poly1305"
@@ -3691,15 +3672,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
 ]

--- a/crates/orca-proxy/Cargo.toml
+++ b/crates/orca-proxy/Cargo.toml
@@ -23,10 +23,11 @@ rustls = "0.23"
 tokio-rustls = "0.26"
 rcgen = "0.13"
 rustls-pemfile = "2"
+x509-parser = "0.18"
 instant-acme = "0.8"
 serde_json = { workspace = true }
 dirs = "6"
 
 [dev-dependencies]
 tempfile = "3"
-filetime = "0.2"
+time = "0.3"

--- a/crates/orca-proxy/src/acme/certs.rs
+++ b/crates/orca-proxy/src/acme/certs.rs
@@ -17,16 +17,78 @@ pub(crate) fn load_pem_certs(
     Ok((certs, key))
 }
 
-/// Estimate days until cert expires using file mtime + 90-day LE default.
+/// Days until the certificate expires, parsed from the leaf cert's
+/// `NotAfter`. Negative when already expired.
+///
+/// Never estimated from file metadata: a cert that is copied, restored from
+/// backup, or migrated between nodes gets a fresh mtime, so an mtime-based
+/// estimate makes months-old certs look freshly issued and renewal fires
+/// after the cert has already expired while serving.
 pub(crate) fn check_cert_expiry(cert_path: &Path) -> anyhow::Result<i64> {
-    let metadata = std::fs::metadata(cert_path)?;
-    let modified = metadata.modified()?;
-    let age = modified.elapsed().unwrap_or_default();
-    let ninety_days = std::time::Duration::from_secs(90 * 24 * 60 * 60);
-    if age > ninety_days {
-        Ok(0)
-    } else {
-        let remaining = ninety_days.saturating_sub(age);
-        Ok((remaining.as_secs() / (24 * 60 * 60)) as i64)
+    let pem = std::fs::read(cert_path)?;
+    // The chain starts with the end-entity cert (leaf first, per RFC 8555).
+    let cert = rustls_pemfile::certs(&mut pem.as_slice())
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("no certificate in {}", cert_path.display()))??;
+    let (_, parsed) = x509_parser::parse_x509_certificate(&cert)
+        .map_err(|e| anyhow::anyhow!("cannot parse certificate {}: {e}", cert_path.display()))?;
+    let not_after = parsed.validity().not_after.timestamp();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_secs() as i64;
+    Ok((not_after - now).div_euclid(24 * 60 * 60))
+}
+
+/// Mint a self-signed cert PEM expiring `days` from now (negative = expired)
+/// and write it into `dir`. Test-only helper shared by the acme test modules.
+#[cfg(test)]
+pub(crate) fn mint_cert_expiring_in(dir: &Path, days: i64) -> std::path::PathBuf {
+    let mut params =
+        rcgen::CertificateParams::new(vec!["test.example.com".into()]).expect("valid cert params");
+    params.not_after = time::OffsetDateTime::now_utc() + time::Duration::days(days);
+    let key = rcgen::KeyPair::generate().expect("keygen");
+    let cert = params.self_signed(&key).expect("self-signed cert");
+    let path = dir.join("cert.pem");
+    std::fs::write(&path, cert.pem()).expect("write cert");
+    path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// A freshly WRITTEN file whose certificate expires in 10 days must
+    /// report ~10 days — not 90. Certs that are copied, restored from
+    /// backup, or migrated between nodes get a fresh mtime; expiry must
+    /// come from the certificate's NotAfter, or renewal fires months late.
+    #[test]
+    fn expiry_comes_from_not_after_not_mtime() {
+        let tmp = TempDir::new().unwrap();
+        let path = mint_cert_expiring_in(tmp.path(), 10);
+        let days = check_cert_expiry(&path).unwrap();
+        assert!(
+            (9..=10).contains(&days),
+            "expected ~10 days from NotAfter, got {days} (mtime-based estimate?)"
+        );
+    }
+
+    /// An already-expired certificate must report non-positive days even
+    /// though the file was just written.
+    #[test]
+    fn expired_cert_reports_nonpositive_days() {
+        let tmp = TempDir::new().unwrap();
+        let path = mint_cert_expiring_in(tmp.path(), -2);
+        let days = check_cert_expiry(&path).unwrap();
+        assert!(days <= 0, "expired cert must report <= 0 days, got {days}");
+    }
+
+    /// Unparseable cert data must error (callers treat that as needs-renewal).
+    #[test]
+    fn garbage_cert_data_errors() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("cert.pem");
+        std::fs::write(&path, b"not a certificate").unwrap();
+        assert!(check_cert_expiry(&path).is_err());
     }
 }

--- a/crates/orca-proxy/src/acme/renewal.rs
+++ b/crates/orca-proxy/src/acme/renewal.rs
@@ -87,40 +87,41 @@ pub async fn check_and_renew_from_cache(manager: &AcmeManager, resolver: &Shared
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use std::time::{Duration, SystemTime};
     use tempfile::TempDir;
 
+    /// A certificate expiring within the 30-day threshold needs renewal —
+    /// regardless of how fresh the file on disk is (copied/restored certs
+    /// have a fresh mtime).
     #[test]
-    fn test_cert_needs_renewal_when_old() {
+    fn test_cert_needs_renewal_when_expiring_soon() {
         let tmp = TempDir::new().unwrap();
         let mgr = AcmeManager::new("test@example.com", tmp.path());
 
-        // Create a cert file with old modification time (91 days ago)
-        let cert_path = mgr.cert_path("old.example.com");
-        fs::write(&cert_path, b"fake-cert-data").unwrap();
-        let old_time = SystemTime::now() - Duration::from_secs(91 * 24 * 3600);
-        filetime::set_file_mtime(&cert_path, filetime::FileTime::from_system_time(old_time))
-            .unwrap();
+        let path = super::super::certs::mint_cert_expiring_in(tmp.path(), 10);
+        std::fs::rename(path, mgr.cert_path("old.example.com")).unwrap();
 
         assert!(mgr.needs_renewal("old.example.com"));
     }
 
+    /// A certificate with plenty of validity left does not need renewal.
     #[test]
-    fn test_cert_ok_when_fresh() {
+    fn test_cert_ok_when_validity_remains() {
         let tmp = TempDir::new().unwrap();
         let mgr = AcmeManager::new("test@example.com", tmp.path());
 
-        // Create a cert file with recent modification time (1 day ago)
-        let cert_path = mgr.cert_path("fresh.example.com");
-        fs::write(&cert_path, b"fake-cert-data").unwrap();
-        let recent_time = SystemTime::now() - Duration::from_secs(24 * 3600);
-        filetime::set_file_mtime(
-            &cert_path,
-            filetime::FileTime::from_system_time(recent_time),
-        )
-        .unwrap();
+        let path = super::super::certs::mint_cert_expiring_in(tmp.path(), 60);
+        std::fs::rename(path, mgr.cert_path("fresh.example.com")).unwrap();
 
         assert!(!mgr.needs_renewal("fresh.example.com"));
+    }
+
+    /// Unparseable cert data must be treated as needing renewal.
+    #[test]
+    fn test_garbage_cert_needs_renewal() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = AcmeManager::new("test@example.com", tmp.path());
+        std::fs::write(mgr.cert_path("junk.example.com"), b"fake-cert-data").unwrap();
+
+        assert!(mgr.needs_renewal("junk.example.com"));
     }
 }


### PR DESCRIPTION
Fixes #156.

## What

`check_cert_expiry` now reads the leaf certificate (chain is leaf-first per RFC 8555) and computes days remaining from its `NotAfter` — never from file metadata:

- Copied / backup-restored / node-migrated certs report their true remaining validity instead of looking freshly issued.
- Already-expired certs report **negative** days (both callers compare against the 30-day threshold, so semantics are unchanged).
- Unparseable cert data errors, which `needs_renewal` already treats as needs-renewal — corrupt certs no longer pass as fresh.

Uses `x509-parser` (already in the dependency tree via the TLS stack — no new crates).

## Tests

- New unit tests in `certs.rs`: fresh-mtime cert expiring in 10 days reports ~10 (fails on `main` with 90), expired cert reports ≤ 0, garbage errors. Certs are minted with rcgen and a controlled `NotAfter`.
- The mtime-manipulation tests in `renewal.rs` (`filetime` dev-dep, now removed) are replaced with real-cert equivalents, plus a garbage-cert-needs-renewal case that the old implementation gets wrong.
- `cargo fmt`, `clippy -D warnings`, full `cargo test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)