### PR TITLE
feat(control): restart dependents when a dependency is recreated

### DIFF
--- a/crates/orca-control/src/api/handlers/ops/deploy.rs
+++ b/crates/orca-control/src/api/handlers/ops/deploy.rs
@@ -41,20 +41,29 @@ pub(crate) async fn rollback(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    ok_or_500(
-        reconciler::rollback(&state, &name).await,
-        &format!("rollback {name}"),
-    )
+    let result = reconciler::rollback(&state, &name).await;
+    if result.is_ok() {
+        // Rollback recreates the container (new network identity); its
+        // dependents must reconnect. reconcile() does this for the declarative
+        // path — the manual path goes straight through operations::redeploy,
+        // so trigger it here. restart_dependents computes the full transitive
+        // set and never re-enters this handler, so no recursion.
+        crate::dependents::restart_dependents(&state, std::slice::from_ref(&name)).await;
+    }
+    ok_or_500(result, &format!("rollback {name}"))
 }
 
 pub(crate) async fn redeploy(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    ok_or_500(
-        reconciler::redeploy(&state, &name).await,
-        &format!("redeploy {name}"),
-    )
+    let result = reconciler::redeploy(&state, &name).await;
+    if result.is_ok() {
+        // See rollback: a manual redeploy replaces the container, so its
+        // dependents are restarted to drop black-holed connections.
+        crate::dependents::restart_dependents(&state, std::slice::from_ref(&name)).await;
+    }
+    ok_or_500(result, &format!("redeploy {name}"))
 }
 
 pub(crate) async fn promote(

--- a/crates/orca-control/src/dependents.rs
+++ b/crates/orca-control/src/dependents.rs
@@ -1,0 +1,74 @@
+//! Restart services whose `depends_on` target was just recreated.
+//!
+//! Regression context (2026-08-10, stepshots login outage): recreating a
+//! valkey container gave it a new network identity, but the app that
+//! `depends_on` it kept pooled TCP connections to the old address. A removed
+//! container never sends RST, so those connections black-hole: every login
+//! hung in the post-handler session write until the reverse proxy's read
+//! timeout and surfaced as a 502 — while the deploy itself reported success
+//! and anonymous traffic stayed healthy. The reconciler now restarts running
+//! dependents (transitively) after a dependency's workloads were replaced.
+
+use std::collections::HashSet;
+
+use orca_core::config::ServiceConfig;
+
+use crate::state::AppState;
+
+/// Compute which services to restart, in dependency order, given the names of
+/// services whose workloads were just replaced.
+///
+/// Transitive on purpose: a restarted dependent counts as changed for *its*
+/// dependents in turn — its restart replaces the containers its own consumers
+/// are connected to. Services already in `changed` are never returned; they
+/// were just (re)created with fresh connections.
+pub fn restart_set(all: &[ServiceConfig], changed: &[String]) -> Vec<String> {
+    let mut changed: HashSet<&str> = changed.iter().map(String::as_str).collect();
+    let ordered = crate::topo_sort::topo_sort(all);
+    let mut to_restart = Vec::new();
+    for svc in &ordered {
+        if changed.contains(svc.name.as_str()) {
+            continue;
+        }
+        if svc.depends_on.iter().any(|d| changed.contains(d.as_str())) {
+            to_restart.push(svc.name.clone());
+            changed.insert(svc.name.as_str());
+        }
+    }
+    to_restart
+}
+
+/// Restart every running dependent of the just-changed services via
+/// `operations::redeploy`, which already handles both master-local services
+/// (rolling replace) and placement-pinned remote ones (WS stop + deploy).
+///
+/// Failures are logged, never propagated — a dependent that fails to restart
+/// must not fail the deploy that triggered it. Stopped/paused services are
+/// skipped: they reconnect on their own next start.
+pub async fn restart_dependents(state: &AppState, changed: &[String]) {
+    if changed.is_empty() {
+        return;
+    }
+    let all: Vec<ServiceConfig> = {
+        let services = state.services.read().await;
+        services.values().map(|s| s.config.clone()).collect()
+    };
+    for name in restart_set(&all, changed) {
+        let running = {
+            let services = state.services.read().await;
+            services
+                .get(&name)
+                .is_some_and(|s| !s.stopped && s.running_count() > 0)
+        };
+        if !running {
+            continue;
+        }
+        tracing::info!(
+            service = %name,
+            "dependency was recreated — restarting dependent to refresh its connections"
+        );
+        if let Err(e) = crate::operations::redeploy(state, &name).await {
+            tracing::warn!(service = %name, "dependent restart failed: {e}");
+        }
+    }
+}

--- a/crates/orca-control/src/lib.rs
+++ b/crates/orca-control/src/lib.rs
@@ -235,7 +235,9 @@ async fn restore_or_reconcile(
         }
     }
 
