### PR TITLE
fix(agent): warn when a redeploy moves a service to a different network (#163)

### DIFF
--- a/crates/orca-agent/src/docker/config_builder/mod.rs
+++ b/crates/orca-agent/src/docker/config_builder/mod.rs
@@ -100,6 +100,25 @@ pub(crate) fn network_name(spec: &WorkloadSpec) -> String {
     }
 }
 
+/// Detect a network-identity change for a service being (re)created (#163).
+///
+/// Given the network the service is about to be created on (`derived`) and the
+/// orca networks its existing container is currently attached to (`attached`),
+/// return the existing service network if it differs from `derived`. A
+/// mismatch means the redeploy would silently move the service off the network
+/// its project siblings share — their connections black-hole (aliases stop
+/// resolving) while the deploy still reports success.
+///
+/// `orca-internal` (the shared cross-service network that every `internal`
+/// service also joins) and non-orca networks (`bridge`, etc.) are ignored:
+/// only a real per-service orca network counts as drift.
+pub(crate) fn drifted_service_network(derived: &str, attached: &[String]) -> Option<String> {
+    attached
+        .iter()
+        .find(|n| n.starts_with("orca-") && n.as_str() != "orca-internal" && n.as_str() != derived)
+        .cloned()
+}
+
 /// Map the spec's restart-policy string to Docker's (#121). Invalid values
 /// are rejected at config load (`ServiceConfig::validate`); anything
 /// unrecognized here degrades to None (Docker default: no restart) rather
@@ -147,5 +166,38 @@ mod restart_policy_tests {
         let p = build_restart_policy(Some("on-failure")).unwrap();
         assert_eq!(p.maximum_retry_count, None);
         assert!(build_restart_policy(Some("garbage")).is_none());
+    }
+}
+
+#[cfg(test)]
+mod network_drift_tests {
+    use super::drifted_service_network;
+
+    #[test]
+    fn no_drift_when_on_the_derived_network() {
+        let attached = vec!["orca-dxseo".to_string(), "orca-internal".to_string()];
+        assert_eq!(drifted_service_network("orca-dxseo", &attached), None);
+    }
+
+    #[test]
+    fn drift_when_existing_service_network_differs() {
+        // The #163 case: existing container on orca-dxseo, redeploy derives
+        // orca-dx-seo — the service would move and split from its siblings.
+        let attached = vec!["orca-dxseo".to_string()];
+        assert_eq!(
+            drifted_service_network("orca-dx-seo", &attached),
+            Some("orca-dxseo".to_string())
+        );
+    }
+
+    #[test]
+    fn internal_and_non_orca_networks_are_ignored() {
+        let attached = vec!["orca-internal".to_string(), "bridge".to_string()];
+        assert_eq!(drifted_service_network("orca-app", &attached), None);
+    }
+
+    #[test]
+    fn no_container_no_drift() {
+        assert_eq!(drifted_service_network("orca-app", &[]), None);
     }
 }

--- a/crates/orca-agent/src/docker/runtime.rs
+++ b/crates/orca-agent/src/docker/runtime.rs
@@ -162,6 +162,24 @@ impl ContainerRuntime {
         Ok(ip)
     }
 
+    /// List the Docker networks a container is currently attached to. Returns
+    /// an empty list if the container does not exist or can't be inspected —
+    /// this is best-effort (it only drives a warning), never a hard error.
+    pub async fn container_networks(&self, container_id: &str) -> Vec<String> {
+        match self
+            .docker
+            .inspect_container(container_id, None::<InspectContainerOptions>)
+            .await
+        {
+            Ok(info) => info
+                .network_settings
+                .and_then(|ns| ns.networks)
+                .map(|nets| nets.into_keys().collect())
+                .unwrap_or_default(),
+            Err(_) => Vec::new(),
+        }
+    }
+
     /// Inspect a container and return its assigned host port for the primary port.
     pub async fn get_host_port(
         &self,

--- a/crates/orca-agent/src/docker/runtime_impl.rs
+++ b/crates/orca-agent/src/docker/runtime_impl.rs
@@ -37,6 +37,26 @@ impl Runtime for ContainerRuntime {
         let config = super::config_builder::build_container_config(spec);
         let network = super::config_builder::network_name(spec);
 
+        // #163: warn if this (re)deploy would move the service onto a different
+        // orca network than its existing container is on. That silently splits
+        // the service from its project siblings (aliases stop resolving) while
+        // the deploy still reports success. Inspect BEFORE the old container is
+        // removed below. Best-effort and non-fatal; we don't auto-reattach,
+        // because the control plane derives the network name for routing and
+        // the two layers must agree — see issue #163 for the full analysis.
+        let attached = self.container_networks(&container_name).await;
+        if let Some(existing) = super::config_builder::drifted_service_network(&network, &attached)
+        {
+            tracing::warn!(
+                service = %spec.name,
+                from_network = %existing,
+                to_network = %network,
+                "service is being recreated on a different network than its running \
+                 container uses — project siblings on {existing} will lose it. Redeploy \
+                 the whole project together, or pin `network` in the service config."
+            );
+        }
+
         // Ensure the service network exists
         let _ = self.ensure_network(&network).await;
 


### PR DESCRIPTION
Fixes #163.

## What #163 actually is

`git blame` correction first: the issue attributes the split to #140, but #140 only added the #89 warn breadcrumb. The `svc.network = Some(<dir>)` default has existed since `bcc66e9` (project isolation, April). So this is **not** a v0.2.12 regression.

The real cause: the derived orca network name is **path-dependent**.
- Directory-loaded services (`orca deploy services/`) get `orca-<dir>`.
- Single-file deploys, adopted containers, and anything from before the project-isolation logic fall back to the service-name prefix `orca-<prefix>`.

When a project's directory name and its service-name prefix differ (`services/dx-seo/` + `dxseo-app`), a **partial** redeploy lands the redeployed service on a different network than its already-running siblings. Their connections then black-hole — a removed container never sends RST and network aliases stop resolving — while the deploy reports success and `orca status` shows nothing wrong.

## Why this is detect-and-warn, not auto-grandfather

An automatic reattach is unsafe as a point fix: the control plane derives the network name **independently** for routing (`instance.rs` → `resolve_container_address(handle, port, network)` reads the container IP *on that network*), so the agent and master must agree on the name. Making them agree across a remote/placement-pinned node is a larger, multi-node change — tracked as follow-up. Until then, the safe, non-destructive fix is to make the drift loud and actionable rather than silent.

## Change

Before replacing a container, the agent compares the orca network it's about to (re)create the service on against the networks the existing container is actually attached to. If they differ, it logs a loud, actionable WARN naming both networks and telling the operator to redeploy the whole project or pin `network`.

- `drifted_service_network` — pure, unit-tested helper (ignores `orca-internal` and non-orca networks).
- `container_networks` — best-effort inspect of a container's attached networks (empty on any failure; only drives the warning, never a hard error).

## Tests

`cargo test -p orca-agent` green; 4 new unit tests cover the drift/no-drift/internal-ignored/no-container cases. `fmt` + `clippy -D warnings` clean.

## Workaround (unchanged, still valid)

Redeploy the whole project together so every container lands on the same network:
`orca redeploy dxseo-postgres && orca redeploy dxseo-app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)