### PR TITLE
chore(release): v0.2.13-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.13-rc.1] - 2026-08-19
+
+Contributor release: six PRs from @hauju plus a network-split diagnostic,
+reviewed and hardened before merge (see the release PR for the review notes).
+
+### Added
+
+- **`depends_on` exposed in the status API.** `ServiceStatus` now carries the service's `depends_on` list (omitted when empty), so dashboards and the TUI can draw the dependency graph without fetching every service config. Pairs with the dependency-aware restarts below. (#161)
+
+### Fixed
+
+- **Certificates are provisioned on every reconcile path, and failed orders self-heal.** A domain added to a running service after startup never got a cert until a full restart, and a provision that failed (DNS not yet cut over, port 80 briefly blocked) stayed broken until the next day. Cert provisioning now runs on the same-spec, rolling/canary, and scale paths — not just first boot — and a 60s fast-retry loop (1m → 5m → 15m backoff, under Let's Encrypt's failed-validation limit) recovers failed or never-attempted orders. The ACME stack now also starts with zero domains whenever `acme_email` is set, and `ORCA_ACME_DIRECTORY` lets migration rehearsals run against LE staging. BYO-cert domains are never registered for ACME, and the fast-retry loop is per-domain time-boxed so one hung challenge can't stall the others. (#152)
+- **Certificate expiry is read from the certificate, not the file's mtime.** `check_cert_expiry` now parses the leaf cert's `NotAfter` instead of assuming `mtime + 90 days`, so a copied, backup-restored, or node-migrated cert reports its true remaining validity (an expired one reports negative days) instead of looking freshly issued and silently skipping renewal. Unparseable cert data is treated as needs-renewal. (#156)
+- **`orca status` reports observed container state, not deploy-time state.** Instances were marked `running` optimistically on create and only corrected by the 30s watchdog, so a failed deploy read as `running` while Docker showed `Exited (1)`. Agent heartbeats and the status endpoint now query the runtime for the real state (a vanished container surfaces as `failed`); the endpoint's refresh is keyed by container id (never a positional index, which a concurrent reconcile could invalidate) and each query is time-boxed so a wedged Docker daemon can't hang `/status`. (#154)
+- **Recreating a service restarts its dependents.** Recreating a container gives it a new network identity while its `depends_on` dependents keep pooled TCP connections to the dead address — a removed container never sends RST, so those connections black-hole and the deploy still reports success (the 2026-08-10 login outage). After a reconcile — and after a manual `orca redeploy` / `orca rollback` — running dependents are now restarted in dependency order so they reconnect. The proxy also warns when a backend exceeds 30s to first byte (mid-flight, during the stall), so a backend hang is no longer mistaken for a proxy fault. (#159)
+- **Security: the proxy no longer trusts a client-supplied `X-Forwarded-For`.** The proxy forwarded the client's `X-Forwarded-For` verbatim when present, letting any client pick the address downstream consumers key on (rate limiting, per-visitor logic). It now always appends the observed peer and re-emits a single header, so the right-most entry is the address the proxy actually saw; a client-supplied prefix is preserved but inert, and a legitimate multi-hop chain (several header lines) is kept intact. (#162)
+- **Warn when a redeploy would move a service to a different network.** A service's orca network name is path-dependent (directory-loaded services get `orca-<dir>`; other paths fall back to `orca-<prefix>`), so a partial redeploy could land a service on a different network than its already-running siblings, black-holing their connections (aliases stop resolving) while the deploy reported success. The agent now warns, before replacing a container, when the derived network differs from the one the existing container is on — telling the operator to redeploy the whole project or pin `network`. (Automatic reattach is deferred: the control plane derives the same name independently for routing, so the two must agree — tracked as follow-up.) (#163)
+
 ## [0.2.12] - 2026-07-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "mallorca"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2966,7 +2966,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orca-agent"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "orca-ai"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "orca-control"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "orca-core"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "aes-gcm",
  "age",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "orca-proxy"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "orca-tui"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "orca-web"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/wasm-hello"]
 
 [workspace.package]
-version = "0.2.12"
+version = "0.2.13"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mighty840/orca"
@@ -38,9 +38,9 @@ incremental = false
 
 [workspace.dependencies]
 # Shared across crates
-orca-core = { path = "crates/orca-core", version = "0.2.12" }
-orca-ai = { path = "crates/orca-ai", version = "0.2.12" }
-orca-proxy = { path = "crates/orca-proxy", version = "0.2.12" }
+orca-core = { path = "crates/orca-core", version = "0.2.13" }
+orca-ai = { path = "crates/orca-ai", version = "0.2.13" }
+orca-proxy = { path = "crates/orca-proxy", version = "0.2.13" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/orca-cli/Cargo.toml
+++ b/crates/orca-cli/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/main.rs"
 [dependencies]
 orca-core = { workspace = true }
 orca-ai = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.12" }
-orca-control = { path = "../orca-control", version = "0.2.12" }
+orca-agent = { path = "../orca-agent", version = "0.2.13" }
+orca-control = { path = "../orca-control", version = "0.2.13" }
 orca-proxy = { workspace = true }
-orca-tui = { path = "../orca-tui", version = "0.2.12" }
+orca-tui = { path = "../orca-tui", version = "0.2.13" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 
 [dependencies]
 orca-core = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.12" }
+orca-agent = { path = "../orca-agent", version = "0.2.13" }
 orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
Bumps the workspace to **0.2.13** and adds the CHANGELOG entry for the rc.1 batch. All the code below is **already on `main`** (merged as individual squash PRs); this PR is just the version + changelog, so tagging `v0.2.13-rc.1` after merge points at a released version.

## What's in rc.1

Six PRs from @hauju plus a net-new #163 diagnostic. Each hauju PR was correctness-reviewed and **hardened before merge** (fixup commits on each branch):

| PR | Change | Review hardening applied |
|----|--------|--------------------------|
| #152 / [#153] | Provision certs on every reconcile path + self-healing fast-retry | **BYO domains excluded from ACME** (was: silent cert overwrite risk); per-domain **timeout** on the retry loop |
| #156 / [#157] | Cert expiry from `NotAfter`, not file mtime | clean as-is |
| #154 / [#155] | `orca status` reports observed container state | write-back **keyed by `runtime_id`** (was: index race); **timeout** on the `/status` hot path |
| #159 / [#160] | Restart dependents when a dependency is recreated | scale-up only `Changed` when an instance was really added; manual `redeploy`/`rollback` now restart dependents; slow-backend WARN fires **mid-flight** |
| — / [#161] | `depends_on` in the status API | clean as-is |
| — / [#162] | Don't trust client `X-Forwarded-For` (security) | multi-line XFF **preserved**, not overwritten |
| #163 / [#164] | Warn when a redeploy would move a service off its siblings' network | net-new; detect-and-warn (auto-reattach deferred — see #163) |

Post-merge fix: [#165] split `forward.rs` (the #160+#162 additions pushed it past the 500-line CI file-size gate).

## Verification
`main` is green after all merges: `cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo test`, and the file-size gate all pass in CI.

## After merge
Tag `v0.2.13-rc.1` on the merge commit (triggers `release-binaries.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)