-    reconciler::reconcile_service(state, config).await.map(|_| ())
+    reconciler::reconcile_service(state, config)
+        .await
+        .map(|_| ())
 }
 
 /// Populate in-memory `ServiceState` from already-running Docker containers.

--- a/crates/orca-control/src/lib.rs
+++ b/crates/orca-control/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cluster_api;
 pub(crate) mod cluster_handlers;
 pub mod cluster_state;
 pub mod declarative;
+pub mod dependents;
 pub mod deploy_history;
 pub mod failures;
 pub mod health;
@@ -234,7 +235,7 @@ async fn restore_or_reconcile(
         }
     }
 
-    reconciler::reconcile_service(state, config).await
+    reconciler::reconcile_service(state, config).await.map(|_| ())
 }
 
 /// Populate in-memory `ServiceState` from already-running Docker containers.

--- a/crates/orca-control/src/operations/lifecycle.rs
+++ b/crates/orca-control/src/operations/lifecycle.rs
@@ -146,7 +146,7 @@ pub async fn scale(state: &AppState, service_name: &str, replicas: u32) -> anyho
         config.replicas = Replicas::Fixed(replicas);
         config
     };
-    reconcile_service(state, &config).await
+    reconcile_service(state, &config).await.map(|_| ())
 }
 
 /// Perform a rolling update: start new instances, update routes to drain

