### PR TITLE
chore(release): set version to 0.2.13-rc.1 to match the tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "mallorca"
-version = "0.2.13"
+version = "0.2.13-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2966,7 +2966,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orca-agent"
-version = "0.2.13"
+version = "0.2.13-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "orca-ai"
-version = "0.2.13"
+version = "0.2.13-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "orca-control"
-version = "0.2.13"
+version = "0.2.13-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "orca-core"
-version = "0.2.13"
+version = "0.2.13-rc.1"
 dependencies = [
  "aes-gcm",
  "age",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "orca-proxy"
-version = "0.2.13"
+version = "0.2.13-rc.1"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "orca-tui"
-version = "0.2.13"
+version = "0.2.13-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "orca-web"
-version = "0.2.13"
+version = "0.2.13-rc.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["examples/wasm-hello"]
 
 [workspace.package]
-version = "0.2.13"
+version = "0.2.13-rc.1"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mighty840/orca"
@@ -38,9 +38,9 @@ incremental = false
 
 [workspace.dependencies]
 # Shared across crates
-orca-core = { path = "crates/orca-core", version = "0.2.13" }
-orca-ai = { path = "crates/orca-ai", version = "0.2.13" }
-orca-proxy = { path = "crates/orca-proxy", version = "0.2.13" }
+orca-core = { path = "crates/orca-core", version = "0.2.13-rc.1" }
+orca-ai = { path = "crates/orca-ai", version = "0.2.13-rc.1" }
+orca-proxy = { path = "crates/orca-proxy", version = "0.2.13-rc.1" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/orca-cli/Cargo.toml
+++ b/crates/orca-cli/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/main.rs"
 [dependencies]
 orca-core = { workspace = true }
 orca-ai = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.13" }
-orca-control = { path = "../orca-control", version = "0.2.13" }
+orca-agent = { path = "../orca-agent", version = "0.2.13-rc.1" }
+orca-control = { path = "../orca-control", version = "0.2.13-rc.1" }
 orca-proxy = { workspace = true }
-orca-tui = { path = "../orca-tui", version = "0.2.13" }
+orca-tui = { path = "../orca-tui", version = "0.2.13-rc.1" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/orca-control/Cargo.toml
+++ b/crates/orca-control/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "build.rs", "proto/**/*", "Cargo.toml"]
 
 [dependencies]
 orca-core = { workspace = true }
-orca-agent = { path = "../orca-agent", version = "0.2.13" }
+orca-agent = { path = "../orca-agent", version = "0.2.13-rc.1" }
 orca-ai = { workspace = true }
 orca-proxy = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
Follow-up to #166. The rc.1 bump used the bare `0.2.13`, but the convention (and publish.yml's `Verify version matches tag` guard) requires the full rc string (prior RCs: `0.2.12-rc.5`, `0.2.11-rc.6`). The mismatch failed the crates.io publish job before it published anything. This sets the workspace version to `0.2.13-rc.1`; the `v0.2.13-rc.1` tag will be moved here so both release workflows re-run cleanly (binaries stamped correctly + crates published as a pre-release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)