### PR TITLE
feat(proxy): negotiate HTTP/2 via ALPN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3780,6 +3780,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/crates/orca-proxy/Cargo.toml
+++ b/crates/orca-proxy/Cargo.toml
@@ -14,8 +14,8 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
-hyper = { version = "1", features = ["http1", "server", "client"] }
-hyper-util = { version = "0.1", features = ["tokio", "http1", "client-legacy"] }
+hyper = { version = "1", features = ["http1", "http2", "server", "client"] }
+hyper-util = { version = "0.1", features = ["tokio", "http1", "http2", "server-auto", "client-legacy"] }
 http-body-util = "0.1"
 reqwest = { workspace = true, features = ["stream"] }
 futures-util = "0.3"
@@ -29,5 +29,9 @@ serde_json = { workspace = true }
 dirs = "6"
 
 [dev-dependencies]
+# `http2` so the HTTP/2 integration test can negotiate h2 against the proxy;
+# `aws-lc-rs` so it can install the same crypto provider the binary does.
+reqwest = { workspace = true, features = ["http2"] }
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
 tempfile = "3"
 time = "0.3"

--- a/crates/orca-proxy/src/acme/mod.rs
+++ b/crates/orca-proxy/src/acme/mod.rs
@@ -121,9 +121,11 @@ impl AcmeManager {
         if self.needs_renewal(domain) {
             warn!(domain, "Cert expiring soon — will auto-renew");
         }
-        let config = rustls::ServerConfig::builder()
-            .with_no_client_auth()
-            .with_single_cert(certs, key)?;
+        let config = crate::tls::with_h2_alpn(
+            rustls::ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(certs, key)?,
+        );
         Ok(Some(TlsAcceptor::from(Arc::new(config))))
     }
 

--- a/crates/orca-proxy/src/handler.rs
+++ b/crates/orca-proxy/src/handler.rs
@@ -141,11 +141,13 @@ pub(crate) async fn handle_request(
         }
     }
 
-    // Extract host header
+    // Extract the host: the Host header on HTTP/1.1, the `:authority`
+    // pseudo-header (surfaced on the URI) on HTTP/2, which carries no Host.
     let host = req
         .headers()
         .get("host")
         .and_then(|h| h.to_str().ok())
