### PR TITLE
fix(control): allow result_large_err where the error type is not ours

### DIFF
--- a/crates/orca-control/src/proto.rs
+++ b/crates/orca-control/src/proto.rs
@@ -1,3 +1,8 @@
 //! Generated gRPC types from `proto/orca.proto`.
 
+// tonic's generated service methods return `Result<_, tonic::Status>`, and
+// `Status` is ~176 bytes: clippy 1.98 flags every one of them under
+// `result_large_err`. Generated code cannot be reshaped, so opt out here.
+#![allow(clippy::result_large_err)]
+
 tonic::include_proto!("orca");

--- a/crates/orca-control/src/raft/state_machine.rs
+++ b/crates/orca-control/src/raft/state_machine.rs
@@ -49,6 +49,10 @@ impl StateMachine {
         }
     }
 
+    // `openraft::StorageError<u64>` is 224 bytes. The trait methods this feeds
+    // are exempt from `result_large_err` (their signature is openraft's); this
+    // helper mirrors them, and boxing here would be unboxed again on return.
+    #[allow(clippy::result_large_err)]
     async fn build_snapshot_impl(&self) -> Result<Snapshot<C>, StorageError<u64>> {
         let snap = self.store.snapshot().map_err(|e| sm_read_err(&e))?;
         let data = serde_json::to_vec(&snap).map_err(|e| sm_read_err(&e))?;


### PR DESCRIPTION
## Why

`main` CI has been failing since 2026-09-04 (e.g. [run 34026773045](https://github.com/mighty840/orca/actions/runs/34026773045)): the workflow uses `stable`, which is now Rust 1.98, and 1.98's clippy raises `result_large_err` on seven functions in `orca-control`. Every PR inherits the failure ([#168](https://github.com/mighty840/orca/pull/168) for example).

## What

Two targeted allows, nothing else:

- `crates/orca-control/src/proto.rs`: the tonic-generated service methods return `Result<_, tonic::Status>`; `Status` is ~176 bytes and the code is generated, so a module-level `#![allow(clippy::result_large_err)]` at the `include_proto!` site.
- `crates/orca-control/src/raft/state_machine.rs`: `build_snapshot_impl` returns `openraft::StorageError<u64>` (224 bytes). The `RaftStateMachine` trait methods it feeds carry the same type and are exempt because the signature is openraft's; the helper mirrors them, and boxing there would be unboxed again on return. A function-level allow.

Verified with `cargo +1.98.0 fmt --all -- --check` and `cargo +1.98.0 clippy -- -D warnings` (the workflow's command) across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B56R2dX2qFuHUDS8sEpX2L
