### PR TITLE
feat(api): expose depends_on in ServiceStatus

### DIFF
--- a/crates/orca-control/src/api/handlers/mod.rs
+++ b/crates/orca-control/src/api/handlers/mod.rs
@@ -129,6 +129,7 @@ pub(crate) async fn status(
                 domain: svc.config.primary_domain(),
                 domains: svc.config.all_domains(),
                 project: svc.config.project.clone(),
+                depends_on: svc.config.depends_on.clone(),
                 memory_usage: cached.map(|s| s.memory_usage.clone()),
                 cpu_percent: cached.map(|s| s.cpu_percent),
                 node: svc.config.placement.as_ref().and_then(|p| p.node.clone()),

--- a/crates/orca-core/src/api_types.rs
+++ b/crates/orca-core/src/api_types.rs
@@ -78,6 +78,10 @@ pub struct ServiceStatus {
     /// Project name (from service directory).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub project: Option<String>,
+    /// Services this one depends on (`depends_on` from the service config).
+    /// Lets dashboards draw the dependency graph without fetching configs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
     /// Current memory usage (e.g. "128Mi"), if stats are available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_usage: Option<String>,


### PR DESCRIPTION
Adds the service's `depends_on` list to `ServiceStatus` (skipped when empty), so dashboards and the TUI can draw the dependency graph without fetching every service config.

Pairs naturally with #160, which acts on `depends_on` at reconcile time — this makes the same relationships visible in the status API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)