+        .or_else(|| req.uri().authority().map(|a| a.as_str()))
         .map(|h| h.split(':').next().unwrap_or(h).to_string());
 
     let Some(host) = host else {

--- a/crates/orca-proxy/src/lib.rs
+++ b/crates/orca-proxy/src/lib.rs
@@ -27,9 +27,9 @@ use std::sync::atomic::AtomicUsize;
 
 use hyper::Request;
 use hyper::body::Incoming;
-use hyper::server::conn::http1;
 use hyper::service::service_fn;
-use hyper_util::rt::TokioIo;
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::server::conn::auto;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
@@ -248,9 +248,11 @@ pub async fn run_proxy_with_acme_and_fallback(
         }
 
         // Build TlsAcceptor with SNI resolver for multi-domain support
-        let config = rustls::ServerConfig::builder()
-            .with_no_client_auth()
-            .with_cert_resolver(resolver_clone);
+        let config = tls::with_h2_alpn(
+            rustls::ServerConfig::builder()
+                .with_no_client_auth()
+                .with_cert_resolver(resolver_clone),
+        );
 
         let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(config));
         info!(
@@ -444,9 +446,12 @@ pub(crate) async fn serve_loop_with_fallback(
                 match acceptor.accept(stream).await {
                     Ok(tls_stream) => {
                         let io = TokioIo::new(tls_stream);
-                        if let Err(e) = http1::Builder::new()
-                            .serve_connection(io, service)
-                            .with_upgrades()
+                        // h1 or h2, picked by the ALPN result. WebSocket
+                        // upgrades stay on h1: extended CONNECT (RFC 8441)
+                        // is not enabled, so browsers open a separate
+                        // HTTP/1.1 connection for them, as before.
+                        if let Err(e) = auto::Builder::new(TokioExecutor::new())
+                            .serve_connection_with_upgrades(io, service)
                             .await
                         {
                             debug!("TLS proxy error from {peer}: {e}");
@@ -456,9 +461,8 @@ pub(crate) async fn serve_loop_with_fallback(
                 }
             } else {
                 let io = TokioIo::new(stream);
-                if let Err(e) = http1::Builder::new()
-                    .serve_connection(io, service)
-                    .with_upgrades()
+                if let Err(e) = auto::Builder::new(TokioExecutor::new())
+                    .serve_connection_with_upgrades(io, service)
                     .await
                 {
                     debug!("Proxy connection error from {peer}: {e}");

--- a/crates/orca-proxy/src/tls.rs
+++ b/crates/orca-proxy/src/tls.rs
@@ -12,6 +12,13 @@ use tracing::info;
 
 use crate::acme::AcmeManager;
 
+/// Offer HTTP/2 via ALPN, HTTP/1.1 as fallback. The serve loop handles both
+/// through `hyper_util::server::conn::auto`.
+pub(crate) fn with_h2_alpn(mut config: ServerConfig) -> ServerConfig {
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    config
+}
+
 /// TLS mode for the proxy.
 #[derive(Debug, Clone)]
 pub enum TlsMode {
@@ -59,9 +66,11 @@ pub fn create_tls_acceptor_for_domain(
             let certs = vec![cert_der];
             let key = rustls::pki_types::PrivatePkcs8KeyDer::from(key_der).into();
 
-            let config = ServerConfig::builder()
-                .with_no_client_auth()
-                .with_single_cert(certs, key)?;
+            let config = with_h2_alpn(
+                ServerConfig::builder()
+                    .with_no_client_auth()
+                    .with_single_cert(certs, key)?,
+            );
 
             Ok(Some(TlsAcceptor::from(Arc::new(config))))
         }
@@ -78,9 +87,11 @@ pub fn create_tls_acceptor_for_domain(
             let key = rustls_pemfile::private_key(&mut key_file.as_slice())?
                 .ok_or_else(|| anyhow::anyhow!("no private key found in {key_path}"))?;
 
-            let config = ServerConfig::builder()
-                .with_no_client_auth()
-                .with_single_cert(certs, key)?;
+            let config = with_h2_alpn(
+                ServerConfig::builder()
+                    .with_no_client_auth()
+                    .with_single_cert(certs, key)?,
+            );
 
             Ok(Some(TlsAcceptor::from(Arc::new(config))))
         }

--- a/crates/orca-proxy/tests/http2_test.rs
+++ b/crates/orca-proxy/tests/http2_test.rs
@@ -1,0 +1,139 @@
+//! HTTP/2 over TLS: the proxy advertises `h2` via ALPN and serves both h1 and
+//! h2 on the same listener. Under h2 there is no `Host` header — the host
+//! arrives as the `:authority` pseudo-header — so routing must still find
+//! the route and the backend must still receive a proper `Host`.
+//!
+//! Fast tests (loopback only, self-signed cert) — not `#[ignore]`d.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use http_body_util::Full;
+use hyper::body::{Bytes, Incoming};
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
+use orca_proxy::tls::{TlsMode, create_tls_acceptor};
+use orca_proxy::{RouteTarget, run_proxy_with_fallback};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::RwLock;
+
+/// Plain-HTTP/1.1 backend that echoes the `Host` header it received.
+async fn spawn_echo_backend() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = listener.accept().await.unwrap();
+            tokio::spawn(async move {
+                let svc = service_fn(|req: Request<Incoming>| async move {
+                    let host = req
+                        .headers()
+                        .get("host")
+                        .and_then(|h| h.to_str().ok())
+                        .unwrap_or("<none>")
+                        .to_string();
+                    Ok::<_, hyper::Error>(Response::new(Full::new(Bytes::from(host))))
+                });
+                let _ = http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), svc)
+                    .await;
+            });
+        }
+    });
+    addr
+}
+
+/// TLS proxy (self-signed cert for `localhost`) routing `localhost` → backend.
+async fn spawn_tls_proxy(backend: SocketAddr) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    let mut routes = HashMap::new();
+    routes.insert(
+        "localhost".to_string(),
+        vec![RouteTarget {
+            address: backend.to_string(),
+            service_name: "app".to_string(),
+            path_pattern: None,
+            weight: 100,
+            strip_prefix: None,
+        }],
+    );
+    let routes = Arc::new(RwLock::new(routes));
+    let triggers = Arc::new(RwLock::new(Vec::new()));
+    // Same provider the orca binary installs at startup; the dependency
+    // graph carries both ring and aws-lc-rs, so rustls cannot pick one.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let acceptor = create_tls_acceptor(&TlsMode::SelfSigned)
+        .unwrap()
+        .expect("self-signed acceptor");
+    tokio::spawn(async move {
+        let _ =
+            run_proxy_with_fallback(routes, triggers, None, port, Some(acceptor), None, None).await;
+    });
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    while tokio::time::Instant::now() < deadline {
+        if TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+            return port;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("orca proxy did not bind on port {port} within 3s");
+}
+
+fn client() -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .no_proxy()
+        .danger_accept_invalid_certs(true)
+}
+
+#[tokio::test]
+async fn negotiates_http2_and_routes_by_authority() {
+    let backend = spawn_echo_backend().await;
+    let port = spawn_tls_proxy(backend).await;
+
+    let resp = client()
+        .build()
+        .unwrap()
+        .get(format!("https://localhost:{port}/"))
+        .send()
+        .await
+        .expect("request to proxy");
+
+    assert_eq!(
+        resp.version(),
+        reqwest::Version::HTTP_2,
+        "ALPN must pick h2"
+    );
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.text().await.unwrap(),
+        "localhost",
+        "backend must see the external host, taken from :authority"
+    );
+}
+
+#[tokio::test]
+async fn still_serves_http1_clients() {
+    let backend = spawn_echo_backend().await;
+    let port = spawn_tls_proxy(backend).await;
+
+    let resp = client()
+        .http1_only()
+        .build()
+        .unwrap()
+        .get(format!("https://localhost:{port}/"))
+        .send()
+        .await
+        .expect("request to proxy");
+
+    assert_eq!(resp.version(), reqwest::Version::HTTP_11);
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "localhost");
+}