--- a/crates/orca-control/src/reconciler.rs
+++ b/crates/orca-control/src/reconciler.rs
@@ -35,14 +35,18 @@ pub fn load_byo_cert(
 pub async fn reconcile(state: &AppState, services: &[ServiceConfig]) -> (Vec<String>, Vec<String>) {
     let mut deployed = Vec::new();
     let mut errors = Vec::new();
+    let mut changed = Vec::new();
 
     let ordered = crate::topo_sort::topo_sort(services);
     for svc_config in &ordered {
         match reconcile_service(state, svc_config).await {
-            Ok(()) => {
+            Ok(outcome) => {
                 // Record successful deploy in history and clear any prior failure.
                 state.deploy_history.write().await.record(svc_config);
                 state.last_failures.write().await.remove(&svc_config.name);
+                if outcome == ReconcileOutcome::Changed {
+                    changed.push(svc_config.name.clone());
+                }
                 deployed.push(svc_config.name.clone());
             }
             Err(e) => {
@@ -62,7 +66,25 @@ pub async fn reconcile(state: &AppState, services: &[ServiceConfig]) -> (Vec<Str
         .iter()
         .for_each(|name| info!("Deployed service: {name}"));
 
+    // Services whose workloads were replaced leave their dependents holding
+    // TCP connections to peers that no longer exist (a removed container
+    // never sends RST) — restart those dependents so they reconnect.
+    crate::dependents::restart_dependents(state, &changed).await;
+
     (deployed, errors)
+}
+
+/// Whether reconciling a service actually touched its workloads.
+///
+/// [`reconcile`] uses this to know which services' containers were replaced —
+/// their dependents (`depends_on`) are then restarted via
+/// [`crate::dependents::restart_dependents`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReconcileOutcome {
+    /// Spec unchanged, instances already at desired state — nothing touched.
+    Unchanged,
+    /// Workloads were created, replaced, scaled, or dispatched to an agent.
+    Changed,
 }
 
 /// Get the appropriate runtime for a service config.
@@ -81,7 +103,7 @@ pub(crate) fn get_runtime(state: &AppState, kind: RuntimeKind) -> anyhow::Result
 pub(crate) async fn reconcile_service(
     state: &AppState,
     config: &ServiceConfig,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<ReconcileOutcome> {
     let desired = match &config.replicas {
         Replicas::Fixed(n) => *n,
         Replicas::Auto => 1,
@@ -123,7 +145,7 @@ pub(crate) async fn reconcile_service(
                         "Service {} already at desired state on node {} (same spec) — skipping",
                         config.name, target_node_id
                     );
-                    return Ok(());
+                    return Ok(ReconcileOutcome::Unchanged);
                 }
             }
         }
@@ -168,7 +190,7 @@ pub(crate) async fn reconcile_service(
             "Queued deploy of {} to remote node {}",
             config.name, target_node_id
         );
-        return Ok(());
+        return Ok(ReconcileOutcome::Changed);
     }
 
     let runtime = get_runtime(state, config.runtime)?;
@@ -233,7 +255,7 @@ pub(crate) async fn reconcile_service(
             RuntimeKind::Container => update_container_routes(state, config).await,
             RuntimeKind::Wasm => update_wasm_triggers(state, config).await,
         }
-        return Ok(());
+        return Ok(ReconcileOutcome::Unchanged);
     }
 
     // Config changed but replica count is the same — update in place.
@@ -251,10 +273,10 @@ pub(crate) async fn reconcile_service(
             info!("Rolling update for {name} ({desired} replicas)");
             crate::operations::rolling_update(state, runtime, config, &spec, desired).await?;
         }
-        return Ok(());
+        return Ok(ReconcileOutcome::Changed);
     }
 
-    if current < desired {
+    let outcome = if current < desired {
         let to_create = desired - current;
         info!(
             "Scaling up {} ({:?}): {} -> {} (+{})",
@@ -318,6 +340,7 @@ pub(crate) async fn reconcile_service(
             let _ = runtime.stop(&handle, Duration::from_secs(10)).await;
             let _ = runtime.remove(&handle).await;
         }
+        ReconcileOutcome::Changed
     } else if current > desired {
         let to_remove = current - desired;
         info!(
@@ -344,9 +367,11 @@ pub(crate) async fn reconcile_service(
             let _ = runtime.stop(&handle, Duration::from_secs(10)).await;
             let _ = runtime.remove(&handle).await;
         }
+        ReconcileOutcome::Changed
     } else {
         drop(services);
-    }
+        ReconcileOutcome::Unchanged
+    };
 
     // Update routing based on runtime type
     match config.runtime {
@@ -379,7 +404,7 @@ pub(crate) async fn reconcile_service(
         }
     }
 
-    Ok(())
+    Ok(outcome)
 }
 
 /// Send a deploy command to a remote agent node and await the result.

--- a/crates/orca-control/src/reconciler.rs
+++ b/crates/orca-control/src/reconciler.rs
@@ -314,9 +314,10 @@ pub(crate) async fn reconcile_service(
         }
         // Re-acquire write lock and guard against concurrent deploy overshoot:
         // another reconcile may have created instances while the lock was dropped.
-        let excess_handles = {
+        let (excess_handles, added) = {
             let mut services = state.services.write().await;
             let mut excess = Vec::new();
+            let mut added = 0usize;
             if let Some(svc_state) = services.get_mut(&config.name) {
                 let already = svc_state
                     .instances
@@ -332,15 +333,24 @@ pub(crate) async fn reconcile_service(
                         .map(|i| i.handle)
                         .collect();
                 }
+                added = to_add.len();
                 svc_state.instances.extend(to_add);
             }
-            excess
+            (excess, added)
         };
         for handle in excess_handles {
             let _ = runtime.stop(&handle, Duration::from_secs(10)).await;
             let _ = runtime.remove(&handle).await;
         }
-        ReconcileOutcome::Changed
+        // A scale-up only counts as Changed if at least one instance was
+        // actually added. If every create failed (or all were trimmed as
+        // concurrent-overshoot), nothing was touched — reporting Changed here
+        // would restart healthy dependents for a no-op deploy.
+        if added > 0 {
+            ReconcileOutcome::Changed
+        } else {
+            ReconcileOutcome::Unchanged
+        }
     } else if current > desired {
         let to_remove = current - desired;
         info!(

--- a/crates/orca-control/tests/depends_on_test.rs
+++ b/crates/orca-control/tests/depends_on_test.rs
@@ -104,8 +104,7 @@ fn test_restart_set_direct_dependent() {
         make_service("app", vec!["postgres", "valkey"]),
     ];
 
-    let restarts =
-        orca_control::dependents::restart_set(&services, &["valkey".to_string()]);
+    let restarts = orca_control::dependents::restart_set(&services, &["valkey".to_string()]);
     assert_eq!(restarts, vec!["app".to_string()]);
 }
 
@@ -138,10 +137,8 @@ fn test_restart_set_skips_changed_and_unrelated() {
     ];
 
     // Both db and app were just recreated by the deploy itself — nothing to do.
-    let restarts = orca_control::dependents::restart_set(
-        &services,
-        &["db".to_string(), "app".to_string()],
-    );
+    let restarts =
+        orca_control::dependents::restart_set(&services, &["db".to_string(), "app".to_string()]);
     assert!(restarts.is_empty());
 
     // Nothing changed at all.

--- a/crates/orca-control/tests/depends_on_test.rs
+++ b/crates/orca-control/tests/depends_on_test.rs
@@ -94,3 +94,57 @@ fn test_missing_dependency_handled() {
     let ordered = topo_sort(&services);
     assert_eq!(ordered.len(), 2, "all services must be present");
 }
+
+/// A recreated dependency puts its direct dependents in the restart set.
+#[test]
+fn test_restart_set_direct_dependent() {
+    let services = vec![
+        make_service("postgres", vec![]),
+        make_service("valkey", vec![]),
+        make_service("app", vec!["postgres", "valkey"]),
+    ];
+
+    let restarts =
+        orca_control::dependents::restart_set(&services, &["valkey".to_string()]);
+    assert_eq!(restarts, vec!["app".to_string()]);
+}
+
+/// The cascade is transitive: restarting a dependent counts as a change for
+/// its own dependents, in dependency order.
+#[test]
+fn test_restart_set_transitive() {
+    let services = vec![
+        make_service("db", vec![]),
+        make_service("api", vec!["db"]),
+        make_service("frontend", vec!["api"]),
+    ];
+
+    let restarts = orca_control::dependents::restart_set(&services, &["db".to_string()]);
+    assert_eq!(
+        restarts,
+        vec!["api".to_string(), "frontend".to_string()],
+        "api must restart before frontend"
+    );
+}
+
+/// Services already recreated in the deploy are never restarted again, and
+/// unrelated services are untouched.
+#[test]
+fn test_restart_set_skips_changed_and_unrelated() {
+    let services = vec![
+        make_service("db", vec![]),
+        make_service("app", vec!["db"]),
+        make_service("other", vec![]),
+    ];
+
+    // Both db and app were just recreated by the deploy itself — nothing to do.
+    let restarts = orca_control::dependents::restart_set(
+        &services,
+        &["db".to_string(), "app".to_string()],
+    );
+    assert!(restarts.is_empty());
+
+    // Nothing changed at all.
+    let restarts = orca_control::dependents::restart_set(&services, &[]);
+    assert!(restarts.is_empty());
+}

--- a/crates/orca-proxy/src/forward.rs
+++ b/crates/orca-proxy/src/forward.rs
@@ -3,10 +3,45 @@
 use http_body_util::BodyDataStream;
 use hyper::body::Incoming;
 use hyper::{Response, StatusCode};
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::RouteTarget;
 use crate::body::{ProxyBody, full_body, stream_body};
+
+/// First-byte latency beyond which the backend is called out explicitly.
+///
+/// A backend that stalls until the client read timeout otherwise surfaces
+/// only as a proxy-side 502, which reads as a proxy fault. 2026-08-10:
+/// black-holed session-store connections made login POSTs hang for the full
+/// 120s read timeout, and the resulting 502s were initially blamed on the
+/// proxy. 30s is far above any healthy backend's first byte but well below
+/// the read timeout, so the log points at the backend while the request is
+/// still pending.
+const SLOW_BACKEND_WARN_AFTER: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Await `send()`, warning once if the backend takes longer than
+/// [`SLOW_BACKEND_WARN_AFTER`] to produce response headers — whether or not
+/// it eventually succeeds.
+async fn send_with_slow_warn(
+    forward_req: reqwest::RequestBuilder,
+    address: &str,
+    path_and_query: &str,
+) -> Result<reqwest::Response, reqwest::Error> {
+    let started = std::time::Instant::now();
+    let result = forward_req.send().await;
+    let elapsed = started.elapsed();
+    if elapsed > SLOW_BACKEND_WARN_AFTER {
+        warn!(
+            backend = %address,
+            path = %path_and_query,
+            elapsed_ms = elapsed.as_millis() as u64,
+            ok = result.is_ok(),
+            "slow backend: first byte exceeded warn threshold — if this \
+             surfaces as a 502, the backend stalled, not the proxy"
+        );
+    }
+    result
+}
 
 /// Select a target index using weighted round-robin.
 ///
@@ -204,7 +239,7 @@ pub(crate) async fn forward_with_retry(
         debug!("Proxying {host}{path_and_query} -> {uri} (attempt {attempt})");
         let forward_req = forward_req.body(body.clone());
 
-        match forward_req.send().await {
+        match send_with_slow_warn(forward_req, &target.address, path_and_query).await {
             Ok(resp) if resp.status() == StatusCode::BAD_GATEWAY && attempt + 1 < max_attempts => {
                 debug!("Got 502 from {}, retrying", target.address);
                 continue;
@@ -278,7 +313,7 @@ pub(crate) async fn forward_streaming(
         forward_req.body(reqwest::Body::wrap_stream(BodyDataStream::new(body)))
     };
 
-    match forward_req.send().await {
+    match send_with_slow_warn(forward_req, &target.address, path_and_query).await {
         Ok(resp) => build_response(resp),
         Err(e) => {
             error!("Proxy error to {}: {e}", target.address);

--- a/crates/orca-proxy/src/forward.rs
+++ b/crates/orca-proxy/src/forward.rs
@@ -19,28 +19,32 @@ use crate::body::{ProxyBody, full_body, stream_body};
 /// still pending.
 const SLOW_BACKEND_WARN_AFTER: std::time::Duration = std::time::Duration::from_secs(30);
 
-/// Await `send()`, warning once if the backend takes longer than
-/// [`SLOW_BACKEND_WARN_AFTER`] to produce response headers — whether or not
-/// it eventually succeeds.
+/// Await `send()`, emitting a warning *while the request is still pending* if
+/// the backend takes longer than [`SLOW_BACKEND_WARN_AFTER`] to respond, then
+/// continuing to wait for the eventual result. Racing the send against a timer
+/// (rather than measuring after it resolves) means the log lands at the 30s
+/// mark during a live stall — not at ~120s alongside the read-timeout 502,
+/// where it would add nothing over the error itself.
 async fn send_with_slow_warn(
     forward_req: reqwest::RequestBuilder,
     address: &str,
     path_and_query: &str,
 ) -> Result<reqwest::Response, reqwest::Error> {
-    let started = std::time::Instant::now();
-    let result = forward_req.send().await;
-    let elapsed = started.elapsed();
-    if elapsed > SLOW_BACKEND_WARN_AFTER {
-        warn!(
-            backend = %address,
-            path = %path_and_query,
-            elapsed_ms = elapsed.as_millis() as u64,
-            ok = result.is_ok(),
-            "slow backend: first byte exceeded warn threshold — if this \
-             surfaces as a 502, the backend stalled, not the proxy"
-        );
+    let send = forward_req.send();
+    tokio::pin!(send);
+    tokio::select! {
+        result = &mut send => result,
+        _ = tokio::time::sleep(SLOW_BACKEND_WARN_AFTER) => {
+            warn!(
+                backend = %address,
+                path = %path_and_query,
+                threshold_secs = SLOW_BACKEND_WARN_AFTER.as_secs(),
+                "slow backend: no response after threshold and still waiting — \
+                 if this surfaces as a 502, the backend stalled, not the proxy"
+            );
+            send.await
+        }
     }
-    result
 }
 
 /// Select a target index using weighted round-robin.


### PR DESCRIPTION
Fixes #159.

## Problem

Recreating a service's container (any spec change) gives it a new network identity, while its `depends_on` dependents keep pooled TCP connections to the old address. A removed container never sends RST, so those connections black-hole silently — the deploy reports success while dependents are broken. This caused the 2026-08-10 stepshots login outage (details in #159).

## Changes

**`feat(control)`: restart dependents on dependency recreation**

- `reconcile_service` now returns `ReconcileOutcome` (`Changed`/`Unchanged`) instead of `()` — the skip paths (#120 idempotency) report `Unchanged`, every path that creates/replaces/scales/dispatches workloads reports `Changed`
- new `dependents` module: after each reconcile batch, `restart_set` computes the transitive restart set in dependency order (reuses `topo_sort`); `restart_dependents` bounces each running dependent via the existing `operations::redeploy` path, which already handles both master-local and placement-pinned remote services
- stopped/paused services are skipped; restart failures are logged, never propagated — a dependent that fails to restart must not fail the deploy that triggered it
- services recreated by the deploy itself are never restarted again (they already have fresh connections)

**`feat(proxy)`: WARN when a backend exceeds 30s to first byte**

A backend that stalls until the 120s read timeout surfaces only as a proxy-side 502, which reads as a proxy fault — during the incident above, the 502s were initially blamed on the proxy. Both forward paths now log an explicit WARN naming the backend and path once first-byte latency crosses 30s.

## Tests

- `restart_set` unit coverage in `tests/depends_on_test.rs`: direct dependent, transitive cascade (dependency order asserted), already-changed and unrelated services excluded, empty change set
- full `orca-control` + `orca-proxy` suites pass; `cargo fmt` + `clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)