### PR DESCRIPTION
## Why

The proxy only spoke HTTP/1.1, so a browser loading a site behind it opened a fresh TCP+TLS connection per asset. Lighthouse on a site hosted this way flagged every stylesheet as render-blocking with a ~1.7 s critical-path chain, most of it handshakes. Advertising `h2` lets one connection carry everything.

## What

- **ALPN**: every serving `rustls::ServerConfig` now offers `["h2", "http/1.1"]` via a small `tls::with_h2_alpn` helper (SNI resolver in `lib.rs`, self-signed and custom certs in `tls.rs`, single-domain cached cert in `acme/mod.rs`).
- **Connection builder**: both serve loops use `hyper_util::server::conn::auto::Builder` with `serve_connection_with_upgrades`, so the protocol is picked per connection from the ALPN result. The plain listener gets h2c prior-knowledge for free; browsers never use it.
- **Host on h2**: HTTP/2 has no `Host` header, the host is the `:authority` pseudo-header, which hyper surfaces on `req.uri()`. Route lookup falls back to it. Without this every h2 request 400s with "missing Host header".
- **Features**: `hyper` gains `http2`; `hyper-util` gains `http2` + `server-auto`. Dev-deps add `reqwest/http2` and `rustls/aws-lc-rs` so the test can install the same crypto provider the binary does.

## WebSockets

Unchanged. RFC 8441 extended CONNECT is not enabled on the h2 side, so browsers open a separate HTTP/1.1 connection for `wss://` upgrades, exactly as before.

## Test

`tests/http2_test.rs` starts a self-signed TLS proxy routing `localhost` to a plain-h1 echo backend and asserts:
- a default reqwest client negotiates `HTTP/2`, gets 200, and the backend saw `Host: localhost` (i.e. routing worked via `:authority`);
- an `http1_only()` client still gets `HTTP/1.1` and the same response.

`cargo fmt --all`, `cargo clippy -- -D warnings`, `cargo test -p orca-proxy` (85 passed) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B56R2dX2qFuHUDS8sEpX2L
